### PR TITLE
feat: AI session state serialization (neura-eb8)

### DIFF
--- a/services/backend-api/database/migrations/067_create_ai_sessions_table.sql
+++ b/services/backend-api/database/migrations/067_create_ai_sessions_table.sql
@@ -1,3 +1,8 @@
+-- Migration 067: Create ai_sessions table for serializing AI agent session state
+-- Created: 2026-02-14
+
+BEGIN;
+
 -- Create ai_sessions table for serializing AI agent session state
 CREATE TABLE IF NOT EXISTS ai_sessions (
     id VARCHAR(100) PRIMARY KEY,
@@ -14,8 +19,11 @@ CREATE INDEX IF NOT EXISTS idx_ai_sessions_symbol ON ai_sessions(symbol);
 CREATE INDEX IF NOT EXISTS idx_ai_sessions_status ON ai_sessions(status);
 CREATE INDEX IF NOT EXISTS idx_ai_sessions_updated_at ON ai_sessions(updated_at DESC);
 
-GRANT SELECT, INSERT, UPDATE, DELETE ON ai_sessions TO authenticated;
+-- Migration completion marker
+INSERT INTO system_config (config_key, config_value, description) VALUES
+    ('migration_067_completed', 'true', 'Migration 067: Create ai_sessions table')
+ON CONFLICT (config_key) DO UPDATE SET
+    config_value = EXCLUDED.config_value,
+    updated_at = CURRENT_TIMESTAMP;
 
-INSERT INTO system_config (config_key, config_value, description)
-VALUES ('migration_067_completed', 'true', 'Migration 067: Create ai_sessions table')
-ON CONFLICT (config_key) DO NOTHING;
+COMMIT;


### PR DESCRIPTION
## Summary
- **neura-eb8**: AI session state serialization with JSON, checksum validation, and PostgreSQL persistence

## Files
- `services/backend-api/internal/services/session_state.go` - Session serialization
- `services/backend-api/database/migrations/067_create_ai_sessions_table.sql` - Database schema

## PR Review Fixes Addressed
- ✅ Database migration for ai_sessions table
- ✅ rand.Read error handling  
- ✅ Nil pointer dereference fix
- ✅ Telemetry logging for errors
- ✅ nullString returns *string instead of interface{}

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Implements AI session state serialization with JSON, SHA-256 checksum validation, and PostgreSQL persistence for the `ai_sessions` table.

- Created database migration for `ai_sessions` table with JSONB storage for full session state
- Implemented `SessionSerializer` with checksum validation to detect data corruption
- Added `DatabaseSessionRepository` with methods to save, load, list, and delete session states
- Includes conversion utilities from execution loop context to serializable snapshots
- **Issue**: Migration uses incorrect table names (`system_settings`, `migration_log`) instead of the correct ones (`system_config`, `schema_migrations`) used throughout the codebase

<h3>Confidence Score: 3/5</h3>

- PR has a critical migration issue that would cause runtime errors, but the Go implementation is solid
- The session serialization logic in `session_state.go` is well-implemented with proper error handling, checksum validation, and clean architecture. However, the database migration references non-existent tables which will cause the migration to fail when executed
- Pay close attention to `services/backend-api/database/migrations/067_create_ai_sessions_table.sql` - the table name issue must be fixed before merging

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| services/backend-api/database/migrations/067_create_ai_sessions_table.sql | Database migration with incorrect table references - uses `system_settings` and `migration_log` instead of `system_config` and `schema_migrations` |
| services/backend-api/internal/services/session_state.go | Session state serialization with JSON, checksum validation, and PostgreSQL persistence - implementation is sound |

</details>


</details>


<h3>Entity Relationship Diagram</h3>

```mermaid
erDiagram
    ai_sessions {
        varchar id PK
        varchar quest_id FK
        varchar symbol
        varchar status
        jsonb state_data
        timestamptz created_at
        timestamptz updated_at
    }
    
    quests {
        varchar id PK
        varchar status
    }
    
    ai_sessions ||--o| quests : "quest_id references"
    
    ai_sessions ||--|| state_data : "contains SessionState JSON"
    
    state_data {
        string id
        string status
        string quest_id
        string symbol
        array conversation_history
        array tool_calls_made
        array loaded_skills
        object market_snapshot
        object portfolio_snapshot
        object analysis_result
        object trading_decision
        object risk_assessment
        object execution_result
        int iteration_count
        object metadata
        string checksum
    }
```

<sub>Last reviewed commit: 1b9e6fa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->