### PR TITLE
fix: prioritize DATABASE_HOST over DATABASE_URL in migrate.sh

### DIFF
--- a/services/backend-api/database/migrate.sh
+++ b/services/backend-api/database/migrate.sh
@@ -36,8 +36,13 @@ log_error() {
 }
 
 # run_psql executes psql with the appropriate connection parameters
+# Prioritizes individual DATABASE_* vars over DATABASE_URL to avoid hostname conflicts
 run_psql() {
-  if [ -n "$DATABASE_URL" ]; then
+  # Use individual vars if DATABASE_HOST is explicitly set (not default localhost)
+  # This handles cases where DATABASE_URL has a different hostname than DATABASE_HOST
+  if [ -n "$DATABASE_HOST" ] && [ "$DATABASE_HOST" != "localhost" ]; then
+    PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" "$@"
+  elif [ -n "$DATABASE_URL" ]; then
     psql "$DATABASE_URL" "$@"
   else
     PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" "$@"


### PR DESCRIPTION
## Summary
- Fix migrate.sh to prioritize individual DATABASE_* environment variables over DATABASE_URL when DATABASE_HOST is explicitly set

## Problem
The migration script was using `DATABASE_URL` which contained `postgres` as hostname (Docker network alias), while `DATABASE_HOST` was correctly set to the external database host. This caused connection failures.

## Solution
When `DATABASE_HOST` is explicitly set (not `localhost`), use individual `DATABASE_*` variables instead of `DATABASE_URL`.

## Test plan
- [ ] Verify backend-api can run migrations on Coolify
- [ ] Verify services start correctly after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)