### PR TITLE
Split PR192A: core config, middleware, ccxt, and ai registry updates

### DIFF
--- a/services/backend-api/internal/ai/policy_engine.go
+++ b/services/backend-api/internal/ai/policy_engine.go
@@ -242,7 +242,6 @@ func (pe *PolicyEngine) RouteWithStrategy(
 	strategy PolicyType,
 	baseConstraints RoutingConstraints,
 ) (*RoutingResult, error) {
-	_ = PolicyWeightsByType(strategy)
 	return pe.router.Route(ctx, baseConstraints)
 }
 

--- a/services/backend-api/internal/ai/registry.go
+++ b/services/backend-api/internal/ai/registry.go
@@ -88,6 +88,8 @@ type ModelRegistry struct {
 	Providers []ProviderInfo `json:"providers"`
 	Models    []ModelInfo    `json:"models"`
 	FetchedAt time.Time      `json:"fetched_at"`
+	// Raw data for compatibility
+	RawProviders map[string]ProviderInfo `json:"-"`
 }
 
 // Registry provides AI provider and model registry functionality
@@ -105,11 +107,22 @@ type Registry struct {
 // RegistryOption configures the Registry
 type RegistryOption func(*Registry)
 
-// WithHTTPClient sets a custom HTTP client
-func WithHTTPClient(client *http.Client) RegistryOption {
-	return func(r *Registry) {
-		r.client = client
+// NewRegistry creates a new AI model registry
+func NewRegistry(opts ...RegistryOption) *Registry {
+	r := &Registry{
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		modelsDevURL: ModelsDevAPIURL,
+		cacheTTL:     CacheTTL,
+		logger:       zap.NewNop(),
 	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
 }
 
 // WithRedis sets the Redis client for caching
@@ -119,43 +132,31 @@ func WithRedis(client *redis.Client) RegistryOption {
 	}
 }
 
-// WithLogger sets the logger
+// WithLogger sets the logger for the registry
 func WithLogger(logger *zap.Logger) RegistryOption {
 	return func(r *Registry) {
 		r.logger = logger
 	}
 }
 
-// WithCacheTTL sets the cache TTL
+// WithCacheTTL sets the cache TTL for the registry
 func WithCacheTTL(ttl time.Duration) RegistryOption {
 	return func(r *Registry) {
 		r.cacheTTL = ttl
 	}
 }
 
-// NewRegistry creates a new AI provider registry
-func NewRegistry(opts ...RegistryOption) *Registry {
-	r := &Registry{
-		client: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		modelsDevURL: ModelsDevAPIURL,
-		cacheTTL:     CacheTTL,
+// WithModelsDevURL sets the models.dev API URL
+func WithModelsDevURL(url string) RegistryOption {
+	return func(r *Registry) {
+		r.modelsDevURL = url
 	}
-
-	for _, opt := range opts {
-		opt(r)
-	}
-
-	if r.logger == nil {
-		r.logger = zap.NewNop()
-	}
-
-	return r
 }
 
 // FetchModels fetches the model registry from models.dev API
 func (r *Registry) FetchModels(ctx context.Context) (*ModelRegistry, error) {
+	r.logger.Info("Fetching models from models.dev API", zap.String("url", r.modelsDevURL))
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.modelsDevURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -176,26 +177,147 @@ func (r *Registry) FetchModels(ctx context.Context) (*ModelRegistry, error) {
 		return nil, fmt.Errorf("models.dev API returned status %d", resp.StatusCode)
 	}
 
-	var registry ModelRegistry
-	if err := json.NewDecoder(resp.Body).Decode(&registry); err != nil {
+	// The new models.dev API format uses provider IDs as keys
+	// e.g., { "openai": { "models": {...}}, "anthropic": {...} }
+	var rawData map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&rawData); err != nil {
 		return nil, fmt.Errorf("failed to decode models.dev response: %w", err)
+	}
+
+	registry := &ModelRegistry{
+		RawProviders: make(map[string]ProviderInfo),
+		Providers:    []ProviderInfo{},
+		Models:       []ModelInfo{},
+	}
+
+	// Parse each provider
+	r.logger.Info("Starting to parse providers", zap.Int("provider_count", len(rawData)))
+	for providerID, providerData := range rawData {
+		r.logger.Debug("Processing provider", zap.String("provider", providerID))
+		pd, ok := providerData.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Extract provider info
+		provider := ProviderInfo{
+			ID: providerID,
+		}
+
+		if name, ok := pd["name"].(string); ok {
+			provider.Name = name
+		}
+		if npm, ok := pd["npm"].(string); ok {
+			provider.NPM = npm
+		}
+		if envVars, ok := pd["env"].([]interface{}); ok {
+			provider.EnvVars = make([]string, len(envVars))
+			for i, v := range envVars {
+				if s, ok := v.(string); ok {
+					provider.EnvVars[i] = s
+				}
+			}
+		}
+
+		// Extract models
+		if modelsData, ok := pd["models"].(map[string]interface{}); ok {
+			for modelID, modelData := range modelsData {
+				md, ok := modelData.(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				model := ModelInfo{
+					ProviderID:    providerID,
+					ProviderLabel: provider.Name,
+					ModelID:       modelID,
+				}
+
+				// Parse model fields
+				if name, ok := md["name"].(string); ok {
+					model.DisplayName = name
+				}
+				if family, ok := md["family"].(string); ok {
+					model.Family = family
+				}
+				if releaseDate, ok := md["release_date"].(string); ok {
+					model.ReleaseDate = releaseDate
+				}
+				if lastUpdated, ok := md["last_updated"].(string); ok {
+					model.LastUpdated = lastUpdated
+				}
+
+				// Capabilities
+				if toolCall, ok := md["tool_call"].(bool); ok {
+					model.Capabilities.SupportsTools = toolCall
+				}
+				if reasoning, ok := md["reasoning"].(bool); ok {
+					model.Capabilities.SupportsReasoning = reasoning
+				}
+
+				// Status - default to active if not specified
+				model.Status = "active"
+				if status, ok := md["status"].(string); ok {
+					model.Status = status
+				}
+
+				// Cost parsing
+				if costData, ok := md["cost"].(map[string]interface{}); ok {
+					if input, ok := costData["input"].(float64); ok {
+						model.Cost.InputCost = decimal.NewFromFloat(input)
+					}
+					if output, ok := costData["output"].(float64); ok {
+						model.Cost.OutputCost = decimal.NewFromFloat(output)
+					}
+					if reasoning, ok := costData["reasoning"].(float64); ok {
+						model.Cost.ReasoningCost = decimal.NewFromFloat(reasoning)
+					}
+					if cacheRead, ok := costData["cache_read"].(float64); ok {
+						model.Cost.CacheReadCost = decimal.NewFromFloat(cacheRead)
+					}
+				}
+
+				// Limits
+				if limitData, ok := md["limit"].(map[string]interface{}); ok {
+					if context, ok := limitData["context"].(float64); ok {
+						model.Limits.ContextLimit = int(context)
+					}
+					if input, ok := limitData["input"].(float64); ok {
+						model.Limits.InputLimit = int(input)
+					}
+					if output, ok := limitData["output"].(float64); ok {
+						model.Limits.OutputLimit = int(output)
+					}
+				}
+
+				// Latency class (infer from provider)
+				model.LatencyClass = inferLatencyClass(providerID)
+
+				registry.Models = append(registry.Models, model)
+			}
+		}
+
+		registry.Providers = append(registry.Providers, provider)
+		registry.RawProviders[providerID] = provider
 	}
 
 	registry.FetchedAt = time.Now().UTC()
 
+	r.logger.Info("Fetched models", zap.Int("providers", len(registry.Providers)), zap.Int("models", len(registry.Models)))
+
 	// Update local cache
 	r.mu.Lock()
-	r.localCache = &registry
+	r.localCache = registry
 	r.mu.Unlock()
 
 	// Cache to Redis if available
 	if r.redis != nil {
-		if err := r.cacheToRedis(ctx, &registry); err != nil {
+		if err := r.cacheToRedis(ctx, registry); err != nil {
 			r.logger.Warn("Failed to cache models to Redis", zap.Error(err))
 		}
 	}
 
-	return &registry, nil
+	return registry, nil
 }
 
 // GetRegistry returns the current model registry, using cache if available
@@ -222,7 +344,13 @@ func (r *Registry) GetRegistry(ctx context.Context) (*ModelRegistry, error) {
 	}
 
 	// Fetch from API
-	return r.FetchModels(ctx)
+	registry, err := r.FetchModels(ctx)
+	if err != nil {
+		r.logger.Error("Failed to fetch models", zap.Error(err))
+		return nil, err
+	}
+	r.logger.Info("Fetched from API", zap.Int("models", len(registry.Models)))
+	return registry, nil
 }
 
 // cacheToRedis caches the registry to Redis
@@ -349,4 +477,33 @@ func (r *Registry) Refresh(ctx context.Context) (*ModelRegistry, error) {
 	}
 
 	return r.FetchModels(ctx)
+}
+
+func inferLatencyClass(providerID string) string {
+	fastProviders := map[string]bool{
+		"openai":       true,
+		"anthropic":    true,
+		"google":       true,
+		"xai":          true,
+		"cohere":       true,
+		"mistral":      true,
+		"fireworks-ai": true,
+		"togetherai":   true,
+		"groq":         true,
+		"deepseek":     true,
+	}
+
+	accurateProviders := map[string]bool{
+		"anthropic":     true,
+		"openai":        true,
+		"google-vertex": true,
+	}
+
+	if fastProviders[providerID] {
+		return "fast"
+	}
+	if accurateProviders[providerID] {
+		return "accurate"
+	}
+	return "balanced"
 }

--- a/services/backend-api/internal/ccxt/interface.go
+++ b/services/backend-api/internal/ccxt/interface.go
@@ -24,6 +24,10 @@ type MarketPriceInterface interface {
 	GetBid() float64
 	// GetAsk retrieves the best ask price.
 	GetAsk() float64
+	// GetHigh retrieves the 24h high price.
+	GetHigh() float64
+	// GetLow retrieves the 24h low price.
+	GetLow() float64
 }
 
 // ArbitrageOpportunityInterface defines the interface for arbitrage opportunity data.
@@ -163,6 +167,9 @@ type CCXTClient interface {
 	GetFundingRates(ctx context.Context, exchange string, symbols []string) ([]FundingRate, error)
 	// GetAllFundingRates gets all funding rates.
 	GetAllFundingRates(ctx context.Context, exchange string) ([]FundingRate, error)
+
+	// Balance operations
+	FetchBalance(ctx context.Context, exchange string) (*BalanceResponse, error)
 
 	// Lifecycle
 

--- a/services/backend-api/internal/ccxt/types.go
+++ b/services/backend-api/internal/ccxt/types.go
@@ -184,6 +184,8 @@ func (s *Service) FetchMarketData(ctx context.Context, exchanges []string, symbo
 			Ask:          tickerData.Ticker.Ask,
 			AskVolume:    decimal.Zero, // CCXT doesn't provide ask volume in ticker, would need order book
 			Price:        tickerData.Ticker.Last,
+			High24h:      tickerData.Ticker.High,
+			Low24h:       tickerData.Ticker.Low,
 			Volume:       tickerData.Ticker.Volume,
 			Timestamp:    tickerData.Ticker.Timestamp.Time(),
 		}
@@ -215,6 +217,10 @@ func (s *Service) FetchSingleTicker(ctx context.Context, exchange, symbol string
 		ExchangeName: resp.Exchange,
 		Symbol:       resp.Ticker.Symbol,
 		Price:        resp.Ticker.Last,
+		Bid:          resp.Ticker.Bid,
+		Ask:          resp.Ticker.Ask,
+		High24h:      resp.Ticker.High,
+		Low24h:       resp.Ticker.Low,
 		Volume:       resp.Ticker.Volume,
 		Timestamp:    resp.Ticker.Timestamp.Time(),
 	}, nil
@@ -697,4 +703,8 @@ func (s *Service) RefreshExchanges(ctx context.Context) (*ExchangeManagementResp
 //	error: Error if operation fails.
 func (s *Service) AddExchange(ctx context.Context, exchange string) (*ExchangeManagementResponse, error) {
 	return s.client.AddExchange(ctx, exchange)
+}
+
+func (s *Service) FetchBalance(ctx context.Context, exchange string) (*BalanceResponse, error) {
+	return s.client.FetchBalance(ctx, exchange)
 }

--- a/services/backend-api/internal/ccxt/types_test.go
+++ b/services/backend-api/internal/ccxt/types_test.go
@@ -163,6 +163,10 @@ func (m *MockClient) Close() error {
 	return nil
 }
 
+func (m *MockClient) FetchBalance(ctx context.Context, exchange string) (*BalanceResponse, error) {
+	return &BalanceResponse{Exchange: exchange, Total: map[string]float64{"USDT": 1000.0}}, nil
+}
+
 func (m *MockClient) BaseURL() string {
 	if m.BaseURLFunc != nil {
 		return m.BaseURLFunc()

--- a/services/backend-api/internal/config/config_test.go
+++ b/services/backend-api/internal/config/config_test.go
@@ -189,7 +189,7 @@ func TestLoad_WithDefaults(t *testing.T) {
 	assert.Equal(t, 8080, config.Server.Port)
 	assert.Equal(t, []string{"http://localhost:3000"}, config.Server.AllowedOrigins)
 	assert.Equal(t, "localhost", config.Database.Host)
-	assert.Equal(t, "postgres", config.Database.Driver)
+	assert.Equal(t, "sqlite", config.Database.Driver)
 	assert.Equal(t, 5432, config.Database.Port)
 	assert.Equal(t, "postgres", config.Database.User)
 	assert.Equal(t, "change-me-in-production", config.Database.Password)
@@ -200,7 +200,7 @@ func TestLoad_WithDefaults(t *testing.T) {
 	assert.Equal(t, 5, config.Database.MaxIdleConns)
 	assert.Equal(t, "300s", config.Database.ConnMaxLifetime)
 	assert.Equal(t, "60s", config.Database.ConnMaxIdleTime)
-	assert.Equal(t, "data/neuratrade.db", config.Database.SQLitePath)
+	assert.Equal(t, "neuratrade.db", config.Database.SQLitePath)
 	assert.Equal(t, "", config.Database.SQLiteVectorExtensionPath)
 	assert.Equal(t, "localhost", config.Redis.Host)
 	assert.Equal(t, 6379, config.Redis.Port)
@@ -325,4 +325,92 @@ func TestLoad_SQLiteDriverRejectsWhitespacePath(t *testing.T) {
 	config, err := Load()
 	assert.Nil(t, config)
 	assert.ErrorContains(t, err, "database.sqlite_path is required")
+}
+
+func TestLoad_UserHomeDirConfig(t *testing.T) {
+	os.Clearenv()
+	t.Setenv("DATABASE_DRIVER", "postgres")
+	t.Setenv("DATABASE_HOST", "test-host")
+
+	_, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("Cannot determine home directory")
+	}
+
+	config, err := Load()
+	require.NotNil(t, config)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-host", config.Database.Host)
+}
+
+func TestLoad_NeuratradeConfigJSON(t *testing.T) {
+	os.Clearenv()
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("Cannot determine home directory")
+	}
+
+	neuratradeDir := homeDir + "/.neuratrade"
+	err = os.MkdirAll(neuratradeDir, 0755)
+	if err != nil {
+		t.Skip("Cannot create .neuratrade directory")
+	}
+	defer os.RemoveAll(neuratradeDir)
+
+	configFile := neuratradeDir + "/config.json"
+	configContent := `{
+		"database": {
+			"host": "neuratrade-host",
+			"port": 5433
+		},
+		"server": {
+			"port": 9999
+		}
+	}`
+	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	if err != nil {
+		t.Skip("Cannot write test config file")
+	}
+	defer os.Remove(configFile)
+
+	config, err := Load()
+	require.NotNil(t, config)
+	assert.NoError(t, err)
+	assert.Equal(t, "neuratrade-host", config.Database.Host)
+	assert.Equal(t, 5433, config.Database.Port)
+}
+
+func TestLoad_NeuratradeConfigEnvTakesPrecedence(t *testing.T) {
+	os.Clearenv()
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("Cannot determine home directory")
+	}
+
+	neuratradeDir := homeDir + "/.neuratrade"
+	err = os.MkdirAll(neuratradeDir, 0755)
+	if err != nil {
+		t.Skip("Cannot create .neuratrade directory")
+	}
+	defer os.RemoveAll(neuratradeDir)
+
+	configFile := neuratradeDir + "/config.json"
+	configContent := `{
+		"database": {
+			"host": "neuratrade-host"
+		}
+	}`
+	err = os.WriteFile(configFile, []byte(configContent), 0644)
+	if err != nil {
+		t.Skip("Cannot write test config file")
+	}
+	defer os.Remove(configFile)
+
+	t.Setenv("DATABASE_HOST", "env-host")
+	config, err := Load()
+	require.NotNil(t, config)
+	assert.NoError(t, err)
+	assert.Equal(t, "env-host", config.Database.Host)
 }

--- a/services/backend-api/internal/middleware/auth_test.go
+++ b/services/backend-api/internal/middleware/auth_test.go
@@ -241,7 +241,8 @@ func TestAuthMiddleware_RequireAuth(t *testing.T) {
 
 func TestAuthMiddleware_OptionalAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	am := NewAuthMiddleware("test-secret")
+	// Use valid 32+ character secret for tests
+	am := NewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
 
 	// Helper function to create test router
 	createTestRouter := func() *gin.Engine {
@@ -343,7 +344,7 @@ func TestAuthMiddleware_OptionalAuth(t *testing.T) {
 
 func TestAuthMiddleware_MiddlewareChain(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	am := NewAuthMiddleware("test-secret")
+	am := NewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
 
 	// Test middleware chain execution order
 	t.Run("middleware chain execution", func(t *testing.T) {

--- a/services/backend-api/internal/middleware/telemetry.go
+++ b/services/backend-api/internal/middleware/telemetry.go
@@ -1,3 +1,4 @@
+// Package middleware provides HTTP middleware components for NeuraTrade.
 package middleware
 
 import (
@@ -8,24 +9,22 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// TelemetryMiddleware creates a Gin middleware for Sentry tracing.
-// It initializes the Sentry hub for each request.
+// TelemetryMiddleware creates Gin middleware for Sentry tracing.
+// Initializes Sentry hub for each request to enable error tracking.
 //
 // Returns:
-//
-//	gin.HandlerFunc: Gin handler.
+//   - gin.HandlerFunc: Gin middleware handler.
 func TelemetryMiddleware() gin.HandlerFunc {
 	return sentrygin.New(sentrygin.Options{
 		Repanic: true,
 	})
 }
 
-// HealthCheckTelemetryMiddleware creates a Gin middleware for health check endpoints.
-// It tags the transaction as a health check.
+// HealthCheckTelemetryMiddleware creates Gin middleware for health check endpoints.
+// Tags transactions as health checks for monitoring purposes.
 //
 // Returns:
-//
-//	gin.HandlerFunc: Gin handler.
+//   - gin.HandlerFunc: Gin middleware handler.
 func HealthCheckTelemetryMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// For now, we just pass through as we want to monitor health checks too
@@ -37,13 +36,13 @@ func HealthCheckTelemetryMiddleware() gin.HandlerFunc {
 	}
 }
 
-// RecordError records an error on the current span/hub.
+// RecordError records an error on the current Sentry span/hub.
+// Captures the error for tracking and sets span status to error.
 //
 // Parameters:
-//
-//	c: Gin context.
-//	err: Error to record.
-//	description: Description of the error.
+//   - c: Gin context.
+//   - err: Error to record.
+//   - description: Description of the error context.
 func RecordError(c *gin.Context, err error, description string) {
 	if hub := sentrygin.GetHubFromContext(c); hub != nil {
 		hub.CaptureException(err)
@@ -53,13 +52,12 @@ func RecordError(c *gin.Context, err error, description string) {
 	}
 }
 
-// StartSpan starts a new span or adds a breadcrumb.
-// This is a wrapper to maintain compatibility with existing code but using Sentry.
+// StartSpan starts a new span or adds a breadcrumb for tracing.
+// Wrapper for Sentry span management with backward compatibility.
 //
 // Parameters:
-//
-//	c: Gin context.
-//	name: Span name.
+//   - c: Gin context.
+//   - name: Span name or operation description.
 func StartSpan(c *gin.Context, name string) {
 	if hub := sentrygin.GetHubFromContext(c); hub != nil {
 		// Sentry Gin middleware starts the transaction automatically.
@@ -73,13 +71,13 @@ func StartSpan(c *gin.Context, name string) {
 	}
 }
 
-// AddSpanAttribute adds an attribute to the current span.
+// AddSpanAttribute adds an attribute to the current Sentry span.
+// Sets a tag on the scope for filtering and searching in Sentry.
 //
 // Parameters:
-//
-//	c: Gin context.
-//	key: Attribute key.
-//	value: Attribute value.
+//   - c: Gin context.
+//   - key: Attribute key name.
+//   - value: Attribute value (converted to string).
 func AddSpanAttribute(c *gin.Context, key string, value interface{}) {
 	if hub := sentrygin.GetHubFromContext(c); hub != nil {
 		hub.Scope().SetTag(key, fmt.Sprint(value))


### PR DESCRIPTION
## Summary
Sub-split of #192 (A): core runtime infrastructure updates only.

Includes:
- config loading updates (`internal/config`)
- middleware hardening (`internal/middleware`)
- CCXT type/interface/client alignment (`internal/ccxt`)
- AI registry/policy internals (`internal/ai`)

## Validation
- `go test ./internal/config/... ./internal/middleware/... ./internal/ccxt/... ./internal/ai/...`

## Base
- Base branch: `codex/pr184-03-sqlite-bootstrap` (#189)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors core runtime infrastructure across config loading, middleware security, CCXT client integration, and AI registry parsing.

**Key Changes:**
- **Config**: Added `~/.neuratrade/config.json` support for user-level overrides, new `AIConfig` and `FeaturesConfig` structs, and changed default database driver from `postgres` to `sqlite`
- **Middleware**: Implemented constant-time comparison in admin auth to prevent timing attacks, added JWT secret length validation (min 32 chars), and improved rate limiter with periodic cleanup
- **CCXT**: Added `FetchBalance` method, expanded market data with `High24h`/`Low24h` fields, and improved int32 conversion safety with inline bounds checking
- **AI Registry**: Major refactor to parse new models.dev API format (provider-keyed JSON map), added latency class inference, and enhanced error logging

**Issues Found:**
- `config.go:377-381` contains duplicate `AddConfigPath` call for `~/.neuratrade` directory
- `admin.go:158` uses plain string comparison in `ValidateAdminKey()` instead of constant-time comparison, creating timing attack vulnerability

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe but contains timing attack vulnerability and duplicate code
- Two critical issues found: (1) timing attack vulnerability in ValidateAdminKey using plain comparison instead of constant-time, and (2) duplicate AddConfigPath call. The middleware security improvements are good, but the inconsistent use of constant-time comparison undermines the security hardening. The CCXT and AI registry changes appear safe.
- Pay close attention to `services/backend-api/internal/middleware/admin.go` (timing attack in ValidateAdminKey) and `services/backend-api/internal/config/config.go` (duplicate config path)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| services/backend-api/internal/ai/registry.go | Major refactor of models.dev API parsing with new JSON structure support and latency inference |
| services/backend-api/internal/ccxt/client.go | Added FetchBalance method and improved int32 conversion safety with inline bounds checking |
| services/backend-api/internal/config/config.go | Added AI/Features config, user home config path, and default driver change to sqlite - contains duplicate AddConfigPath call |
| services/backend-api/internal/middleware/admin.go | Added constant-time comparison for auth headers but ValidateAdminKey still uses plain comparison |
| services/backend-api/internal/middleware/auth.go | Added JWT secret validation (min 32 chars) and improved package documentation |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Config Loading] --> B{Load ~/.neuratrade/config.json?}
    B -->|Found| C[Load User Config]
    B -->|Not Found| D[Load ./config.yml]
    C --> E[Apply Environment Variables]
    D --> E
    E --> F[Config Ready]
    
    G[Middleware Auth Flow] --> H{Admin Endpoint?}
    H -->|Yes| I[AdminMiddleware.RequireAdminAuth]
    H -->|No| J[AuthMiddleware.RequireAuth]
    I --> K{Check Authorization Header}
    K -->|Valid Bearer| L[Constant-Time Compare]
    K -->|Invalid| M{Check X-API-Key Header}
    M -->|Valid| L
    M -->|Invalid| N[Return 401]
    L -->|Match| O[Allow Request]
    L -->|No Match| N
    
    J --> P{JWT Token Present?}
    P -->|Yes| Q[Parse & Validate JWT]
    P -->|No| N
    Q -->|Valid| O
    Q -->|Invalid/Expired| N
    
    R[CCXT Client] --> S[GetOrderBook/GetTrades/GetOHLCV]
    S --> T{gRPC Available?}
    T -->|Yes| U[Convert int to int32 with Bounds Check]
    U --> V[Call gRPC Service]
    T -->|No| W[Call HTTP API]
    V --> X[Return Market Data]
    W --> X
    
    Y[AI Registry] --> Z[FetchModels from models.dev]
    Z --> AA[Parse Provider JSON Map]
    AA --> AB[Extract Provider Info]
    AB --> AC[Extract Models per Provider]
    AC --> AD[Infer Latency Class]
    AD --> AE[Cache to Redis & Local]
    AE --> AF[Return ModelRegistry]
```

<sub>Last reviewed commit: 0893ecf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->