### PR TITLE
fix(cleanup): Prevent panic and resource leaks in CleanupService

### DIFF
--- a/services/backend-api/internal/services/cleanup.go
+++ b/services/backend-api/internal/services/cleanup.go
@@ -122,6 +122,11 @@ func (c *CleanupService) Start(config CleanupConfig) {
 		}
 	}()
 
+	// Validate interval to prevent panic from time.NewTicker
+	if config.IntervalMinutes <= 0 {
+		c.logger.Warn("Cleanup interval is non-positive; periodic cleanup disabled", "interval_minutes", config.IntervalMinutes)
+		return
+	}
 	// Start periodic cleanup
 	ticker := time.NewTicker(time.Duration(config.IntervalMinutes) * time.Minute)
 	c.wg.Add(1)
@@ -133,22 +138,23 @@ func (c *CleanupService) Start(config CleanupConfig) {
 			case <-c.ctx.Done():
 				return
 			case <-ticker.C:
-				// Create timeout context for periodic cleanup
-				ctx, cancel := context.WithTimeout(c.ctx, 30*time.Minute)
-
-				spanCtx, span := observability.StartSpan(ctx, "maintenance.cleanup", "CleanupService.periodicCleanup")
-				err := c.executeWithRetry(spanCtx, "periodic_cleanup", func() error {
-					return c.runCleanup(spanCtx, config)
-				})
-				observability.FinishSpan(span, err)
-				if err != nil {
-					c.logger.Error("Cleanup failed", "error", err)
-					observability.AddBreadcrumbWithData(spanCtx, "cleanup", "Periodic cleanup failed", sentry.LevelError, map[string]interface{}{
-						"error": err.Error(),
+				// Wrap in IIFE to ensure cancel() runs even on panic
+				func() {
+					ctx, cancel := context.WithTimeout(c.ctx, 30*time.Minute)
+					defer cancel()
+					spanCtx, span := observability.StartSpan(ctx, "maintenance.cleanup", "CleanupService.periodicCleanup")
+					err := c.executeWithRetry(spanCtx, "periodic_cleanup", func() error {
+						return c.runCleanup(spanCtx, config)
 					})
-					// Note: Performance monitor doesn't have RecordFailure method
-				}
-				cancel()
+					observability.FinishSpan(span, err)
+					if err != nil {
+						c.logger.Error("Cleanup failed", "error", err)
+						observability.AddBreadcrumbWithData(spanCtx, "cleanup", "Periodic cleanup failed", sentry.LevelError, map[string]interface{}{
+							"error": err.Error(),
+						})
+						// Note: Performance monitor doesn't have RecordFailure method
+					}
+				}()
 			}
 		}
 	}()


### PR DESCRIPTION
## Summary

Fixes critical issues in CleanupService that could cause panics and resource leaks during periodic cleanup operations.

## Changes

- **Prevent panic**: Validate cleanup interval before creating ticker (prevents `time.NewTicker` panic with non-positive values)
- **Fix context leak**: Wrap cleanup operation in IIFE with `defer cancel()` to ensure context is always cancelled
- **Improve error handling**: Better structure for cleanup error handling

## Testing

- ✅ All service tests passing: `go test ./internal/services/...`
- ✅ No race conditions detected
- ✅ No memory leaks in cleanup tests

## Impact

- Prevents potential runtime panics from misconfigured cleanup intervals
- Ensures proper resource cleanup even on errors
- No breaking changes - defensive improvements only

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds important defensive improvements to `CleanupService`:
- Validates `IntervalMinutes` before calling `time.NewTicker` to prevent runtime panics when configured with non-positive values
- Wraps periodic cleanup operations in an IIFE with `defer cancel()` to ensure context resources are always released, even on panic

The changes are well-tested with comprehensive test coverage and follow Go best practices for resource management.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - purely defensive improvements
- Changes are defensive bug fixes that prevent potential runtime panics and resource leaks. The implementation is straightforward, well-tested (as confirmed by PR description), and follows established Go patterns. No breaking changes or risky refactoring.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| services/backend-api/internal/services/cleanup.go | Added panic prevention for non-positive intervals and fixed context leak with IIFE wrapper |

</details>


</details>


<sub>Last reviewed commit: dbf89b7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->