### PR TITLE
fix(ai): address PR review - type safety and decimal precision

### DIFF
--- a/services/backend-api/internal/ai/registry.go
+++ b/services/backend-api/internal/ai/registry.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/shopspring/decimal"
 	"go.uber.org/zap"
 )
 
@@ -34,13 +35,13 @@ type ModelCapability struct {
 
 // ModelCost represents cost metadata for a model
 type ModelCost struct {
-	InputCost       float64 `json:"input_cost"`
-	OutputCost      float64 `json:"output_cost"`
-	ReasoningCost   float64 `json:"reasoning_cost,omitempty"`
-	CacheReadCost   float64 `json:"cache_read_cost,omitempty"`
-	CacheWriteCost  float64 `json:"cache_write_cost,omitempty"`
-	AudioInputCost  float64 `json:"audio_input_cost,omitempty"`
-	AudioOutputCost float64 `json:"audio_output_cost,omitempty"`
+	InputCost       decimal.Decimal `json:"input_cost"`
+	OutputCost      decimal.Decimal `json:"output_cost"`
+	ReasoningCost   decimal.Decimal `json:"reasoning_cost,omitempty"`
+	CacheReadCost   decimal.Decimal `json:"cache_read_cost,omitempty"`
+	CacheWriteCost  decimal.Decimal `json:"cache_write_cost,omitempty"`
+	AudioInputCost  decimal.Decimal `json:"audio_input_cost,omitempty"`
+	AudioOutputCost decimal.Decimal `json:"audio_output_cost,omitempty"`
 }
 
 // ModelLimits represents token limits for a model

--- a/services/backend-api/internal/ai/registry_test.go
+++ b/services/backend-api/internal/ai/registry_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -82,7 +83,7 @@ func TestRegistryCacheOperations(t *testing.T) {
 				ModelID:      "gpt-4",
 				DisplayName:  "GPT-4",
 				Capabilities: ModelCapability{SupportsTools: true},
-				Cost:         ModelCost{InputCost: 30.0, OutputCost: 60.0},
+				Cost:         ModelCost{InputCost: decimal.NewFromFloat(30.0), OutputCost: decimal.NewFromFloat(60.0)},
 				Limits:       ModelLimits{ContextLimit: 8192},
 				Status:       "active",
 				LatencyClass: "medium",
@@ -92,7 +93,7 @@ func TestRegistryCacheOperations(t *testing.T) {
 				ModelID:      "claude-3-opus",
 				DisplayName:  "Claude 3 Opus",
 				Capabilities: ModelCapability{SupportsTools: true, SupportsReasoning: true},
-				Cost:         ModelCost{InputCost: 15.0, OutputCost: 75.0},
+				Cost:         ModelCost{InputCost: decimal.NewFromFloat(15.0), OutputCost: decimal.NewFromFloat(75.0)},
 				Limits:       ModelLimits{ContextLimit: 200000},
 				Status:       "active",
 				LatencyClass: "slow",
@@ -291,7 +292,7 @@ func TestModelInfoJSON(t *testing.T) {
 		ModelID:      "gpt-4",
 		DisplayName:  "GPT-4",
 		Capabilities: ModelCapability{SupportsTools: true},
-		Cost:         ModelCost{InputCost: 30.0, OutputCost: 60.0},
+		Cost:         ModelCost{InputCost: decimal.NewFromFloat(30.0), OutputCost: decimal.NewFromFloat(60.0)},
 		Limits:       ModelLimits{ContextLimit: 8192, OutputLimit: 4096},
 		Status:       "active",
 	}
@@ -306,6 +307,6 @@ func TestModelInfoJSON(t *testing.T) {
 	assert.Equal(t, model.ProviderID, decoded.ProviderID)
 	assert.Equal(t, model.ModelID, decoded.ModelID)
 	assert.Equal(t, model.Capabilities.SupportsTools, decoded.Capabilities.SupportsTools)
-	assert.Equal(t, model.Cost.InputCost, decoded.Cost.InputCost)
+	assert.True(t, model.Cost.InputCost.Equal(decoded.Cost.InputCost))
 	assert.Equal(t, model.Limits.ContextLimit, decoded.Limits.ContextLimit)
 }


### PR DESCRIPTION
## Summary
This PR addresses critical issues flagged by automated code review bots on PR #97.

### Issues Fixed

#### 1. Unsafe Type Assertions (CRITICAL)
**File:** `internal/middleware/ratelimit.go:182-185`

**Problem:** Direct type assertions without ok check could cause runtime panics if Redis returns unexpected types.

**Fix:** 
- Added proper type assertions with ok idiom
- Return descriptive errors instead of panicking
- Validate response format and all value types

```go
values, ok := result.([]interface{})
if !ok || len(values) != 3 {
    return false, 0, time.Time{}, fmt.Errorf("unexpected Redis response format")
}

allowedVal, ok := values[0].(int64)
if !ok {
    return false, 0, time.Time{}, fmt.Errorf("unexpected type for allowed value")
}
```

#### 2. Financial Precision with float64 (CRITICAL)
**Files:** `internal/ai/registry.go`, `internal/ai/router.go`

**Problem:** Using float64 for monetary values violates repository style guide and can cause precision loss.

**Fix:**
- Converted `ModelCost` struct to use `decimal.Decimal` for all cost fields
- Updated `RoutingConstraints` to use `decimal.Decimal` for budget constraints
- Modified `CalculateCost` to return `decimal.Decimal` for precise calculations
- Updated all tests to use `decimal.NewFromFloat()` instead of float64 literals

**Changes:**
```go
// Before
type ModelCost struct {
    InputCost  float64
    OutputCost float64
}

// After
type ModelCost struct {
    InputCost  decimal.Decimal
    OutputCost decimal.Decimal
}
```

### Testing
- ✅ All existing tests updated and passing
- ✅ `TestModelInfoJSON` updated to compare decimal values properly
- ✅ `TestCalculateCost` updated to use decimal comparisons
- ✅ Type safety tests for Redis responses

### Files Changed
- `services/backend-api/internal/ai/registry.go` - Add decimal import, update ModelCost
- `services/backend-api/internal/ai/registry_test.go` - Update tests for decimal
- `services/backend-api/internal/ai/router.go` - Update constraints and calculations
- `services/backend-api/internal/ai/router_test.go` - Update tests for decimal
- `services/backend-api/internal/middleware/ratelimit.go` - Fix type assertions

### Related
- Follow-up to PR #97
- Addresses issues flagged by kiloconnect and gemini-code-assist bots