### PR TITLE
fix: run bundled code directly without bun run wrapper

### DIFF
--- a/services/ccxt-service/Dockerfile
+++ b/services/ccxt-service/Dockerfile
@@ -26,4 +26,5 @@ ENV PORT=3001
 
 EXPOSE 3001
 
-CMD ["bun", "run", "dist/index.js"]
+# Run the bundled file directly to avoid bun run overhead and potential duplicate server
+CMD ["bun", "dist/index.js"]

--- a/services/telegram-service/Dockerfile
+++ b/services/telegram-service/Dockerfile
@@ -26,4 +26,5 @@ ENV TELEGRAM_PORT=3002
 
 EXPOSE 3002
 
-CMD ["bun", "run", "dist/index.js"]
+# Run the bundled file directly to avoid bun run overhead and potential duplicate server
+CMD ["bun", "dist/index.js"]


### PR DESCRIPTION
## Summary
Follow-up fix for EADDRINUSE issue. Changes Dockerfile CMD from `bun run dist/index.js` to `bun dist/index.js` to avoid potential overhead or duplicate server startup.

## Changes
- `services/ccxt-service/Dockerfile`: Use `bun dist/index.js` instead of `bun run dist/index.js`
- `services/telegram-service/Dockerfile`: Same change

## Test plan
- [x] Deploy to Coolify and verify services start without EADDRINUSE error

🤖 Generated with [Claude Code](https://claude.ai/code)