### PR TITLE
fix: disable reusePort by default to prevent EADDRINUSE on Linux

### DIFF
--- a/services/ccxt-service/index.ts
+++ b/services/ccxt-service/index.ts
@@ -1190,7 +1190,9 @@ if (shouldAutoServe) {
       const server = Bun.serve({
         fetch: app.fetch,
         port: Number(PORT),
-        reusePort: true, // Enable SO_REUSEPORT for graceful restarts
+        // reusePort can cause EADDRINUSE on some Linux configurations
+        // Only enable if explicitly requested via environment variable
+        reusePort: process.env.BUN_REUSE_PORT === "true",
       });
       console.log(
         `✅ CCXT Service successfully started on port ${server.port}`,

--- a/services/telegram-service/index.ts
+++ b/services/telegram-service/index.ts
@@ -469,7 +469,9 @@ if (!config.usePolling) {
 const server = Bun.serve({
   fetch: app.fetch,
   port: config.port,
-  reusePort: true,
+  // reusePort can cause EADDRINUSE on some Linux configurations
+  // Only enable if explicitly requested via environment variable
+  reusePort: process.env.BUN_REUSE_PORT === "true",
 });
 
 console.log(`🤖 Telegram service listening on port ${server.port}`);


### PR DESCRIPTION
## Summary
- Fixes CCXT service EADDRINUSE error on Linux that was causing container restart loops
- Makes Bun's `reusePort` option opt-in via `BUN_REUSE_PORT` environment variable
- Also applies the same fix to Telegram service for consistency

## Root Cause
The `reusePort: true` option in `Bun.serve()` can cause EADDRINUSE errors on some Linux configurations, particularly in containerized environments. The server would start successfully but then immediately fail with a port conflict.

## Changes
- `services/ccxt-service/index.ts`: Changed `reusePort: true` to `reusePort: process.env.BUN_REUSE_PORT === "true"`
- `services/telegram-service/index.ts`: Same change for consistency

## Test plan
- [x] All TypeScript tests pass (CCXT service + Telegram service)
- [x] All Go tests pass
- [x] Deploy to Coolify and verify services start successfully
- [x] Verify health checks pass for all services

🤖 Generated with [Claude Code](https://claude.ai/code)