### PR TITLE
PR14: Legacy cleanup and boundary enforcement

### DIFF
--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -1061,6 +1061,16 @@ func readQuestMetricInt(v interface{}) int {
 	return 0
 }
 
+func readQuestMetricIntWithFallback(checkpoint map[string]interface{}, primary, fallback string) int {
+	if checkpoint == nil {
+		return 0
+	}
+	if value, ok := checkpoint[primary]; ok {
+		return readQuestMetricInt(value)
+	}
+	return readQuestMetricInt(checkpoint[fallback])
+}
+
 func readQuestMetricBool(v interface{}) bool {
 	switch value := v.(type) {
 	case bool:
@@ -1894,7 +1904,7 @@ func (e *QuestEngine) GetChatRuntimeDiagnostics(chatID string) map[string]interf
 		holdStreak = maxInt(holdStreak, readQuestMetricInt(cp["runtime_hold_streak"]))
 		unlockCycles = maxInt(unlockCycles, readQuestMetricInt(cp["runtime_unlock_cycles"]))
 		failureStreak = maxInt(failureStreak, readQuestMetricInt(cp["runtime_failure_streak"]))
-		recoveryCleanCycles = maxInt(recoveryCleanCycles, readQuestMetricInt(cp["recovery_clean_cycles"]))
+		recoveryCleanCycles = maxInt(recoveryCleanCycles, readQuestMetricIntWithFallback(cp, "recovery_clean_cycles_current", "recovery_clean_cycles"))
 		recoveryCleanRequired = maxInt(recoveryCleanRequired, readQuestMetricInt(cp["recovery_clean_cycles_required"]))
 		recoveryCyclesToEntry = maxInt(recoveryCyclesToEntry, readQuestMetricInt(cp["recovery_cycles_to_entry"]))
 		if mode := readQuestMetricString(cp["recovery_mode"]); mode != "" {

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -2396,7 +2396,7 @@ func (h *IntegratedQuestHandlers) maybeSendHoldDigest(
 		fmt.Sprintf(
 			"Recovery mode: %s (clean cycles %d, entry_allowed=%t)",
 			checkpointString(quest.Checkpoint["recovery_mode"]),
-			checkpointInt(quest.Checkpoint["recovery_clean_cycles"]),
+			checkpointIntWithFallback(quest.Checkpoint, "recovery_clean_cycles_current", "recovery_clean_cycles"),
 			checkpointBool(quest.Checkpoint["recovery_entry_allowed"]),
 		),
 		fmt.Sprintf("AI runtime error-rate window: %.0f%%", errorRate*100),
@@ -2490,7 +2490,7 @@ func (h *IntegratedQuestHandlers) evaluateRecoveryGateStateForScope(
 	cleanCycles := 0
 	failureStreak := 0
 	if quest != nil && quest.Checkpoint != nil {
-		cleanCycles = checkpointInt(quest.Checkpoint["recovery_clean_cycles"])
+		cleanCycles = checkpointIntWithFallback(quest.Checkpoint, "recovery_clean_cycles_current", "recovery_clean_cycles")
 		failureStreak = checkpointInt(quest.Checkpoint["runtime_failure_streak"])
 	}
 	recentLoss := h.currentRecentLossStreak(ctx, chatID, exchange)
@@ -2565,7 +2565,8 @@ func (h *IntegratedQuestHandlers) applyRecoveryStateCheckpoint(
 
 	quest.Checkpoint["recovery_mode"] = state.Mode
 	quest.Checkpoint["recovery_entry_allowed"] = state.EntryAllowed
-	quest.Checkpoint["recovery_clean_cycles"] = state.CleanCycles
+	quest.Checkpoint["recovery_clean_cycles_current"] = state.CleanCycles
+	delete(quest.Checkpoint, "recovery_clean_cycles")
 	quest.Checkpoint["recovery_clean_cycles_required"] = state.RequiredCleanCycles
 	quest.Checkpoint["recovery_cycles_to_entry"] = state.CyclesToEntry
 	if evaluatedAt.IsZero() {
@@ -2587,15 +2588,17 @@ func (h *IntegratedQuestHandlers) updateRecoveryCleanCycles(quest *Quest, clean 
 		quest.Checkpoint = make(map[string]interface{})
 	}
 	if !clean {
-		quest.Checkpoint["recovery_clean_cycles"] = 0
+		quest.Checkpoint["recovery_clean_cycles_current"] = 0
+		delete(quest.Checkpoint, "recovery_clean_cycles")
 		if strings.TrimSpace(reason) != "" {
 			quest.Checkpoint["recovery_last_reset_reason"] = strings.TrimSpace(reason)
 		}
 		return
 	}
-	cleanCycles := checkpointInt(quest.Checkpoint["recovery_clean_cycles"])
+	cleanCycles := checkpointIntWithFallback(quest.Checkpoint, "recovery_clean_cycles_current", "recovery_clean_cycles")
 	cleanCycles++
-	quest.Checkpoint["recovery_clean_cycles"] = cleanCycles
+	quest.Checkpoint["recovery_clean_cycles_current"] = cleanCycles
+	delete(quest.Checkpoint, "recovery_clean_cycles")
 	delete(quest.Checkpoint, "recovery_last_reset_reason")
 }
 
@@ -4105,6 +4108,16 @@ func checkpointInt(v interface{}) int {
 		}
 	}
 	return 0
+}
+
+func checkpointIntWithFallback(checkpoint map[string]interface{}, primary, fallback string) int {
+	if checkpoint == nil {
+		return 0
+	}
+	if value, ok := checkpoint[primary]; ok {
+		return checkpointInt(value)
+	}
+	return checkpointInt(checkpoint[fallback])
 }
 
 func checkpointFloat(v interface{}) float64 {

--- a/services/backend-api/internal/services/quest_handlers_integrated_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_test.go
@@ -515,10 +515,12 @@ func TestIntegratedQuestHandlers_UpdateRecoveryCleanCycles_ResetOnFailure(t *tes
 
 	handlers.updateRecoveryCleanCycles(quest, true, "")
 	handlers.updateRecoveryCleanCycles(quest, true, "")
-	assert.Equal(t, 2, checkpointInt(quest.Checkpoint["recovery_clean_cycles"]))
+	assert.Equal(t, 2, checkpointInt(quest.Checkpoint["recovery_clean_cycles_current"]))
+	assert.NotContains(t, quest.Checkpoint, "recovery_clean_cycles")
 
 	handlers.updateRecoveryCleanCycles(quest, false, "runtime_error")
-	assert.Equal(t, 0, checkpointInt(quest.Checkpoint["recovery_clean_cycles"]))
+	assert.Equal(t, 0, checkpointInt(quest.Checkpoint["recovery_clean_cycles_current"]))
+	assert.NotContains(t, quest.Checkpoint, "recovery_clean_cycles")
 	assert.Equal(t, "runtime_error", checkpointString(quest.Checkpoint["recovery_last_reset_reason"]))
 }
 


### PR DESCRIPTION
## Scope
- Remove unused legacy wrapper bridge code:
  - `internal/app/marketdata/collector_wrapper.go`
  - `internal/app/marketdata/collector_wrapper_test.go`
- Add boundary guard test to fail if `main.go` or `routes.go` reintroduce direct legacy integrated autonomy runtime coupling from `internal/services`.

## Files
- `services/backend-api/internal/app/autonomy/boundary_guard_test.go`
- `services/backend-api/internal/app/marketdata/collector_wrapper.go` (deleted)
- `services/backend-api/internal/app/marketdata/collector_wrapper_test.go` (deleted)

## Validation
- `go test ./internal/app/autonomy/... -count=1`
- `go test ./internal/app/marketdata/... -count=1`

## Notes
- Stacked after PR13. This branch contains PR11 + PR12 + PR13 + PR14 commits because all PRs target `development` as requested.

## Summary by Sourcery

Modularize the autonomous trading runtime into the app/autonomy package, tighten recovery and liveness gating, and remove legacy integration and HTTP alias paths while updating diagnostics and clients.

New Features:
- Introduce a reusable autonomy recovery and liveness gate module with default configuration and evaluation helpers.
- Add an autonomy runtime wiring entrypoint to construct integrated quest handlers and register quest execution with the quest engine.
- Expose richer recovery diagnostics fields, including clean-cycle requirements and evaluation timestamps, to downstream status and doctor views.

Bug Fixes:
- Fix recovery micro-entry gating so entry reasons, unblock conditions, and clean-cycle counters are consistently updated and cleared when conditions change.
- Ensure forced liveness entry-attempt logic respects a configurable per-hour budget and idle thresholds under all checkpoint states.

Enhancements:
- Refine integrated quest handlers to separate quest execution from handler registration and to centralize recovery checkpoint application.
- Extend chat runtime diagnostics with current entry-gate reason fields and more granular recovery state, and adapt doctor and status reporting to use them.
- Align Telegram internal HTTP routes behind a single /internal/telegram namespace and update backend, CLI, scripts, tests, and TypeScript clients accordingly.
- Add tests to guard against reintroduction of legacy autonomy runtime wiring in main server entrypoints and to validate new recovery and liveness behavior.

Documentation:
- Document autonomous recovery and liveness tuning environment variables in the project README.

Tests:
- Expand backend and Telegram-service tests to cover new recovery diagnostics fields, entry-gate naming, autonomous doctor output, and removal of legacy Telegram paths.
- Add autonomy boundary guard tests to enforce the new runtime integration boundary from API and main server code.