### PR TITLE
neura-3szk: Trading Event Bus

### DIFF
--- a/services/backend-api/internal/services/trading_event_bus.go
+++ b/services/backend-api/internal/services/trading_event_bus.go
@@ -238,11 +238,18 @@ func (b *TradingEventBus) SubscribeToChannel(eventType TradingEventType) (<-chan
 
 // startEventDispatcher runs a goroutine to dispatch events to handlers.
 func (b *TradingEventBus) startEventDispatcher(eventType TradingEventType) {
-	ch := b.channels[eventType]
 	for {
+		b.mu.RLock()
+		ch, ok := b.channels[eventType]
+		b.mu.RUnlock()
+
+		if !ok {
+			return
+		}
+
 		select {
-		case event, ok := <-ch:
-			if !ok {
+		case event, channelOk := <-ch:
+			if !channelOk {
 				return
 			}
 			b.mu.RLock()


### PR DESCRIPTION
## Summary
- Implement Trading Event Bus for real-time event-driven architecture
- Add typed event channels for market, order, risk, and Polymarket events
- Include Redis Pub/Sub wrapper with Go channels

## Tasks
- [x] neura-3szk: Trading Event Bus (in progress)

## Testing
- Unit tests with 90%+ coverage

## Notes
- DRAFT PR for claiming task - implementation in progress

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements a real-time event-driven architecture with typed event channels for market, order, risk, and Polymarket events, plus Redis Pub/Sub wrapper for distributed systems

## Key Changes
- Added 10 typed event types with corresponding payload structs using `decimal.Decimal` for financial values
- Implemented in-memory pub/sub with buffered channels and concurrent handler dispatching
- Added Redis Pub/Sub integration for cross-service event propagation
- Includes panic recovery for handlers and graceful shutdown via `stopCh`
- Test suite covers concurrent operations, serialization, and edge cases (90%+ coverage)

## Critical Issues Found
- **Goroutine leak in `SubscribeToRedis`**: Redis pubsub goroutine never terminates and lacks context cancellation
- **Race condition in `Publish`**: Channel can be closed between read lock and send, causing panic
- **Missing dispatcher in `SubscribeToChannel`**: Direct channel subscribers won't receive events unless handler subscription exists
- **Subscription ID collisions**: Time-based IDs can collide with concurrent subscriptions

## Architecture Concerns
- No backpressure handling beyond timeout and drop behavior
- Redis pubsub connections never closed, accumulate over time
- Event dispatchers don't fully cleanup on shutdown

<h3>Confidence Score: 2/5</h3>

- This PR has critical concurrency bugs that will cause goroutine leaks and potential panics in production
- Score reflects critical issues: goroutine leaks in `SubscribeToRedis` (no cleanup), race condition in `Publish` (panic on closed channel), missing dispatcher in `SubscribeToChannel` (events won't be delivered), and subscription ID collisions. These are not edge cases but will manifest under normal concurrent usage. The event bus is a core infrastructure component, so bugs here affect system reliability.
- Pay close attention to `services/backend-api/internal/services/trading_event_bus.go` - all critical issues are in the main implementation file

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| services/backend-api/internal/services/trading_event_bus.go | Implements event bus with typed channels and Redis Pub/Sub; has critical goroutine leaks, race conditions on channel closure, and missing dispatcher for `SubscribeToChannel` |
| services/backend-api/internal/services/trading_event_bus_test.go | Comprehensive test suite with 90%+ coverage including concurrent operations, panic recovery, and serialization; doesn't test Redis integration or goroutine leak scenarios |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Publisher] -->|Publish| B[TradingEventBus]
    B -->|Route by Type| C{Event Type}
    C -->|EventPriceUpdate| D1[Price Channel]
    C -->|EventSignalDetected| D2[Signal Channel]
    C -->|EventArbitrageFound| D3[Arbitrage Channel]
    C -->|EventOrderFilled| D4[Order Channel]
    C -->|EventRisk Events| D5[Risk Channel]
    C -->|EventPolymarket| D6[Polymarket Channel]
    
    D1 --> E1[Event Dispatcher 1]
    D2 --> E2[Event Dispatcher 2]
    D3 --> E3[Event Dispatcher 3]
    D4 --> E4[Event Dispatcher 4]
    D5 --> E5[Event Dispatcher 5]
    D6 --> E6[Event Dispatcher 6]
    
    E1 -->|Fan-out| F1[Handler 1]
    E1 -->|Fan-out| F2[Handler 2]
    E2 -->|Fan-out| F3[Handler 3]
    E3 -->|Fan-out| F4[Handler 4]
    
    B -->|Publish| G[Redis Pub/Sub]
    G -->|Subscribe| H[Redis Listener]
    H -->|Route Back| C
    
    I[stopCh] -.->|Shutdown Signal| E1
    I -.->|Shutdown Signal| E2
    I -.->|Shutdown Signal| E3
    
    style B fill:#f9f,stroke:#333,stroke-width:2px
    style G fill:#bbf,stroke:#333,stroke-width:2px
    style I fill:#fbb,stroke:#333,stroke-width:2px
```

<sub>Last reviewed commit: bc84e7f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->