### PR TITLE
feat(pubsub): Redis pub/sub market data channels (neura-n7l, neura-z5l, neura-8on)

### DIFF
--- a/services/backend-api/internal/services/pubsub/channels.go
+++ b/services/backend-api/internal/services/pubsub/channels.go
@@ -1,0 +1,142 @@
+// Package pubsub provides typed Redis pub/sub messaging for market data.
+//
+// Channel naming convention: {domain}:{entity}:{qualifier}
+// Examples: market:ticker:binance:BTC/USDT, market:signal:aggregated
+package pubsub
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DomainMarket = "market"
+)
+
+const (
+	EntityTicker    = "ticker"
+	EntityOrderBook = "orderbook"
+	EntityTrade     = "trade"
+	EntitySignal    = "signal"
+	EntityFunding   = "funding"
+)
+
+const (
+	QualifierAggregated = "aggregated"
+	QualifierTechnical  = "technical"
+	QualifierArbitrage  = "arbitrage"
+	QualifierRisk       = "risk"
+)
+
+const (
+	ChannelAllTickers    = DomainMarket + ":" + EntityTicker + ":*"
+	ChannelAllOrderBooks = DomainMarket + ":" + EntityOrderBook + ":*"
+	ChannelAllTrades     = DomainMarket + ":" + EntityTrade + ":*"
+	ChannelAllSignals    = DomainMarket + ":" + EntitySignal + ":*"
+	ChannelAllFunding    = DomainMarket + ":" + EntityFunding + ":*"
+)
+
+func TickerChannel(exchange, symbol string) string {
+	return fmt.Sprintf("%s:%s:%s:%s", DomainMarket, EntityTicker, exchange, symbol)
+}
+
+func OrderBookChannel(exchange, symbol string) string {
+	return fmt.Sprintf("%s:%s:%s:%s", DomainMarket, EntityOrderBook, exchange, symbol)
+}
+
+func TradeChannel(exchange, symbol string) string {
+	return fmt.Sprintf("%s:%s:%s:%s", DomainMarket, EntityTrade, exchange, symbol)
+}
+
+func SignalChannel(qualifier string) string {
+	return fmt.Sprintf("%s:%s:%s", DomainMarket, EntitySignal, qualifier)
+}
+
+func FundingChannel(exchange, symbol string) string {
+	return fmt.Sprintf("%s:%s:%s:%s", DomainMarket, EntityFunding, exchange, symbol)
+}
+
+func ExchangeTickerChannel(exchange string) string {
+	return fmt.Sprintf("%s:%s:%s:*", DomainMarket, EntityTicker, exchange)
+}
+
+// ParseChannel extracts domain, entity, and qualifiers from a channel name.
+// Channel format is {domain}:{entity}[:{q1}:{q2}:...].
+func ParseChannel(channel string) (domain, entity string, qualifiers []string) {
+	parts := strings.SplitN(channel, ":", 3)
+	if len(parts) < 2 {
+		return "", "", nil
+	}
+	domain = parts[0]
+	entity = parts[1]
+	if len(parts) == 3 {
+		qualifiers = strings.Split(parts[2], ":")
+	}
+	return domain, entity, qualifiers
+}
+
+type MessageType string
+
+const (
+	MessageTypeTicker    MessageType = "ticker"
+	MessageTypeOrderBook MessageType = "orderbook"
+	MessageTypeTrade     MessageType = "trade"
+	MessageTypeSignal    MessageType = "signal"
+	MessageTypeFunding   MessageType = "funding"
+)
+
+type Envelope struct {
+	Type      MessageType `json:"type"`
+	Channel   string      `json:"channel"`
+	Exchange  string      `json:"exchange,omitempty"`
+	Symbol    string      `json:"symbol,omitempty"`
+	Data      []byte      `json:"data"`
+	Timestamp time.Time   `json:"timestamp"`
+	TraceID   string      `json:"trace_id,omitempty"`
+}
+
+type TickerPayload struct {
+	Bid       string `json:"bid"`
+	Ask       string `json:"ask"`
+	Last      string `json:"last"`
+	Volume    string `json:"volume"`
+	High24h   string `json:"high_24h,omitempty"`
+	Low24h    string `json:"low_24h,omitempty"`
+	Change24h string `json:"change_24h,omitempty"`
+}
+
+type OrderBookPayload struct {
+	Bids      []PriceLevel `json:"bids"`
+	Asks      []PriceLevel `json:"asks"`
+	Timestamp time.Time    `json:"timestamp"`
+}
+
+type PriceLevel struct {
+	Price  string `json:"price"`
+	Amount string `json:"amount"`
+}
+
+type TradePayload struct {
+	ID        string `json:"id,omitempty"`
+	Price     string `json:"price"`
+	Amount    string `json:"amount"`
+	Side      string `json:"side"` // buy | sell
+	Timestamp int64  `json:"timestamp"`
+}
+
+type SignalPayload struct {
+	SignalType string                 `json:"signal_type"`
+	Direction  string                 `json:"direction"` // long | short | neutral
+	Strength   float64                `json:"strength"`
+	Confidence float64                `json:"confidence"`
+	Source     string                 `json:"source"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+}
+
+type FundingPayload struct {
+	Rate          string `json:"rate"`
+	NextFundingAt int64  `json:"next_funding_at"`
+	PredictedRate string `json:"predicted_rate,omitempty"`
+	IntervalHours int    `json:"interval_hours"`
+}

--- a/services/backend-api/internal/services/pubsub/channels_test.go
+++ b/services/backend-api/internal/services/pubsub/channels_test.go
@@ -1,0 +1,106 @@
+package pubsub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTickerChannel(t *testing.T) {
+	assert.Equal(t, "market:ticker:binance:BTC/USDT", TickerChannel("binance", "BTC/USDT"))
+	assert.Equal(t, "market:ticker:kraken:ETH/USD", TickerChannel("kraken", "ETH/USD"))
+}
+
+func TestOrderBookChannel(t *testing.T) {
+	assert.Equal(t, "market:orderbook:binance:BTC/USDT", OrderBookChannel("binance", "BTC/USDT"))
+}
+
+func TestTradeChannel(t *testing.T) {
+	assert.Equal(t, "market:trade:coinbase:SOL/USD", TradeChannel("coinbase", "SOL/USD"))
+}
+
+func TestSignalChannel(t *testing.T) {
+	assert.Equal(t, "market:signal:aggregated", SignalChannel(QualifierAggregated))
+	assert.Equal(t, "market:signal:technical", SignalChannel(QualifierTechnical))
+	assert.Equal(t, "market:signal:arbitrage", SignalChannel(QualifierArbitrage))
+	assert.Equal(t, "market:signal:risk", SignalChannel(QualifierRisk))
+}
+
+func TestFundingChannel(t *testing.T) {
+	assert.Equal(t, "market:funding:binance:BTC/USDT", FundingChannel("binance", "BTC/USDT"))
+}
+
+func TestExchangeTickerChannel(t *testing.T) {
+	assert.Equal(t, "market:ticker:binance:*", ExchangeTickerChannel("binance"))
+}
+
+func TestChannelConstants(t *testing.T) {
+	assert.Equal(t, "market:ticker:*", ChannelAllTickers)
+	assert.Equal(t, "market:orderbook:*", ChannelAllOrderBooks)
+	assert.Equal(t, "market:trade:*", ChannelAllTrades)
+	assert.Equal(t, "market:signal:*", ChannelAllSignals)
+	assert.Equal(t, "market:funding:*", ChannelAllFunding)
+}
+
+func TestParseChannel(t *testing.T) {
+	tests := []struct {
+		name       string
+		channel    string
+		wantDomain string
+		wantEntity string
+		wantQuals  []string
+	}{
+		{
+			name:       "ticker with exchange and symbol",
+			channel:    "market:ticker:binance:BTC/USDT",
+			wantDomain: "market",
+			wantEntity: "ticker",
+			wantQuals:  []string{"binance", "BTC/USDT"},
+		},
+		{
+			name:       "signal with qualifier",
+			channel:    "market:signal:aggregated",
+			wantDomain: "market",
+			wantEntity: "signal",
+			wantQuals:  []string{"aggregated"},
+		},
+		{
+			name:       "domain and entity only",
+			channel:    "market:ticker",
+			wantDomain: "market",
+			wantEntity: "ticker",
+			wantQuals:  nil,
+		},
+		{
+			name:       "malformed single segment",
+			channel:    "market",
+			wantDomain: "",
+			wantEntity: "",
+			wantQuals:  nil,
+		},
+		{
+			name:       "empty string",
+			channel:    "",
+			wantDomain: "",
+			wantEntity: "",
+			wantQuals:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			domain, entity, quals := ParseChannel(tt.channel)
+			assert.Equal(t, tt.wantDomain, domain)
+			assert.Equal(t, tt.wantEntity, entity)
+			assert.Equal(t, tt.wantQuals, quals)
+		})
+	}
+}
+
+func TestMessageTypeValues(t *testing.T) {
+	assert.Equal(t, MessageType("ticker"), MessageTypeTicker)
+	assert.Equal(t, MessageType("orderbook"), MessageTypeOrderBook)
+	assert.Equal(t, MessageType("trade"), MessageTypeTrade)
+	assert.Equal(t, MessageType("signal"), MessageTypeSignal)
+	assert.Equal(t, MessageType("funding"), MessageTypeFunding)
+}

--- a/services/backend-api/internal/services/pubsub/publisher.go
+++ b/services/backend-api/internal/services/pubsub/publisher.go
@@ -1,0 +1,130 @@
+package pubsub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+type Publisher struct {
+	client    *redis.Client
+	logger    *zap.Logger
+	published atomic.Int64
+	errors    atomic.Int64
+}
+
+func NewPublisher(client *redis.Client, logger *zap.Logger) *Publisher {
+	return &Publisher{
+		client: client,
+		logger: logger,
+	}
+}
+
+func (p *Publisher) Publish(ctx context.Context, channel string, envelope Envelope) error {
+	if channel == "" {
+		return fmt.Errorf("pubsub: channel cannot be empty")
+	}
+
+	envelope.Channel = channel
+	if envelope.Timestamp.IsZero() {
+		envelope.Timestamp = time.Now().UTC()
+	}
+
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		p.errors.Add(1)
+		return fmt.Errorf("pubsub: marshal envelope: %w", err)
+	}
+
+	if err := p.client.Publish(ctx, channel, data).Err(); err != nil {
+		p.errors.Add(1)
+		p.logger.Error("pubsub: publish failed",
+			zap.String("channel", channel),
+			zap.Error(err),
+		)
+		return fmt.Errorf("pubsub: publish to %s: %w", channel, err)
+	}
+
+	p.published.Add(1)
+	return nil
+}
+
+func (p *Publisher) PublishTicker(ctx context.Context, exchange, symbol string, payload TickerPayload) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("pubsub: marshal ticker payload: %w", err)
+	}
+	return p.Publish(ctx, TickerChannel(exchange, symbol), Envelope{
+		Type:     MessageTypeTicker,
+		Exchange: exchange,
+		Symbol:   symbol,
+		Data:     data,
+	})
+}
+
+func (p *Publisher) PublishOrderBook(ctx context.Context, exchange, symbol string, payload OrderBookPayload) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("pubsub: marshal orderbook payload: %w", err)
+	}
+	return p.Publish(ctx, OrderBookChannel(exchange, symbol), Envelope{
+		Type:     MessageTypeOrderBook,
+		Exchange: exchange,
+		Symbol:   symbol,
+		Data:     data,
+	})
+}
+
+func (p *Publisher) PublishTrade(ctx context.Context, exchange, symbol string, payload TradePayload) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("pubsub: marshal trade payload: %w", err)
+	}
+	return p.Publish(ctx, TradeChannel(exchange, symbol), Envelope{
+		Type:     MessageTypeTrade,
+		Exchange: exchange,
+		Symbol:   symbol,
+		Data:     data,
+	})
+}
+
+func (p *Publisher) PublishSignal(ctx context.Context, qualifier string, payload SignalPayload) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("pubsub: marshal signal payload: %w", err)
+	}
+	return p.Publish(ctx, SignalChannel(qualifier), Envelope{
+		Type: MessageTypeSignal,
+		Data: data,
+	})
+}
+
+func (p *Publisher) PublishFunding(ctx context.Context, exchange, symbol string, payload FundingPayload) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("pubsub: marshal funding payload: %w", err)
+	}
+	return p.Publish(ctx, FundingChannel(exchange, symbol), Envelope{
+		Type:     MessageTypeFunding,
+		Exchange: exchange,
+		Symbol:   symbol,
+		Data:     data,
+	})
+}
+
+type PublisherStats struct {
+	Published int64 `json:"published"`
+	Errors    int64 `json:"errors"`
+}
+
+func (p *Publisher) Stats() PublisherStats {
+	return PublisherStats{
+		Published: p.published.Load(),
+		Errors:    p.errors.Load(),
+	}
+}

--- a/services/backend-api/internal/services/pubsub/pubsub_test.go
+++ b/services/backend-api/internal/services/pubsub/pubsub_test.go
@@ -1,0 +1,422 @@
+package pubsub
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func setupTestRedis(t *testing.T) (*redis.Client, *miniredis.Miniredis) {
+	t.Helper()
+	s := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	return client, s
+}
+
+func TestPublisher_Publish(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+	pub := NewPublisher(client, zap.NewNop())
+
+	ctx := context.Background()
+	sub := client.Subscribe(ctx, "market:ticker:binance:BTC/USDT")
+	defer sub.Close()
+	_, err := sub.Receive(ctx)
+	require.NoError(t, err)
+
+	env := Envelope{
+		Type:     MessageTypeTicker,
+		Exchange: "binance",
+		Symbol:   "BTC/USDT",
+		Data:     []byte(`{"bid":"50000"}`),
+	}
+	err = pub.Publish(ctx, "market:ticker:binance:BTC/USDT", env)
+	require.NoError(t, err)
+
+	msg, err := sub.ReceiveMessage(ctx)
+	require.NoError(t, err)
+
+	var received Envelope
+	err = json.Unmarshal([]byte(msg.Payload), &received)
+	require.NoError(t, err)
+
+	assert.Equal(t, MessageTypeTicker, received.Type)
+	assert.Equal(t, "binance", received.Exchange)
+	assert.Equal(t, "BTC/USDT", received.Symbol)
+	assert.Equal(t, "market:ticker:binance:BTC/USDT", received.Channel)
+	assert.False(t, received.Timestamp.IsZero())
+}
+
+func TestPublisher_PublishEmptyChannel(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+	pub := NewPublisher(client, zap.NewNop())
+
+	err := pub.Publish(context.Background(), "", Envelope{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "channel cannot be empty")
+}
+
+func TestPublisher_PublishTicker(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+	pub := NewPublisher(client, zap.NewNop())
+
+	ctx := context.Background()
+	sub := client.Subscribe(ctx, TickerChannel("binance", "ETH/USDT"))
+	defer sub.Close()
+	_, err := sub.Receive(ctx)
+	require.NoError(t, err)
+
+	payload := TickerPayload{Bid: "3000", Ask: "3001", Last: "3000.5", Volume: "1000"}
+	err = pub.PublishTicker(ctx, "binance", "ETH/USDT", payload)
+	require.NoError(t, err)
+
+	msg, err := sub.ReceiveMessage(ctx)
+	require.NoError(t, err)
+
+	var env Envelope
+	require.NoError(t, json.Unmarshal([]byte(msg.Payload), &env))
+	assert.Equal(t, MessageTypeTicker, env.Type)
+
+	var received TickerPayload
+	require.NoError(t, json.Unmarshal(env.Data, &received))
+	assert.Equal(t, "3000", received.Bid)
+	assert.Equal(t, "3001", received.Ask)
+}
+
+func TestPublisher_PublishOrderBook(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+	pub := NewPublisher(client, zap.NewNop())
+
+	ctx := context.Background()
+	channel := OrderBookChannel("kraken", "BTC/USD")
+	sub := client.Subscribe(ctx, channel)
+	defer sub.Close()
+	_, err := sub.Receive(ctx)
+	require.NoError(t, err)
+
+	payload := OrderBookPayload{
+		Bids:      []PriceLevel{{Price: "50000", Amount: "1.5"}},
+		Asks:      []PriceLevel{{Price: "50001", Amount: "2.0"}},
+		Timestamp: time.Now().UTC(),
+	}
+	err = pub.PublishOrderBook(ctx, "kraken", "BTC/USD", payload)
+	require.NoError(t, err)
+
+	msg, err := sub.ReceiveMessage(ctx)
+	require.NoError(t, err)
+
+	var env Envelope
+	require.NoError(t, json.Unmarshal([]byte(msg.Payload), &env))
+	assert.Equal(t, MessageTypeOrderBook, env.Type)
+	assert.Equal(t, "kraken", env.Exchange)
+}
+
+func TestPublisher_PublishTrade(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+	pub := NewPublisher(client, zap.NewNop())
+
+	ctx := context.Background()
+	channel := TradeChannel("coinbase", "SOL/USD")
+	sub := client.Subscribe(ctx, channel)
+	defer sub.Close()
+	_, err := sub.Receive(ctx)
+	require.NoError(t, err)
+
+	payload := TradePayload{Price: "150", Amount: "10", Side: "buy", Timestamp: time.Now().Unix()}
+	err = pub.PublishTrade(ctx, "coinbase", "SOL/USD", payload)
+	require.NoError(t, err)
+
+	msg, err := sub.ReceiveMessage(ctx)
+	require.NoError(t, err)
+
+	var env Envelope
+	require.NoError(t, json.Unmarshal([]byte(msg.Payload), &env))
+	assert.Equal(t, MessageTypeTrade, env.Type)
+}
+
+func TestPublisher_PublishSignal(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+	pub := NewPublisher(client, zap.NewNop())
+
+	ctx := context.Background()
+	channel := SignalChannel(QualifierAggregated)
+	sub := client.Subscribe(ctx, channel)
+	defer sub.Close()
+	_, err := sub.Receive(ctx)
+	require.NoError(t, err)
+
+	payload := SignalPayload{
+		SignalType: "momentum",
+		Direction:  "long",
+		Strength:   0.85,
+		Confidence: 0.92,
+		Source:     "analyst_agent",
+	}
+	err = pub.PublishSignal(ctx, QualifierAggregated, payload)
+	require.NoError(t, err)
+
+	msg, err := sub.ReceiveMessage(ctx)
+	require.NoError(t, err)
+
+	var env Envelope
+	require.NoError(t, json.Unmarshal([]byte(msg.Payload), &env))
+	assert.Equal(t, MessageTypeSignal, env.Type)
+}
+
+func TestPublisher_PublishFunding(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+	pub := NewPublisher(client, zap.NewNop())
+
+	ctx := context.Background()
+	channel := FundingChannel("binance", "BTC/USDT")
+	sub := client.Subscribe(ctx, channel)
+	defer sub.Close()
+	_, err := sub.Receive(ctx)
+	require.NoError(t, err)
+
+	payload := FundingPayload{Rate: "0.0001", NextFundingAt: time.Now().Add(8 * time.Hour).Unix(), IntervalHours: 8}
+	err = pub.PublishFunding(ctx, "binance", "BTC/USDT", payload)
+	require.NoError(t, err)
+
+	msg, err := sub.ReceiveMessage(ctx)
+	require.NoError(t, err)
+
+	var env Envelope
+	require.NoError(t, json.Unmarshal([]byte(msg.Payload), &env))
+	assert.Equal(t, MessageTypeFunding, env.Type)
+}
+
+func TestPublisher_Stats(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+	pub := NewPublisher(client, zap.NewNop())
+
+	stats := pub.Stats()
+	assert.Equal(t, int64(0), stats.Published)
+	assert.Equal(t, int64(0), stats.Errors)
+
+	ctx := context.Background()
+	_ = pub.Publish(ctx, "test", Envelope{Type: MessageTypeTicker, Data: []byte(`{}`)})
+	_ = pub.Publish(ctx, "test2", Envelope{Type: MessageTypeTicker, Data: []byte(`{}`)})
+
+	stats = pub.Stats()
+	assert.Equal(t, int64(2), stats.Published)
+}
+
+func TestSubscriber_HandleByChannel(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+
+	pub := NewPublisher(client, zap.NewNop())
+	sub := NewSubscriber(client, zap.NewNop())
+	defer sub.Close()
+
+	var received Envelope
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	channel := TickerChannel("binance", "BTC/USDT")
+	sub.Handle(channel, func(_ context.Context, env Envelope) error {
+		received = env
+		wg.Done()
+		return nil
+	})
+
+	ctx := context.Background()
+	err := sub.Subscribe(ctx, channel)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	err = pub.PublishTicker(ctx, "binance", "BTC/USDT", TickerPayload{Bid: "50000", Ask: "50001"})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+
+	assert.Equal(t, MessageTypeTicker, received.Type)
+	assert.Equal(t, "binance", received.Exchange)
+}
+
+func TestSubscriber_HandleFuncByType(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+
+	pub := NewPublisher(client, zap.NewNop())
+	sub := NewSubscriber(client, zap.NewNop())
+	defer sub.Close()
+
+	var received Envelope
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	sub.HandleFunc(MessageTypeSignal, func(_ context.Context, env Envelope) error {
+		received = env
+		wg.Done()
+		return nil
+	})
+
+	channel := SignalChannel(QualifierTechnical)
+	ctx := context.Background()
+	err := sub.Subscribe(ctx, channel)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	err = pub.PublishSignal(ctx, QualifierTechnical, SignalPayload{
+		SignalType: "rsi", Direction: "long", Strength: 0.7, Confidence: 0.8, Source: "ta",
+	})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+
+	assert.Equal(t, MessageTypeSignal, received.Type)
+}
+
+func TestSubscriber_Close(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+
+	sub := NewSubscriber(client, zap.NewNop())
+
+	ctx := context.Background()
+	err := sub.Subscribe(ctx, "test:channel")
+	require.NoError(t, err)
+
+	stats := sub.Stats()
+	assert.Equal(t, 1, stats.Subscriptions)
+
+	err = sub.Close()
+	require.NoError(t, err)
+
+	stats = sub.Stats()
+	assert.Equal(t, 0, stats.Subscriptions)
+}
+
+func TestSubscriber_SubscribeEmptyChannels(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+
+	sub := NewSubscriber(client, zap.NewNop())
+	defer sub.Close()
+
+	err := sub.Subscribe(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one channel required")
+}
+
+func TestSubscriber_PSubscribeEmptyPatterns(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+
+	sub := NewSubscriber(client, zap.NewNop())
+	defer sub.Close()
+
+	err := sub.PSubscribe(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one pattern required")
+}
+
+func TestSubscriber_Stats(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+
+	sub := NewSubscriber(client, zap.NewNop())
+
+	stats := sub.Stats()
+	assert.Equal(t, int64(0), stats.Received)
+	assert.Equal(t, int64(0), stats.Errors)
+	assert.Equal(t, 0, stats.Subscriptions)
+
+	ctx := context.Background()
+	err := sub.Subscribe(ctx, "ch1")
+	require.NoError(t, err)
+	err = sub.Subscribe(ctx, "ch2")
+	require.NoError(t, err)
+
+	stats = sub.Stats()
+	assert.Equal(t, 2, stats.Subscriptions)
+
+	sub.Close()
+}
+
+func TestEndToEnd_PublisherSubscriberRoundTrip(t *testing.T) {
+	client, _ := setupTestRedis(t)
+	defer client.Close()
+
+	pub := NewPublisher(client, zap.NewNop())
+	sub := NewSubscriber(client, zap.NewNop())
+	defer sub.Close()
+
+	results := make(chan Envelope, 5)
+
+	sub.Handle(TickerChannel("binance", "BTC/USDT"), func(_ context.Context, env Envelope) error {
+		results <- env
+		return nil
+	})
+	sub.Handle(FundingChannel("binance", "BTC/USDT"), func(_ context.Context, env Envelope) error {
+		results <- env
+		return nil
+	})
+
+	ctx := context.Background()
+	err := sub.Subscribe(ctx, TickerChannel("binance", "BTC/USDT"), FundingChannel("binance", "BTC/USDT"))
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	err = pub.PublishTicker(ctx, "binance", "BTC/USDT", TickerPayload{Bid: "60000", Ask: "60001"})
+	require.NoError(t, err)
+
+	err = pub.PublishFunding(ctx, "binance", "BTC/USDT", FundingPayload{Rate: "0.0003", IntervalHours: 8})
+	require.NoError(t, err)
+
+	received := make(map[MessageType]Envelope)
+	timeout := time.After(3 * time.Second)
+	for i := 0; i < 2; i++ {
+		select {
+		case env := <-results:
+			received[env.Type] = env
+		case <-timeout:
+			t.Fatalf("timed out after receiving %d of 2 messages", i)
+		}
+	}
+
+	assert.Contains(t, received, MessageTypeTicker)
+	assert.Contains(t, received, MessageTypeFunding)
+
+	tickerEnv := received[MessageTypeTicker]
+	var tickerData TickerPayload
+	require.NoError(t, json.Unmarshal(tickerEnv.Data, &tickerData))
+	assert.Equal(t, "60000", tickerData.Bid)
+
+	pubStats := pub.Stats()
+	assert.Equal(t, int64(2), pubStats.Published)
+
+	subStats := sub.Stats()
+	assert.Equal(t, int64(2), subStats.Received)
+}

--- a/services/backend-api/internal/services/pubsub/subscriber.go
+++ b/services/backend-api/internal/services/pubsub/subscriber.go
@@ -1,0 +1,189 @@
+package pubsub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+type MessageHandler func(ctx context.Context, envelope Envelope) error
+
+type Subscriber struct {
+	client        *redis.Client
+	logger        *zap.Logger
+	handlers      map[string]MessageHandler
+	mu            sync.RWMutex
+	subscriptions []*activeSubscription
+	received      atomic.Int64
+	errors        atomic.Int64
+}
+
+type activeSubscription struct {
+	pubsub *redis.PubSub
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func NewSubscriber(client *redis.Client, logger *zap.Logger) *Subscriber {
+	return &Subscriber{
+		client:   client,
+		logger:   logger,
+		handlers: make(map[string]MessageHandler),
+	}
+}
+
+func (s *Subscriber) Handle(channel string, handler MessageHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.handlers[channel] = handler
+}
+
+func (s *Subscriber) HandleFunc(msgType MessageType, handler MessageHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.handlers[string(msgType)] = handler
+}
+
+func (s *Subscriber) Subscribe(ctx context.Context, channels ...string) error {
+	if len(channels) == 0 {
+		return fmt.Errorf("pubsub: at least one channel required")
+	}
+
+	pubsub := s.client.Subscribe(ctx, channels...)
+	if _, err := pubsub.Receive(ctx); err != nil {
+		_ = pubsub.Close()
+		return fmt.Errorf("pubsub: subscribe to %v: %w", channels, err)
+	}
+
+	subCtx, cancel := context.WithCancel(ctx)
+	sub := &activeSubscription{
+		pubsub: pubsub,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+
+	s.mu.Lock()
+	s.subscriptions = append(s.subscriptions, sub)
+	s.mu.Unlock()
+
+	go s.listen(subCtx, sub)
+	return nil
+}
+
+func (s *Subscriber) PSubscribe(ctx context.Context, patterns ...string) error {
+	if len(patterns) == 0 {
+		return fmt.Errorf("pubsub: at least one pattern required")
+	}
+
+	pubsub := s.client.PSubscribe(ctx, patterns...)
+	if _, err := pubsub.Receive(ctx); err != nil {
+		_ = pubsub.Close()
+		return fmt.Errorf("pubsub: psubscribe to %v: %w", patterns, err)
+	}
+
+	subCtx, cancel := context.WithCancel(ctx)
+	sub := &activeSubscription{
+		pubsub: pubsub,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+
+	s.mu.Lock()
+	s.subscriptions = append(s.subscriptions, sub)
+	s.mu.Unlock()
+
+	go s.listen(subCtx, sub)
+	return nil
+}
+
+func (s *Subscriber) listen(ctx context.Context, sub *activeSubscription) {
+	defer close(sub.done)
+	ch := sub.pubsub.Channel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			_ = sub.pubsub.Close()
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			s.dispatch(ctx, msg)
+		}
+	}
+}
+
+func (s *Subscriber) dispatch(ctx context.Context, msg *redis.Message) {
+	var envelope Envelope
+	if err := json.Unmarshal([]byte(msg.Payload), &envelope); err != nil {
+		s.errors.Add(1)
+		s.logger.Warn("pubsub: unmarshal message failed",
+			zap.String("channel", msg.Channel),
+			zap.Error(err),
+		)
+		return
+	}
+
+	s.received.Add(1)
+
+	s.mu.RLock()
+	handler, ok := s.handlers[msg.Channel]
+	if !ok {
+		handler, ok = s.handlers[string(envelope.Type)]
+	}
+	s.mu.RUnlock()
+
+	if !ok {
+		return
+	}
+
+	handlerCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if err := handler(handlerCtx, envelope); err != nil {
+		s.errors.Add(1)
+		s.logger.Error("pubsub: handler error",
+			zap.String("channel", msg.Channel),
+			zap.String("type", string(envelope.Type)),
+			zap.Error(err),
+		)
+	}
+}
+
+func (s *Subscriber) Close() error {
+	s.mu.Lock()
+	subs := make([]*activeSubscription, len(s.subscriptions))
+	copy(subs, s.subscriptions)
+	s.subscriptions = nil
+	s.mu.Unlock()
+
+	for _, sub := range subs {
+		sub.cancel()
+		<-sub.done
+	}
+	return nil
+}
+
+type SubscriberStats struct {
+	Received      int64 `json:"received"`
+	Errors        int64 `json:"errors"`
+	Subscriptions int   `json:"subscriptions"`
+}
+
+func (s *Subscriber) Stats() SubscriberStats {
+	s.mu.RLock()
+	subCount := len(s.subscriptions)
+	s.mu.RUnlock()
+	return SubscriberStats{
+		Received:      s.received.Load(),
+		Errors:        s.errors.Load(),
+		Subscriptions: subCount,
+	}
+}


### PR DESCRIPTION
## Summary
- **neura-n7l**: Define market data channel constants and message types for Redis pub/sub
- **neura-z5l**: Implement Redis message publishing service with typed channel support
- **neura-8on**: Implement Redis message subscription service with handler pattern

## Scope
Builds on existing `database.RedisClient.Publish/Subscribe` methods to create a proper market data messaging layer:
- Channel name constants and message envelope types
- Publisher service with JSON serialization and error handling
- Subscriber service with message routing, graceful shutdown, and reconnection

## Tasks
- [x] Lock tasks (Draft PR)
- [x] Define channel constants and message types (neura-n7l)
- [x] Implement publishing service (neura-z5l)
- [x] Implement subscription service (neura-8on)
- [x] Unit tests with miniredis
- [x] Integration tests
- [x] CI green

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Implements a well-structured Redis pub/sub messaging layer for market data distribution. The implementation introduces typed channel naming conventions, message envelope structures, and separate Publisher/Subscriber services with proper concurrency handling.

**Key Changes:**
- Channel naming follows `{domain}:{entity}:{qualifier}` pattern with constants for tickers, orderbooks, trades, signals, and funding data
- Publisher service handles JSON serialization, automatic timestamps, and tracks metrics with atomic counters
- Subscriber service supports both channel-specific and type-based message routing with 5-second handler timeouts
- Comprehensive test coverage using miniredis for both unit and integration testing
- Clean separation of concerns with independent publisher and subscriber implementations

**Architecture:**
The code properly uses `*redis.Client` (not `database.RedisClient`) for pub/sub operations, which aligns with Redis best practices. The subscriber implements graceful shutdown with context cancellation and waits for goroutines to finish.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects clean implementation with proper error handling, concurrency safety, comprehensive test coverage, and follows Go best practices. All critical paths are tested with miniredis.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| services/backend-api/internal/services/pubsub/channels.go | Defines typed channel naming constants, message envelope structure, and payload types for market data pub/sub |
| services/backend-api/internal/services/pubsub/channels_test.go | Comprehensive unit tests for channel naming functions and message type constants with good edge case coverage |
| services/backend-api/internal/services/pubsub/publisher.go | Redis publisher service with typed message publishing, JSON serialization, error handling, and atomic stats tracking |
| services/backend-api/internal/services/pubsub/subscriber.go | Redis subscriber with handler routing, graceful shutdown, and context timeout handling; proper concurrency management |
| services/backend-api/internal/services/pubsub/pubsub_test.go | Complete integration tests using miniredis covering publisher, subscriber, and end-to-end message flow scenarios |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant P as Publisher
    participant R as Redis
    participant S as Subscriber
    participant H as Handler
    
    Note over P,H: Market Data Publishing Flow
    
    P->>P: Marshal payload to JSON
    P->>P: Create Envelope with metadata
    P->>P: Set timestamp if not provided
    P->>P: Marshal Envelope to JSON
    P->>R: PUBLISH channel message
    R-->>P: Subscriber count
    P->>P: Increment published counter
    
    Note over S,H: Subscription & Listening Flow
    
    S->>R: SUBSCRIBE to channels
    R-->>S: Subscription confirmation
    S->>S: Spawn listen goroutine
    
    loop Message Reception
        R->>S: Message on subscribed channel
        S->>S: Unmarshal Envelope
        S->>S: Increment received counter
        S->>S: Lookup handler (by channel or type)
        alt Handler found
            S->>H: Invoke handler with 5s timeout
            H-->>S: Return error or nil
            alt Handler error
                S->>S: Log error & increment error counter
            end
        else No handler
            S->>S: Silently skip message
        end
    end
    
    Note over S,H: Graceful Shutdown
    
    S->>S: Cancel context
    S->>R: Close PubSub connection
    S->>S: Wait for goroutine completion
```

<sub>Last reviewed commit: 253180c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->