### PR TITLE
Add tests for ai_cli.go truncate function (tech debt)

### DIFF
--- a/services/backend-api/cmd/server/ai_cli.go
+++ b/services/backend-api/cmd/server/ai_cli.go
@@ -466,5 +466,8 @@ func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
+	if maxLen <= 3 {
+		return "..."
+	}
 	return s[:maxLen-3] + "..."
 }

--- a/services/backend-api/cmd/server/ai_cli_test.go
+++ b/services/backend-api/cmd/server/ai_cli_test.go
@@ -67,6 +67,24 @@ func TestTruncateEdgeCases(t *testing.T) {
 		expected string
 	}{
 		{
+			name:     "maxLen 0 returns ellipsis only",
+			input:    "test",
+			maxLen:   0,
+			expected: "...",
+		},
+		{
+			name:     "maxLen 1 returns ellipsis only",
+			input:    "test",
+			maxLen:   1,
+			expected: "...",
+		},
+		{
+			name:     "maxLen 2 returns ellipsis only",
+			input:    "test",
+			maxLen:   2,
+			expected: "...",
+		},
+		{
 			name:     "unicode string truncates by bytes",
 			input:    "こんにちは",
 			maxLen:   5,
@@ -78,12 +96,18 @@ func TestTruncateEdgeCases(t *testing.T) {
 			maxLen:   6,
 			expected: "Hello",
 		},
+		{
+			name:     "short string with maxLen 3",
+			input:    "Hi",
+			maxLen:   3,
+			expected: "Hi",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := truncate(tt.input, tt.maxLen)
-			if tt.maxLen >= 3 && result != tt.expected {
+			if result != tt.expected {
 				t.Errorf("truncate(%q, %d) = %q; want %q", tt.input, tt.maxLen, result, tt.expected)
 			}
 		})


### PR DESCRIPTION
## Summary
- Add unit tests for the `truncate` function in `ai_cli.go`
- Tests cover normal cases, edge cases, and unicode handling
- Increases test coverage for cmd/server package

## Tasks
- [x] neura-tdz: Add ai_cli.go test file

## Status
Draft PR to claim tech debt work and prevent race conditions.

## Tests
- All tests pass: `go test ./cmd/server/...`
- go vet passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added comprehensive unit tests for the `truncate` function covering normal cases, edge cases, and unicode handling. The tests properly validate the function's byte-based truncation behavior, including the edge case where unicode strings are truncated at byte boundaries (which produces broken UTF-8 sequences). All tests use table-driven test pattern consistent with Go best practices.

<h3>Confidence Score: 3/5</h3>

- This test-only PR is generally safe but contains a test case that validates broken UTF-8 output behavior
- The tests properly cover the `truncate` function's behavior, but the unicode test case documents that the function produces invalid UTF-8 when truncating multi-byte characters. This is a design issue with the underlying function, not the test itself, but the test validates potentially problematic behavior without documenting it as a known limitation
- Pay attention to `services/backend-api/cmd/server/ai_cli_test.go` line 70-73 - the unicode test validates broken UTF-8 output

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| services/backend-api/cmd/server/ai_cli_test.go | Added unit tests for `truncate` function with normal cases, edge cases, and unicode handling; unicode test has incorrect expected output that causes broken UTF-8 sequences |

</details>


</details>


<sub>Last reviewed commit: aa84ca3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->