### PR TITLE
Align CCXT interface usage with internal services

### DIFF
--- a/internal/api/handlers/test_helpers.go
+++ b/internal/api/handlers/test_helpers.go
@@ -3,8 +3,8 @@ package handlers
 import (
 	"context"
 
+	"github.com/irfndi/celebrum-ai-go/internal/ccxt"
 	"github.com/irfndi/celebrum-ai-go/internal/models"
-	"github.com/irfandi/celebrum-ai-go/pkg/ccxt"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/mock"
 )
@@ -39,17 +39,17 @@ func (m *MockCCXTService) GetExchangeInfo(exchangeID string) (ccxt.ExchangeInfo,
 	return args.Get(0).(ccxt.ExchangeInfo), args.Bool(1)
 }
 
-func (m *MockCCXTService) FetchMarketData(ctx context.Context, exchanges []string, symbols []string) ([]models.MarketPrice, error) {
+func (m *MockCCXTService) FetchMarketData(ctx context.Context, exchanges []string, symbols []string) ([]ccxt.MarketPriceInterface, error) {
 	args := m.Called(ctx, exchanges, symbols)
-	return args.Get(0).([]models.MarketPrice), args.Error(1)
+	return args.Get(0).([]ccxt.MarketPriceInterface), args.Error(1)
 }
 
-func (m *MockCCXTService) FetchSingleTicker(ctx context.Context, exchange, symbol string) (*models.MarketPrice, error) {
+func (m *MockCCXTService) FetchSingleTicker(ctx context.Context, exchange, symbol string) (ccxt.MarketPriceInterface, error) {
 	args := m.Called(ctx, exchange, symbol)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).(*models.MarketPrice), args.Error(1)
+	return args.Get(0).(ccxt.MarketPriceInterface), args.Error(1)
 }
 
 func (m *MockCCXTService) FetchOrderBook(ctx context.Context, exchange, symbol string, limit int) (*ccxt.OrderBookResponse, error) {

--- a/internal/ccxt/interface.go
+++ b/internal/ccxt/interface.go
@@ -49,8 +49,8 @@ type CCXTService interface {
 	AddExchange(ctx context.Context, exchange string) (*ExchangeManagementResponse, error)
 
 	// Market data operations
-	FetchMarketData(ctx context.Context, exchanges []string, symbols []string) ([]models.MarketPrice, error)
-	FetchSingleTicker(ctx context.Context, exchange, symbol string) (*models.MarketPrice, error)
+	FetchMarketData(ctx context.Context, exchanges []string, symbols []string) ([]MarketPriceInterface, error)
+	FetchSingleTicker(ctx context.Context, exchange, symbol string) (MarketPriceInterface, error)
 	FetchOrderBook(ctx context.Context, exchange, symbol string, limit int) (*OrderBookResponse, error)
 	FetchOHLCV(ctx context.Context, exchange, symbol, timeframe string, limit int) (*OHLCVResponse, error)
 	FetchTrades(ctx context.Context, exchange, symbol string, limit int) (*TradesResponse, error)

--- a/internal/ccxt/service_test.go
+++ b/internal/ccxt/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/irfndi/celebrum-ai-go/internal/cache"
 	"github.com/irfndi/celebrum-ai-go/internal/config"
+	"github.com/irfndi/celebrum-ai-go/internal/models"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,9 +87,12 @@ func TestService_FetchSingleTicker(t *testing.T) {
 	marketPrice, err := service.FetchSingleTicker(ctx, "binance", "BTC/USDT")
 	assert.NoError(t, err)
 	assert.NotNil(t, marketPrice)
-	assert.Equal(t, "binance", marketPrice.ExchangeName)
-	assert.Equal(t, "BTC/USDT", marketPrice.Symbol)
-	assert.True(t, marketPrice.Price.IsPositive())
+
+	mp, ok := marketPrice.(*models.MarketPrice)
+	require.True(t, ok)
+	assert.Equal(t, "binance", mp.ExchangeName)
+	assert.Equal(t, "BTC/USDT", mp.Symbol)
+	assert.True(t, mp.Price.IsPositive())
 }
 
 func TestService_FetchMarketData(t *testing.T) {
@@ -120,8 +124,10 @@ func TestService_FetchMarketData(t *testing.T) {
 
 	// Should have data for each exchange-symbol combination
 	for _, data := range marketData {
-		assert.Contains(t, exchanges, data.ExchangeName)
-		assert.Contains(t, symbols, data.Symbol)
-		assert.True(t, data.Price.IsPositive())
+		mp, ok := data.(*models.MarketPrice)
+		require.True(t, ok)
+		assert.Contains(t, exchanges, mp.ExchangeName)
+		assert.Contains(t, symbols, mp.Symbol)
+		assert.True(t, mp.Price.IsPositive())
 	}
 }

--- a/internal/ccxt/types.go
+++ b/internal/ccxt/types.go
@@ -100,7 +100,7 @@ func (s *Service) GetExchangeInfo(exchangeID string) (ExchangeInfo, bool) {
 }
 
 // FetchMarketData fetches market data for multiple exchanges and symbols
-func (s *Service) FetchMarketData(ctx context.Context, exchanges []string, symbols []string) ([]models.MarketPrice, error) {
+func (s *Service) FetchMarketData(ctx context.Context, exchanges []string, symbols []string) ([]MarketPriceInterface, error) {
 	if len(exchanges) == 0 || len(symbols) == 0 {
 		return nil, fmt.Errorf("exchanges and symbols cannot be empty")
 	}
@@ -116,9 +116,9 @@ func (s *Service) FetchMarketData(ctx context.Context, exchanges []string, symbo
 		return nil, fmt.Errorf("failed to fetch tickers: %w", err)
 	}
 
-	marketData := make([]models.MarketPrice, 0, len(resp.Tickers))
+	marketData := make([]MarketPriceInterface, 0, len(resp.Tickers))
 	for _, tickerData := range resp.Tickers {
-		md := models.MarketPrice{
+		md := &models.MarketPrice{
 			ExchangeName: tickerData.Exchange,
 			Symbol:       tickerData.Ticker.Symbol,
 			Price:        tickerData.Ticker.Last,
@@ -132,7 +132,7 @@ func (s *Service) FetchMarketData(ctx context.Context, exchanges []string, symbo
 }
 
 // FetchSingleTicker fetches ticker data for a single exchange and symbol
-func (s *Service) FetchSingleTicker(ctx context.Context, exchange, symbol string) (*models.MarketPrice, error) {
+func (s *Service) FetchSingleTicker(ctx context.Context, exchange, symbol string) (MarketPriceInterface, error) {
 	resp, err := s.client.GetTicker(ctx, exchange, symbol)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch ticker for %s:%s: %w", exchange, symbol, err)

--- a/internal/services/cache_warming_test.go
+++ b/internal/services/cache_warming_test.go
@@ -2,21 +2,16 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
-	"time"
 
-	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
-
 
 // TestCacheWarmingService_NewCacheWarmingService tests service creation
 func TestCacheWarmingService_NewCacheWarmingService(t *testing.T) {
 	// Create service with nil dependencies to test service creation
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	// Service should be created successfully (nil dependencies are handled gracefully)
 	assert.NotNil(t, service)
 }
@@ -25,10 +20,10 @@ func TestCacheWarmingService_NewCacheWarmingService(t *testing.T) {
 func TestCacheWarmingService_WarmCache(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.WarmCache(ctx)
-	
+
 	// The function should handle nil dependencies gracefully and return nil
 	// Individual warming operations will fail and log warnings, but overall function succeeds
 	assert.Nil(t, err)
@@ -38,10 +33,10 @@ func TestCacheWarmingService_WarmCache(t *testing.T) {
 func TestCacheWarmingService_warmExchangeConfig(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.warmExchangeConfig(ctx)
-	
+
 	// The function should handle nil dependencies gracefully
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "nil")
@@ -51,10 +46,10 @@ func TestCacheWarmingService_warmExchangeConfig(t *testing.T) {
 func TestCacheWarmingService_warmSupportedExchanges(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.warmSupportedExchanges(ctx)
-	
+
 	// The function should handle nil dependencies gracefully
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "nil")
@@ -64,10 +59,10 @@ func TestCacheWarmingService_warmSupportedExchanges(t *testing.T) {
 func TestCacheWarmingService_warmTradingPairs(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.warmTradingPairs(ctx)
-	
+
 	// The function should handle nil dependencies gracefully
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "nil")
@@ -77,10 +72,10 @@ func TestCacheWarmingService_warmTradingPairs(t *testing.T) {
 func TestCacheWarmingService_warmExchanges(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.warmExchanges(ctx)
-	
+
 	// The function should handle nil dependencies gracefully
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "nil")
@@ -90,10 +85,10 @@ func TestCacheWarmingService_warmExchanges(t *testing.T) {
 func TestCacheWarmingService_warmFundingRates(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.warmFundingRates(ctx)
-	
+
 	// The function should handle nil dependencies gracefully
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "nil")
@@ -103,10 +98,10 @@ func TestCacheWarmingService_warmFundingRates(t *testing.T) {
 func TestCacheWarmingService_errorHandling(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.WarmCache(ctx)
-	
+
 	// The function should handle nil dependencies gracefully and return nil
 	// Individual warming operations will fail and log warnings, but overall function succeeds
 	assert.Nil(t, err)

--- a/internal/services/resource_optimizer_test.go
+++ b/internal/services/resource_optimizer_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-				"github.com/stretchr/testify/assert"
-	)
+	"github.com/stretchr/testify/assert"
+)
 
 func TestNewResourceOptimizer(t *testing.T) {
 	config := ResourceOptimizerConfig{
@@ -41,8 +41,8 @@ func TestNewResourceOptimizer_WithDefaults(t *testing.T) {
 	assert.Greater(t, ro.cpuCores, 0)
 	assert.Greater(t, ro.memoryGB, 0.0)
 	assert.Equal(t, 5*time.Minute, ro.optimizationInterval) // Default value
-	assert.Equal(t, 100, ro.maxHistorySize)                // Default value
-	assert.False(t, ro.adaptiveMode)                         // Default value
+	assert.Equal(t, 100, ro.maxHistorySize)                 // Default value
+	assert.False(t, ro.adaptiveMode)                        // Default value
 }
 
 func TestResourceOptimizer_calculateOptimalConcurrency(t *testing.T) {
@@ -166,16 +166,19 @@ func TestResourceOptimizer_RecordPerformanceSnapshot(t *testing.T) {
 	}
 	ro := NewResourceOptimizer(config)
 
+	initialLen := len(ro.performanceHistory)
+
 	// Record initial snapshot
 	ro.RecordPerformanceSnapshot(10, 100.0, 1.0, 50.0)
 
-	assert.Equal(t, 1, len(ro.performanceHistory))
-	snapshot := ro.performanceHistory[0]
-	assert.Equal(t, 10, snapshot.ActiveOperations)
-	assert.Equal(t, 100.0, snapshot.Throughput)
-	assert.Equal(t, 1.0, snapshot.ErrorRate)
-	assert.Equal(t, 50.0, snapshot.ResponseTime)
-	assert.False(t, snapshot.Timestamp.IsZero())
+	if assert.Equal(t, initialLen+1, len(ro.performanceHistory)) {
+		snapshot := ro.performanceHistory[len(ro.performanceHistory)-1]
+		assert.Equal(t, 10, snapshot.ActiveOperations)
+		assert.Equal(t, 100.0, snapshot.Throughput)
+		assert.Equal(t, 1.0, snapshot.ErrorRate)
+		assert.Equal(t, 50.0, snapshot.ResponseTime)
+		assert.False(t, snapshot.Timestamp.IsZero())
+	}
 
 	// Record multiple snapshots
 	for i := 0; i < 10; i++ {
@@ -229,17 +232,17 @@ func TestResourceOptimizer_OptimizeIfNeeded_AdaptiveMode(t *testing.T) {
 	t.Logf("Performance history length: %d", len(ro.performanceHistory))
 	t.Logf("Last optimization: %v", ro.lastOptimization)
 	t.Logf("Time since last optimization: %v", time.Since(ro.lastOptimization))
-	
+
 	// Debug: check the shouldOptimize logic
 	for i, snapshot := range ro.performanceHistory {
-		t.Logf("Snapshot %d: CPU=%.2f, Memory=%.2f, ErrorRate=%.2f, ResponseTime=%.2f", 
+		t.Logf("Snapshot %d: CPU=%.2f, Memory=%.2f, ErrorRate=%.2f, ResponseTime=%.2f",
 			i, snapshot.CPUUsage, snapshot.MemoryUsage, snapshot.ErrorRate, snapshot.ResponseTime)
 	}
-	
+
 	// Test shouldOptimize directly
 	shouldOpt := ro.shouldOptimize()
 	t.Logf("Should optimize result: %v", shouldOpt)
-	
+
 	// Try with the original config
 	optimized := ro.OptimizeIfNeeded(config)
 	t.Logf("Optimization result: %v", optimized)
@@ -305,7 +308,7 @@ func TestResourceOptimizer_shouldOptimize(t *testing.T) {
 		snapshot := PerformanceSnapshot{
 			CPUUsage:     60.0,
 			MemoryUsage:  60.0,
-			ErrorRate:   1.0,
+			ErrorRate:    1.0,
 			ResponseTime: 6000.0, // High response time
 		}
 		ro.performanceHistory = append(ro.performanceHistory, snapshot)
@@ -320,6 +323,8 @@ func TestResourceOptimizer_GetPerformanceHistory(t *testing.T) {
 	}
 	ro := NewResourceOptimizer(config)
 
+	initialLen := len(ro.performanceHistory)
+
 	// Add some snapshots
 	for i := 0; i < 5; i++ {
 		ro.RecordPerformanceSnapshot(i+1, float64(i*10), float64(i), float64(i*5))
@@ -327,7 +332,7 @@ func TestResourceOptimizer_GetPerformanceHistory(t *testing.T) {
 
 	// Get all history
 	history := ro.GetPerformanceHistory(0)
-	assert.Equal(t, 5, len(history))
+	assert.Equal(t, initialLen+5, len(history))
 
 	// Get limited history
 	limited := ro.GetPerformanceHistory(3)
@@ -335,7 +340,7 @@ func TestResourceOptimizer_GetPerformanceHistory(t *testing.T) {
 
 	// Get more than available
 	overflow := ro.GetPerformanceHistory(10)
-	assert.Equal(t, 5, len(overflow))
+	assert.Equal(t, initialLen+5, len(overflow))
 }
 
 func TestResourceOptimizer_GetSystemInfo(t *testing.T) {

--- a/internal/services/signal_aggregator_interface_test.go
+++ b/internal/services/signal_aggregator_interface_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/shopspring/decimal"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/irfndi/celebrum-ai-go/internal/models"
 )
 
 // TestMockSignalQualityScorer implements SignalQualityScorerInterface for testing
@@ -34,14 +36,14 @@ func (m *TestMockSignalQualityScorer) GetDefaultQualityThresholds() *QualityThre
 // TestSignalAggregator_Interface tests the interface design
 func TestSignalAggregator_Interface(t *testing.T) {
 	logger := logrus.New()
-	
+
 	// Test that we can create a SignalAggregator with a mock quality scorer
 	sa := NewSignalAggregator(nil, nil, logger)
-	
+
 	// Replace the QualityScorer with a mock for testing
 	mockScorer := &TestMockSignalQualityScorer{}
 	sa.qualityScorer = mockScorer
-	
+
 	// Configure mock to return acceptable quality metrics
 	qualityMetrics := &SignalQualityMetrics{
 		OverallScore:         decimal.NewFromFloat(0.8),
@@ -55,7 +57,7 @@ func TestSignalAggregator_Interface(t *testing.T) {
 		DataFreshnessScore:   decimal.NewFromFloat(0.9),
 		MarketConditionScore: decimal.NewFromFloat(0.8),
 	}
-	
+
 	thresholds := &QualityThresholds{
 		MinOverallScore:   decimal.NewFromFloat(0.6),
 		MinExchangeScore:  decimal.NewFromFloat(0.7),
@@ -64,15 +66,36 @@ func TestSignalAggregator_Interface(t *testing.T) {
 		MaxRiskScore:      decimal.NewFromFloat(0.4),
 		MinDataFreshness:  5 * time.Minute,
 	}
-	
+
 	mockScorer.On("AssessSignalQuality", mock.Anything, mock.Anything).Return(qualityMetrics, nil)
 	mockScorer.On("IsSignalQualityAcceptable", qualityMetrics, thresholds).Return(true)
 	mockScorer.On("GetDefaultQualityThresholds").Return(thresholds)
-	
+
 	// Test that the interface is working correctly
 	assert.NotNil(t, sa)
 	assert.NotNil(t, sa.qualityScorer)
-	
+
+	// Trigger an aggregation to exercise the quality scorer interactions
+	input := ArbitrageSignalInput{
+		Opportunities: []models.ArbitrageOpportunity{
+			{
+				TradingPair:      &models.TradingPair{Symbol: "BTC/USDT"},
+				ProfitPercentage: decimal.NewFromFloat(0.8),
+				BuyPrice:         decimal.NewFromFloat(100),
+				SellPrice:        decimal.NewFromFloat(101),
+				BuyExchanges:     []string{"Binance"},
+				SellExchanges:    []string{"Coinbase"},
+				DetectedAt:       time.Now(),
+				ExpiresAt:        time.Now().Add(5 * time.Minute),
+				MinVolume:        decimal.NewFromFloat(10000),
+			},
+		},
+		MinVolume:  decimal.NewFromFloat(10000),
+		BaseAmount: decimal.NewFromFloat(20000),
+	}
+
+	_, _ = sa.AggregateArbitrageSignals(context.Background(), input)
+
 	// Verify the mock was called correctly
 	mockScorer.AssertExpectations(t)
 }
@@ -80,11 +103,11 @@ func TestSignalAggregator_Interface(t *testing.T) {
 // TestSignalAggregator_QualityAssessment tests quality assessment functionality
 func TestSignalAggregator_QualityAssessment(t *testing.T) {
 	logger := logrus.New()
-	
+
 	sa := NewSignalAggregator(nil, nil, logger)
 	mockScorer := &TestMockSignalQualityScorer{}
 	sa.qualityScorer = mockScorer
-	
+
 	// Test data
 	qualityInput := SignalQualityInput{
 		SignalType:       "arbitrage",
@@ -97,7 +120,7 @@ func TestSignalAggregator_QualityAssessment(t *testing.T) {
 		SignalCount:      1,
 		SignalComponents: []string{"price_diff", "volume"},
 	}
-	
+
 	qualityMetrics := &SignalQualityMetrics{
 		OverallScore:         decimal.NewFromFloat(0.8),
 		ExchangeScore:        decimal.NewFromFloat(0.8),
@@ -110,7 +133,7 @@ func TestSignalAggregator_QualityAssessment(t *testing.T) {
 		DataFreshnessScore:   decimal.NewFromFloat(0.9),
 		MarketConditionScore: decimal.NewFromFloat(0.8),
 	}
-	
+
 	thresholds := &QualityThresholds{
 		MinOverallScore:   decimal.NewFromFloat(0.6),
 		MinExchangeScore:  decimal.NewFromFloat(0.7),
@@ -119,27 +142,27 @@ func TestSignalAggregator_QualityAssessment(t *testing.T) {
 		MaxRiskScore:      decimal.NewFromFloat(0.4),
 		MinDataFreshness:  5 * time.Minute,
 	}
-	
+
 	mockScorer.On("AssessSignalQuality", mock.Anything, &qualityInput).Return(qualityMetrics, nil)
 	mockScorer.On("IsSignalQualityAcceptable", qualityMetrics, thresholds).Return(true)
 	mockScorer.On("GetDefaultQualityThresholds").Return(thresholds)
-	
+
 	// Test quality assessment
 	ctx := context.Background()
 	result, err := sa.qualityScorer.AssessSignalQuality(ctx, &qualityInput)
-	
+
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, decimal.NewFromFloat(0.8), result.OverallScore)
-	
+
 	// Test quality acceptance
 	isAcceptable := sa.qualityScorer.IsSignalQualityAcceptable(qualityMetrics, thresholds)
 	assert.True(t, isAcceptable)
-	
+
 	// Test default thresholds
 	defaultThresholds := sa.qualityScorer.GetDefaultQualityThresholds()
 	assert.NotNil(t, defaultThresholds)
 	assert.Equal(t, decimal.NewFromFloat(0.6), defaultThresholds.MinOverallScore)
-	
+
 	mockScorer.AssertExpectations(t)
 }

--- a/test/testmocks/mocks.go
+++ b/test/testmocks/mocks.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/irfndi/celebrum-ai-go/internal/ccxt"
 	"github.com/irfndi/celebrum-ai-go/internal/models"
-	"github.com/irfandi/celebrum-ai-go/pkg/ccxt"
 	"github.com/redis/go-redis/v9"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/mock"
@@ -102,14 +102,17 @@ func (m *MockCCXTService) AddExchange(ctx context.Context, exchange string) (*cc
 	return args.Get(0).(*ccxt.ExchangeManagementResponse), args.Error(1)
 }
 
-func (m *MockCCXTService) FetchMarketData(ctx context.Context, exchanges []string, symbols []string) ([]models.MarketPrice, error) {
+func (m *MockCCXTService) FetchMarketData(ctx context.Context, exchanges []string, symbols []string) ([]ccxt.MarketPriceInterface, error) {
 	args := m.Called(ctx, exchanges, symbols)
-	return args.Get(0).([]models.MarketPrice), args.Error(1)
+	return args.Get(0).([]ccxt.MarketPriceInterface), args.Error(1)
 }
 
-func (m *MockCCXTService) FetchSingleTicker(ctx context.Context, exchange, symbol string) (*models.MarketPrice, error) {
+func (m *MockCCXTService) FetchSingleTicker(ctx context.Context, exchange, symbol string) (ccxt.MarketPriceInterface, error) {
 	args := m.Called(ctx, exchange, symbol)
-	return args.Get(0).(*models.MarketPrice), args.Error(1)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(ccxt.MarketPriceInterface), args.Error(1)
 }
 
 func (m *MockCCXTService) FetchOrderBook(ctx context.Context, exchange, symbol string, limit int) (*ccxt.OrderBookResponse, error) {


### PR DESCRIPTION
## Summary
- Update the internal CCXT service interface to return `MarketPriceInterface` values and adjust the concrete service plus associated mocks/tests to work with interface-based market data.
- Seed the resource optimizer with default configuration values, record an initial performance snapshot, and refresh unit tests to account for the new baseline behavior.
- Exercise the signal aggregator quality scorer in tests and tidy cache warming tests by removing unused imports.

## Testing
- `go test ./internal/ccxt`


------
https://chatgpt.com/codex/tasks/task_e_68d8c2a18ee8832e80e5161812bba9bf