### PR TITLE
build(docker): add curl for health checks and update compose config

### DIFF
--- a/ccxt-service/Dockerfile
+++ b/ccxt-service/Dockerfile
@@ -2,8 +2,9 @@
 FROM oven/bun:1 AS base
 WORKDIR /usr/src/app
 
-# Install curl for health checks
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+# Install curl for health checks as root
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies into temp directory
 # This will cache them and speed up future builds

--- a/ccxt-service/Dockerfile
+++ b/ccxt-service/Dockerfile
@@ -2,6 +2,9 @@
 FROM oven/bun:1 AS base
 WORKDIR /usr/src/app
 
+# Install curl for health checks
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 # Install dependencies into temp directory
 # This will cache them and speed up future builds
 FROM base AS install

--- a/ccxt-service/index.ts
+++ b/ccxt-service/index.ts
@@ -433,6 +433,7 @@ console.log(`📊 Supported exchanges: ${Object.keys(exchanges).join(', ')}`);
 
 export default {
   port: PORT,
+  hostname: '0.0.0.0',
   fetch: app.fetch,
   idleTimeout: 30, // 30 seconds timeout to prevent Bun.serve timeout issues
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     depends_on:
       - redis
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:3001/health || exit 1"]
       interval: 30s
       timeout: 15s
       retries: 5
@@ -70,10 +70,6 @@ services:
       - ENVIRONMENT=development
       - DATABASE_HOST=postgres
       - DATABASE_PORT=5432
-      - DATABASE_USER=postgres
-      - DATABASE_PASSWORD=postgres
-      - DATABASE_DBNAME=celebrum_ai
-      - DATABASE_SSLMODE=disable
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - CCXT_SERVICE_URL=http://ccxt-service:3001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,10 +46,11 @@ services:
     depends_on:
       - redis
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://ccxt-service:3001/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
       interval: 30s
-      timeout: 10s
-      retries: 3
+      timeout: 15s
+      retries: 5
+      start_period: 60s
     profiles:
       - ccxt
 
@@ -63,6 +64,8 @@ services:
     container_name: celebrum-app
     ports:
       - "8080:8080"
+    env_file:
+      - .env
     environment:
       - ENVIRONMENT=development
       - DATABASE_HOST=postgres


### PR DESCRIPTION
Add curl installation in Dockerfile for health checks and update docker-compose healthcheck configuration with longer timeout and retries. Also add env_file to celebrum-app service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container healthcheck reliability by updating the healthcheck URL, increasing timeout and retry values, and adding a start period.
  * Updated service configuration to load environment variables from an external file.
  * Enhanced container image by installing curl and optimizing image size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->