### PR TITLE
Fix CCXT mocks and collector conversions to match internal models

### DIFF
--- a/internal/api/handlers/test_helpers.go
+++ b/internal/api/handlers/test_helpers.go
@@ -3,8 +3,8 @@ package handlers
 import (
 	"context"
 
+	"github.com/irfndi/celebrum-ai-go/internal/ccxt"
 	"github.com/irfndi/celebrum-ai-go/internal/models"
-	"github.com/irfandi/celebrum-ai-go/pkg/ccxt"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/services/cache_warming_test.go
+++ b/internal/services/cache_warming_test.go
@@ -2,21 +2,16 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
-	"time"
 
-	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
-
 
 // TestCacheWarmingService_NewCacheWarmingService tests service creation
 func TestCacheWarmingService_NewCacheWarmingService(t *testing.T) {
 	// Create service with nil dependencies to test service creation
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	// Service should be created successfully (nil dependencies are handled gracefully)
 	assert.NotNil(t, service)
 }
@@ -25,10 +20,10 @@ func TestCacheWarmingService_NewCacheWarmingService(t *testing.T) {
 func TestCacheWarmingService_WarmCache(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.WarmCache(ctx)
-	
+
 	// The function should handle nil dependencies gracefully and return nil
 	// Individual warming operations will fail and log warnings, but overall function succeeds
 	assert.Nil(t, err)
@@ -38,10 +33,10 @@ func TestCacheWarmingService_WarmCache(t *testing.T) {
 func TestCacheWarmingService_warmExchangeConfig(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.warmExchangeConfig(ctx)
-	
+
 	// The function should handle nil dependencies gracefully
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "nil")
@@ -51,10 +46,10 @@ func TestCacheWarmingService_warmExchangeConfig(t *testing.T) {
 func TestCacheWarmingService_warmSupportedExchanges(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.warmSupportedExchanges(ctx)
-	
+
 	// The function should handle nil dependencies gracefully
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "nil")
@@ -64,10 +59,10 @@ func TestCacheWarmingService_warmSupportedExchanges(t *testing.T) {
 func TestCacheWarmingService_warmTradingPairs(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.warmTradingPairs(ctx)
-	
+
 	// The function should handle nil dependencies gracefully
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "nil")
@@ -77,10 +72,10 @@ func TestCacheWarmingService_warmTradingPairs(t *testing.T) {
 func TestCacheWarmingService_warmExchanges(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.warmExchanges(ctx)
-	
+
 	// The function should handle nil dependencies gracefully
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "nil")
@@ -90,10 +85,10 @@ func TestCacheWarmingService_warmExchanges(t *testing.T) {
 func TestCacheWarmingService_warmFundingRates(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.warmFundingRates(ctx)
-	
+
 	// The function should handle nil dependencies gracefully
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "nil")
@@ -103,10 +98,10 @@ func TestCacheWarmingService_warmFundingRates(t *testing.T) {
 func TestCacheWarmingService_errorHandling(t *testing.T) {
 	// Create service with nil dependencies to test error handling
 	service := NewCacheWarmingService(nil, nil, nil)
-	
+
 	ctx := context.Background()
 	err := service.WarmCache(ctx)
-	
+
 	// The function should handle nil dependencies gracefully and return nil
 	// Individual warming operations will fail and log warnings, but overall function succeeds
 	assert.Nil(t, err)

--- a/internal/services/collector.go
+++ b/internal/services/collector.go
@@ -16,45 +16,14 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/irfndi/celebrum-ai-go/internal/cache"
+	"github.com/irfndi/celebrum-ai-go/internal/ccxt"
 	"github.com/irfndi/celebrum-ai-go/internal/config"
 	"github.com/irfndi/celebrum-ai-go/internal/database"
 	"github.com/irfndi/celebrum-ai-go/internal/models"
 	"github.com/irfndi/celebrum-ai-go/internal/telemetry"
-	"github.com/irfndi/celebrum-ai-go/internal/ccxt"
 	"github.com/shopspring/decimal"
 	"github.com/sirupsen/logrus"
 )
-
-// convertMarketPriceInterfacesToModels converts CCXT MarketPriceInterface to models.MarketPrice
-func (c *CollectorService) convertMarketPriceInterfacesToModels(interfaceData []ccxt.MarketPriceInterface) []models.MarketPrice {
-	var marketData []models.MarketPrice
-	for _, item := range interfaceData {
-		marketData = append(marketData, models.MarketPrice{
-			ExchangeID:   0, // Will be filled later
-			ExchangeName: item.GetExchangeName(),
-			Symbol:       item.GetSymbol(),
-			Price:        decimal.NewFromFloat(item.GetPrice()),
-			Volume:       decimal.NewFromFloat(item.GetVolume()),
-			Timestamp:    item.GetTimestamp(),
-		})
-	}
-	return marketData
-}
-
-// convertMarketPriceInterfaceToModel converts a single CCXT MarketPriceInterface to models.MarketPrice
-func (c *CollectorService) convertMarketPriceInterfaceToModel(interfaceData ccxt.MarketPriceInterface) *models.MarketPrice {
-	if interfaceData == nil {
-		return nil
-	}
-	return &models.MarketPrice{
-		ExchangeID:   0, // Will be filled later
-		ExchangeName: interfaceData.GetExchangeName(),
-		Symbol:       interfaceData.GetSymbol(),
-		Price:        decimal.NewFromFloat(interfaceData.GetPrice()),
-		Volume:       decimal.NewFromFloat(interfaceData.GetVolume()),
-		Timestamp:    interfaceData.GetTimestamp(),
-	}
-}
 
 // CollectorConfig holds configuration for the collector service
 type CollectorConfig struct {
@@ -508,13 +477,13 @@ func (c *CollectorService) Start() error {
 func (c *CollectorService) getPrioritizedExchanges() []string {
 	// Get all supported exchanges from CCXT
 	allExchanges := c.ccxtService.GetSupportedExchanges()
-	
+
 	// If database is not available, return all exchanges
 	if c.db == nil || c.db.Pool == nil {
 		c.logger.Warn("Database not available, returning all exchanges")
 		return allExchanges
 	}
-	
+
 	// Query database to get exchanges with their priorities
 	query := `
 		SELECT e.name, e.priority, e.is_active, ce.ccxt_id 
@@ -522,41 +491,41 @@ func (c *CollectorService) getPrioritizedExchanges() []string {
 		LEFT JOIN ccxt_exchanges ce ON e.id = ce.exchange_id 
 		WHERE e.name = ANY($1) AND e.is_active = true 
 		ORDER BY e.priority ASC, e.name ASC`
-	
+
 	rows, err := c.db.Pool.Query(c.ctx, query, allExchanges)
 	if err != nil {
 		c.logger.Error("Failed to query prioritized exchanges", "error", err)
 		return allExchanges // Fallback to all exchanges
 	}
 	defer rows.Close()
-	
+
 	var prioritizedExchanges []string
 	for rows.Next() {
 		var name string
 		var priority int
 		var isActive bool
 		var ccxtID *string
-		
+
 		if err := rows.Scan(&name, &priority, &isActive, &ccxtID); err != nil {
 			c.logger.Error("Failed to scan exchange row", "error", err)
 			continue
 		}
-		
+
 		// Use CCXT ID if available, otherwise use name
 		exchangeID := name
 		if ccxtID != nil {
 			exchangeID = *ccxtID
 		}
-		
+
 		prioritizedExchanges = append(prioritizedExchanges, exchangeID)
 		c.logger.Debug("Added prioritized exchange", "exchange", exchangeID, "priority", priority)
 	}
-	
+
 	if len(prioritizedExchanges) == 0 {
 		c.logger.Warn("No prioritized exchanges found, using all exchanges")
 		return allExchanges
 	}
-	
+
 	c.logger.Info("Using prioritized exchanges", "total", len(prioritizedExchanges), "priority_count", len(prioritizedExchanges))
 	return prioritizedExchanges
 }
@@ -933,14 +902,11 @@ func (c *CollectorService) collectTickerDataBulk(worker *Worker) error {
 	var marketData []models.MarketPrice
 	err := c.circuitBreakerManager.GetOrCreate("ccxt", CircuitBreakerConfig{}).Execute(ctx, func(ctx context.Context) error {
 		return c.errorRecoveryManager.ExecuteWithRetry(ctx, "ccxt_bulk_fetch", func() error {
-			var interfaceData []ccxt.MarketPriceInterface
 			var fetchErr error
-			interfaceData, fetchErr = c.ccxtService.FetchMarketData(ctx, []string{worker.Exchange}, validSymbols)
+			marketData, fetchErr = c.ccxtService.FetchMarketData(ctx, []string{worker.Exchange}, validSymbols)
 			if fetchErr != nil {
 				return fetchErr
 			}
-			// Convert interface data to models.MarketPrice
-			marketData = c.convertMarketPriceInterfacesToModels(interfaceData)
 			return nil
 		})
 	})
@@ -1227,13 +1193,11 @@ func (c *CollectorService) collectTickerDataDirect(exchange, symbol string) erro
 	var ticker *models.MarketPrice
 	cbErr := c.circuitBreakerManager.GetOrCreate("ccxt", CircuitBreakerConfig{}).Execute(ctx, func(ctx context.Context) error {
 		return c.errorRecoveryManager.ExecuteWithRetry(ctx, "ccxt_single_fetch", func() error {
-			var interfaceData ccxt.MarketPriceInterface
 			var retryErr error
-			interfaceData, retryErr = c.ccxtService.FetchSingleTicker(ctx, exchange, symbol)
+			ticker, retryErr = c.ccxtService.FetchSingleTicker(ctx, exchange, symbol)
 			if retryErr != nil {
 				return retryErr
 			}
-			ticker = c.convertMarketPriceInterfaceToModel(interfaceData)
 			return nil
 		})
 	})
@@ -2447,13 +2411,11 @@ func (c *CollectorService) generateHistoricalDataPoints(ctx context.Context, exc
 	// Get current ticker data as baseline with circuit breaker
 	var ticker *models.MarketPrice
 	err := c.errorRecoveryManager.ExecuteWithRetry(ctx, "api_call", func() error {
-		var interfaceData ccxt.MarketPriceInterface
 		var fetchErr error
-		interfaceData, fetchErr = c.ccxtService.FetchSingleTicker(ctx, exchangeID, symbol)
+		ticker, fetchErr = c.ccxtService.FetchSingleTicker(ctx, exchangeID, symbol)
 		if fetchErr != nil {
 			return fetchErr
 		}
-		ticker = c.convertMarketPriceInterfaceToModel(interfaceData)
 		return nil
 	})
 	if err != nil {

--- a/test/testmocks/mocks.go
+++ b/test/testmocks/mocks.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/irfndi/celebrum-ai-go/internal/ccxt"
 	"github.com/irfndi/celebrum-ai-go/internal/models"
-	"github.com/irfandi/celebrum-ai-go/pkg/ccxt"
 	"github.com/redis/go-redis/v9"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/mock"


### PR DESCRIPTION
## Summary
- align handler and shared CCXT mocks with the internal ccxt interfaces
- update the collector service to use the concrete model types returned by FetchMarketData/FetchSingleTicker
- clean up unused imports in the cache warming tests

## Testing
- go test ./internal/api/handlers -run TestHealthCheckHandler -count=1 -v
- go test ./internal/services -run TestCollectorService_Start -count=1


------
https://chatgpt.com/codex/tasks/task_e_68d8c2a18ee8832e80e5161812bba9bf