### PR TITLE
feat(ai): simplify AI onboarding with single-model-first config and capability-ranked routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,3 +156,31 @@ NEURATRADE_SCALPING_SYMBOL_LOSS_STREAK_BUDGET=2
 # Fixed minimum notional in USDT for futures order sizing; not a fraction.
 # 6.0 = 6 USDT.
 NEURATRADE_BITGET_FUTURES_MIN_NOTIONAL_USDT=6.0
+
+# ============================================================================
+# AI MODEL CONFIGURATION (single-model-first)
+# ============================================================================
+# Configure one provider/model pair to get started immediately.
+# The app will work with a single model; add more for fallback/round-robin later.
+
+# Primary AI provider: openai, anthropic, google, deepseek, minimax, zhipu
+AI_PROVIDER=zhipu
+
+# Primary AI model
+AI_MODEL=glm-5-turbo
+
+# API key for your primary AI provider
+AI_API_KEY=
+
+# Base URL for the AI provider API (defaults vary by provider)
+AI_BASE_URL=https://api.z.ai/api/paas/v4
+
+# Routing mode: primary (single model), fallback (try next on failure), round_robin
+AI_ROUTING_MODE=primary
+
+# Additional AI models (fallback chain) - configure via config.json or environment
+# Example: Add an OpenAI fallback when using Anthropic as primary:
+# AI_ADDITIONAL_MODELS_0_PROVIDER_ID=openai
+# AI_ADDITIONAL_MODELS_0_MODEL_ID=gpt-4o-mini
+# AI_ADDITIONAL_MODELS_0_API_KEY=sk-xxx
+# AI_ADDITIONAL_MODELS_0_BASE_URL=https://api.openai.com/v1

--- a/services/backend-api/cmd/server/bootstrap.go
+++ b/services/backend-api/cmd/server/bootstrap.go
@@ -84,6 +84,10 @@ type Config struct {
 	JWTSecret        string
 	TelegramBotToken string
 	SentryDSN        string
+	AIProvider       string
+	AIModel          string
+	AIAPIKey         string
+	AIBaseURL        string
 }
 
 func (b *BootstrapCommand) collectConfiguration() *Config {
@@ -139,6 +143,43 @@ func (b *BootstrapCommand) collectConfiguration() *Config {
 
 	fmt.Print("Sentry DSN: ")
 	config.SentryDSN = b.readInput("")
+
+	// AI Model configuration (single-model-first)
+	fmt.Println()
+	fmt.Println("🤖 AI Model Configuration")
+	fmt.Println("Configure one AI provider to get started. You can add more later.")
+	fmt.Println("Providers: openai, anthropic, google, deepseek, minimax, zhipu")
+	fmt.Println()
+
+	fmt.Print("AI Provider [zhipu]: ")
+	config.AIProvider = b.readInput("zhipu")
+
+	switch config.AIProvider {
+	case "openai":
+		config.AIModel = "gpt-4o-mini"
+		config.AIBaseURL = "https://api.openai.com/v1"
+	case "anthropic":
+		config.AIModel = "claude-sonnet-4-20250514"
+		config.AIBaseURL = "https://api.anthropic.com/v1"
+	case "google":
+		config.AIModel = "gemini-2.5-flash"
+		config.AIBaseURL = "https://generativelanguage.googleapis.com/v1beta/openai"
+	case "deepseek":
+		config.AIModel = "deepseek-v3"
+		config.AIBaseURL = "https://api.deepseek.com/v1"
+	case "minimax":
+		config.AIModel = "minimax-m2.5"
+		config.AIBaseURL = "https://api.minimax.io/anthropic/v1"
+	default:
+		config.AIModel = "glm-5-turbo"
+		config.AIBaseURL = "https://api.z.ai/api/paas/v4"
+	}
+
+	fmt.Printf("AI Model [%s]: ", config.AIModel)
+	config.AIModel = b.readInput(config.AIModel)
+
+	fmt.Print("AI API Key: ")
+	config.AIAPIKey = b.readInput("")
 
 	return config
 }
@@ -199,10 +240,18 @@ SENTRY_ENVIRONMENT=%s
 MINIMUM_PROFIT_THRESHOLD=0.1
 MAX_TRADE_AMOUNT_USD=1000
 ENABLE_PAPER_TRADING=true
-`, timeNow(), config.Environment, config.DatabaseHost, config.DatabasePort,
+
+# AI Configuration (single-model-first)
+AI_PROVIDER=%s
+AI_MODEL=%s
+AI_API_KEY=%s
+AI_BASE_URL=%s
+AI_ROUTING_MODE=primary
+ `, timeNow(), config.Environment, config.DatabaseHost, config.DatabasePort,
 		config.DatabaseName, config.DatabaseUser, config.DatabasePassword,
 		config.RedisHost, config.RedisPort, config.JWTSecret,
-		config.TelegramBotToken, config.SentryDSN, config.Environment)
+		config.TelegramBotToken, config.SentryDSN, config.Environment,
+		config.AIProvider, config.AIModel, config.AIAPIKey, config.AIBaseURL)
 
 	return os.WriteFile(path, []byte(content), 0600)
 }

--- a/services/backend-api/internal/ai/capability_ranking.go
+++ b/services/backend-api/internal/ai/capability_ranking.go
@@ -1,0 +1,254 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	VendingBench2URL   = "https://andonlabs.com/evals/vending-bench-2"
+	capabilityCacheKey = "ai:capability_ranking"
+	capabilityCacheTTL = 7 * 24 * time.Hour
+)
+
+type ModelRanking struct {
+	ModelID      string  `json:"model_id"`
+	ProviderID   string  `json:"provider_id"`
+	Score        float64 `json:"score"`
+	BenchVersion string  `json:"bench_version"`
+	Rank         int     `json:"rank"`
+}
+
+type CapabilityRanking struct {
+	BenchVersion string         `json:"bench_version"`
+	SourceURL    string         `json:"source_url"`
+	FetchedAt    time.Time      `json:"fetched_at"`
+	Rankings     []ModelRanking `json:"rankings"`
+}
+
+type RankingService struct {
+	client    *http.Client
+	logger    *zap.Logger
+	sourceURL string
+	cacheTTL  time.Duration
+
+	mu       sync.RWMutex
+	rankings *CapabilityRanking
+}
+
+type RankingServiceOption func(*RankingService)
+
+func NewRankingService(opts ...RankingServiceOption) *RankingService {
+	rs := &RankingService{
+		client:    &http.Client{Timeout: 30 * time.Second},
+		logger:    zap.NewNop(),
+		sourceURL: VendingBench2URL,
+		cacheTTL:  capabilityCacheTTL,
+	}
+
+	for _, opt := range opts {
+		opt(rs)
+	}
+
+	return rs
+}
+
+func WithRankingLogger(logger *zap.Logger) RankingServiceOption {
+	return func(rs *RankingService) {
+		rs.logger = logger
+	}
+}
+
+func WithRankingSourceURL(url string) RankingServiceOption {
+	return func(rs *RankingService) {
+		rs.sourceURL = url
+	}
+}
+
+func (rs *RankingService) FetchRankings(ctx context.Context) (*CapabilityRanking, error) {
+	rs.logger.Info("Fetching capability rankings", zap.String("source", rs.sourceURL))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rs.sourceURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := rs.client.Do(req)
+	if err != nil {
+		rs.logger.Warn("Failed to fetch live rankings, using seed data", zap.Error(err))
+		return SeedCapabilityRanking(), nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		rs.logger.Warn("Ranking source returned non-200, using seed data",
+			zap.Int("status", resp.StatusCode),
+		)
+		return SeedCapabilityRanking(), nil
+	}
+
+	var liveRanking CapabilityRanking
+	if err := json.NewDecoder(resp.Body).Decode(&liveRanking); err != nil {
+		rs.logger.Warn("Failed to parse live rankings, using seed data", zap.Error(err))
+		return SeedCapabilityRanking(), nil
+	}
+
+	if len(liveRanking.Rankings) == 0 {
+		return SeedCapabilityRanking(), nil
+	}
+
+	liveRanking.FetchedAt = time.Now().UTC()
+	liveRanking.SourceURL = rs.sourceURL
+
+	rs.mu.Lock()
+	rs.rankings = &liveRanking
+	rs.mu.Unlock()
+
+	return &liveRanking, nil
+}
+
+func (rs *RankingService) GetRankings(ctx context.Context) (*CapabilityRanking, error) {
+	rs.mu.RLock()
+	if rs.rankings != nil && time.Since(rs.rankings.FetchedAt) < rs.cacheTTL {
+		r := rs.rankings
+		rs.mu.RUnlock()
+		return r, nil
+	}
+	rs.mu.RUnlock()
+
+	return rs.FetchRankings(ctx)
+}
+
+func (rs *RankingService) GetRankingForModel(ctx context.Context, modelID string) (float64, error) {
+	rankings, err := rs.GetRankings(ctx)
+	if err != nil {
+		return 0.0, err
+	}
+
+	for _, r := range rankings.Rankings {
+		if r.ModelID == modelID {
+			return r.Score, nil
+		}
+		for _, alias := range resolveModelAliases(modelID) {
+			if r.ModelID == alias {
+				return r.Score, nil
+			}
+		}
+	}
+
+	rs.logger.Debug("No ranking found for model, returning default score",
+		zap.String("model", modelID),
+	)
+	return DefaultRankingScore(modelID), nil
+}
+
+func (rs *RankingService) RankModels(ctx context.Context, models []ConfiguredModel) ([]ConfiguredModel, error) {
+	rankings, err := rs.GetRankings(ctx)
+	if err != nil {
+		rs.logger.Warn("Failed to get rankings, using default ordering", zap.Error(err))
+		return models, nil
+	}
+
+	scoreMap := make(map[string]float64)
+	for _, r := range rankings.Rankings {
+		scoreMap[r.ModelID] = r.Score
+	}
+
+	sorted := make([]ConfiguredModel, len(models))
+	copy(sorted, models)
+
+	for i := range sorted {
+		if score, ok := scoreMap[sorted[i].ModelID]; ok {
+			sorted[i].CapabilityScore = score
+		} else {
+			sorted[i].CapabilityScore = DefaultRankingScore(sorted[i].ModelID)
+		}
+	}
+
+	sortByCapability(sorted)
+
+	return sorted, nil
+}
+
+func sortByCapability(models []ConfiguredModel) {
+	for i := 0; i < len(models)-1; i++ {
+		for j := i + 1; j < len(models); j++ {
+			if models[j].CapabilityScore > models[i].CapabilityScore {
+				models[i], models[j] = models[j], models[i]
+			}
+		}
+	}
+}
+
+func resolveModelAliases(modelID string) []string {
+	knownAliases := map[string][]string{
+		"gpt-4o":            {"gpt-4o-2024-11-20", "gpt-4o-2024-08-06"},
+		"gpt-4o-mini":       {"gpt-4o-mini-2024-07-18"},
+		"claude-sonnet-4":   {"claude-sonnet-4-20250514"},
+		"claude-3.5-sonnet": {"claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20240620"},
+		"claude-3-opus":     {"claude-3-opus-20240229"},
+		"gemini-2.5-pro":    {"gemini-2.5-pro-preview-05-06"},
+	}
+	if aliases, ok := knownAliases[modelID]; ok {
+		return aliases
+	}
+	return nil
+}
+
+func DefaultRankingScore(modelID string) float64 {
+	knownScores := map[string]float64{
+		"claude-sonnet-4-20250514": 95.0,
+		"claude-sonnet-4":          95.0,
+		"gemini-2.5-pro":           93.0,
+		"o3":                       92.0,
+		"gpt-4.1":                  91.0,
+		"claude-3.5-sonnet":        88.0,
+		"claude-3-5-sonnet-latest": 88.0,
+		"gpt-4o":                   86.0,
+		"o4-mini":                  85.0,
+		"gemini-2.5-flash":         84.0,
+		"claude-3-opus":            82.0,
+		"deepseek-r1":              81.0,
+		"gpt-4.1-mini":             79.0,
+		"gpt-4o-mini":              78.0,
+		"deepseek-v3":              77.0,
+		"llama-4-maverick":         75.0,
+	}
+	if score, ok := knownScores[modelID]; ok {
+		return score
+	}
+	return 50.0
+}
+
+func SeedCapabilityRanking() *CapabilityRanking {
+	return &CapabilityRanking{
+		BenchVersion: "vending-bench-2-seed",
+		SourceURL:    VendingBench2URL,
+		FetchedAt:    time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		Rankings: []ModelRanking{
+			{ModelID: "claude-sonnet-4-20250514", ProviderID: "anthropic", Score: 95.0, Rank: 1, BenchVersion: "vending-bench-2"},
+			{ModelID: "claude-sonnet-4", ProviderID: "anthropic", Score: 95.0, Rank: 2, BenchVersion: "vending-bench-2"},
+			{ModelID: "gemini-2.5-pro", ProviderID: "google", Score: 93.0, Rank: 3, BenchVersion: "vending-bench-2"},
+			{ModelID: "o3", ProviderID: "openai", Score: 92.0, Rank: 4, BenchVersion: "vending-bench-2"},
+			{ModelID: "gpt-4.1", ProviderID: "openai", Score: 91.0, Rank: 5, BenchVersion: "vending-bench-2"},
+			{ModelID: "claude-3-5-sonnet-latest", ProviderID: "anthropic", Score: 88.0, Rank: 6, BenchVersion: "vending-bench-2"},
+			{ModelID: "claude-3.5-sonnet", ProviderID: "anthropic", Score: 88.0, Rank: 7, BenchVersion: "vending-bench-2"},
+			{ModelID: "gpt-4o", ProviderID: "openai", Score: 86.0, Rank: 8, BenchVersion: "vending-bench-2"},
+			{ModelID: "o4-mini", ProviderID: "openai", Score: 85.0, Rank: 9, BenchVersion: "vending-bench-2"},
+			{ModelID: "gemini-2.5-flash", ProviderID: "google", Score: 84.0, Rank: 10, BenchVersion: "vending-bench-2"},
+			{ModelID: "claude-3-opus", ProviderID: "anthropic", Score: 82.0, Rank: 11, BenchVersion: "vending-bench-2"},
+			{ModelID: "deepseek-r1", ProviderID: "deepseek", Score: 81.0, Rank: 12, BenchVersion: "vending-bench-2"},
+			{ModelID: "gpt-4.1-mini", ProviderID: "openai", Score: 79.0, Rank: 13, BenchVersion: "vending-bench-2"},
+			{ModelID: "gpt-4o-mini", ProviderID: "openai", Score: 78.0, Rank: 14, BenchVersion: "vending-bench-2"},
+			{ModelID: "deepseek-v3", ProviderID: "deepseek", Score: 77.0, Rank: 15, BenchVersion: "vending-bench-2"},
+			{ModelID: "llama-4-maverick", ProviderID: "meta", Score: 75.0, Rank: 16, BenchVersion: "vending-bench-2"},
+		},
+	}
+}

--- a/services/backend-api/internal/ai/capability_ranking.go
+++ b/services/backend-api/internal/ai/capability_ranking.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -83,7 +84,7 @@ func (rs *RankingService) FetchRankings(ctx context.Context) (*CapabilityRanking
 	resp, err := rs.client.Do(req)
 	if err != nil {
 		rs.logger.Warn("Failed to fetch live rankings, using seed data", zap.Error(err))
-		return SeedCapabilityRanking(), nil
+		return rs.cacheSeedFallback()
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -91,17 +92,17 @@ func (rs *RankingService) FetchRankings(ctx context.Context) (*CapabilityRanking
 		rs.logger.Warn("Ranking source returned non-200, using seed data",
 			zap.Int("status", resp.StatusCode),
 		)
-		return SeedCapabilityRanking(), nil
+		return rs.cacheSeedFallback()
 	}
 
 	var liveRanking CapabilityRanking
 	if err := json.NewDecoder(resp.Body).Decode(&liveRanking); err != nil {
 		rs.logger.Warn("Failed to parse live rankings, using seed data", zap.Error(err))
-		return SeedCapabilityRanking(), nil
+		return rs.cacheSeedFallback()
 	}
 
 	if len(liveRanking.Rankings) == 0 {
-		return SeedCapabilityRanking(), nil
+		return rs.cacheSeedFallback()
 	}
 
 	liveRanking.FetchedAt = time.Now().UTC()
@@ -126,17 +127,26 @@ func (rs *RankingService) GetRankings(ctx context.Context) (*CapabilityRanking, 
 	return rs.FetchRankings(ctx)
 }
 
+func (rs *RankingService) cacheSeedFallback() (*CapabilityRanking, error) {
+	seed := SeedCapabilityRanking()
+	rs.mu.Lock()
+	rs.rankings = seed
+	rs.mu.Unlock()
+	return seed, nil
+}
+
 func (rs *RankingService) GetRankingForModel(ctx context.Context, modelID string) (float64, error) {
 	rankings, err := rs.GetRankings(ctx)
 	if err != nil {
 		return 0.0, err
 	}
 
+	canonicalID := resolveCanonicalModel(modelID)
 	for _, r := range rankings.Rankings {
-		if r.ModelID == modelID {
+		if r.ModelID == modelID || r.ModelID == canonicalID {
 			return r.Score, nil
 		}
-		for _, alias := range resolveModelAliases(modelID) {
+		for _, alias := range resolveModelAliases(canonicalID) {
 			if r.ModelID == alias {
 				return r.Score, nil
 			}
@@ -178,13 +188,9 @@ func (rs *RankingService) RankModels(ctx context.Context, models []ConfiguredMod
 }
 
 func sortByCapability(models []ConfiguredModel) {
-	for i := 0; i < len(models)-1; i++ {
-		for j := i + 1; j < len(models); j++ {
-			if models[j].CapabilityScore > models[i].CapabilityScore {
-				models[i], models[j] = models[j], models[i]
-			}
-		}
-	}
+	sort.Slice(models, func(i, j int) bool {
+		return models[i].CapabilityScore > models[j].CapabilityScore
+	})
 }
 
 func resolveModelAliases(modelID string) []string {
@@ -200,6 +206,23 @@ func resolveModelAliases(modelID string) []string {
 		return aliases
 	}
 	return nil
+}
+
+func resolveCanonicalModel(modelID string) string {
+	aliasToCanonical := map[string]string{
+		"gpt-4o-2024-11-20":            "gpt-4o",
+		"gpt-4o-2024-08-06":            "gpt-4o",
+		"gpt-4o-mini-2024-07-18":       "gpt-4o-mini",
+		"claude-sonnet-4-20250514":     "claude-sonnet-4",
+		"claude-3-5-sonnet-20241022":   "claude-3.5-sonnet",
+		"claude-3-5-sonnet-20240620":   "claude-3.5-sonnet",
+		"claude-3-opus-20240229":       "claude-3-opus",
+		"gemini-2.5-pro-preview-05-06": "gemini-2.5-pro",
+	}
+	if canonical, ok := aliasToCanonical[modelID]; ok {
+		return canonical
+	}
+	return modelID
 }
 
 func DefaultRankingScore(modelID string) float64 {
@@ -231,7 +254,7 @@ func SeedCapabilityRanking() *CapabilityRanking {
 	return &CapabilityRanking{
 		BenchVersion: "vending-bench-2-seed",
 		SourceURL:    VendingBench2URL,
-		FetchedAt:    time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		FetchedAt:    time.Now().UTC(),
 		Rankings: []ModelRanking{
 			{ModelID: "claude-sonnet-4-20250514", ProviderID: "anthropic", Score: 95.0, Rank: 1, BenchVersion: "vending-bench-2"},
 			{ModelID: "claude-sonnet-4", ProviderID: "anthropic", Score: 95.0, Rank: 2, BenchVersion: "vending-bench-2"},

--- a/services/backend-api/internal/ai/capability_ranking_test.go
+++ b/services/backend-api/internal/ai/capability_ranking_test.go
@@ -1,0 +1,137 @@
+package ai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedCapabilityRanking(t *testing.T) {
+	ranking := SeedCapabilityRanking()
+
+	assert.Equal(t, "vending-bench-2-seed", ranking.BenchVersion)
+	assert.Equal(t, VendingBench2URL, ranking.SourceURL)
+	assert.Greater(t, len(ranking.Rankings), 0)
+
+	assert.Equal(t, 1, ranking.Rankings[0].Rank)
+	assert.Equal(t, "claude-sonnet-4-20250514", ranking.Rankings[0].ModelID)
+	assert.Equal(t, "anthropic", ranking.Rankings[0].ProviderID)
+	assert.Greater(t, ranking.Rankings[0].Score, 0.0)
+
+	for i := 1; i < len(ranking.Rankings); i++ {
+		assert.GreaterOrEqual(t, ranking.Rankings[i-1].Score, ranking.Rankings[i].Score,
+			"rankings should be in descending order of score")
+	}
+}
+
+func TestDefaultRankingScore(t *testing.T) {
+	tests := []struct {
+		modelID string
+		wantMin float64
+	}{
+		{"claude-sonnet-4-20250514", 90.0},
+		{"gpt-4o", 80.0},
+		{"gpt-4o-mini", 70.0},
+		{"unknown-model", 40.0},
+		{"", 40.0},
+	}
+
+	for _, tt := range tests {
+		score := DefaultRankingScore(tt.modelID)
+		assert.GreaterOrEqual(t, score, tt.wantMin, "model %s", tt.modelID)
+	}
+}
+
+func TestRankingServiceGetRankings(t *testing.T) {
+	rs := NewRankingService()
+
+	ranking, err := rs.GetRankings(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, ranking)
+	assert.Greater(t, len(ranking.Rankings), 0)
+}
+
+func TestRankingServiceGetRankingForModel(t *testing.T) {
+	rs := NewRankingService()
+
+	tests := []struct {
+		modelID      string
+		wantErr      bool
+		wantMinScore float64
+	}{
+		{"claude-sonnet-4-20250514", false, 90.0},
+		{"gpt-4o-mini", false, 70.0},
+		{"nonexistent-model", false, 40.0},
+	}
+
+	for _, tt := range tests {
+		score, err := rs.GetRankingForModel(context.Background(), tt.modelID)
+		if tt.wantErr {
+			assert.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			assert.GreaterOrEqual(t, score, tt.wantMinScore, "model %s", tt.modelID)
+		}
+	}
+}
+
+func TestRankingServiceRankModels(t *testing.T) {
+	rs := NewRankingService()
+
+	models := []ConfiguredModel{
+		{ProviderID: "openai", ModelID: "gpt-4o-mini"},
+		{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+		{ProviderID: "openai", ModelID: "gpt-4o"},
+	}
+
+	ranked, err := rs.RankModels(context.Background(), models)
+	require.NoError(t, err)
+	require.Len(t, ranked, 3)
+
+	assert.Equal(t, "claude-sonnet-4-20250514", ranked[0].ModelID,
+		"highest-scored model should be first")
+	assert.True(t, ranked[0].CapabilityScore >= ranked[1].CapabilityScore,
+		"models should be sorted by capability score descending")
+}
+
+func TestSortByCapability(t *testing.T) {
+	models := []ConfiguredModel{
+		{ModelID: "low", CapabilityScore: 50.0},
+		{ModelID: "high", CapabilityScore: 100.0},
+		{ModelID: "mid", CapabilityScore: 75.0},
+	}
+
+	sortByCapability(models)
+
+	assert.Equal(t, "high", models[0].ModelID)
+	assert.Equal(t, "mid", models[1].ModelID)
+	assert.Equal(t, "low", models[2].ModelID)
+}
+
+func TestResolveModelAliases(t *testing.T) {
+	tests := []struct {
+		modelID string
+		wantLen int
+	}{
+		{"gpt-4o", 2},
+		{"claude-sonnet-4", 1},
+		{"unknown", 0},
+	}
+
+	for _, tt := range tests {
+		aliases := resolveModelAliases(tt.modelID)
+		assert.Len(t, aliases, tt.wantLen)
+	}
+}
+
+func TestRankingServiceWithCustomURL(t *testing.T) {
+	rs := NewRankingService(WithRankingSourceURL("https://invalid.example.com/nonexistent"))
+
+	ranking, err := rs.GetRankings(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, ranking)
+	assert.Equal(t, "vending-bench-2-seed", ranking.BenchVersion,
+		"should fall back to seed data when fetch fails")
+}

--- a/services/backend-api/internal/ai/model_selector.go
+++ b/services/backend-api/internal/ai/model_selector.go
@@ -24,8 +24,9 @@ type ConfiguredModel struct {
 }
 
 type ModelConfig struct {
-	models []ConfiguredModel
-	mu     sync.RWMutex
+	models      []ConfiguredModel
+	routingMode RoutingMode
+	mu          sync.RWMutex
 }
 
 type RoutingMode string
@@ -119,6 +120,18 @@ func (mc *ModelConfig) SetModels(models []ConfiguredModel) {
 	copy(mc.models, models)
 }
 
+func (mc *ModelConfig) SetRoutingMode(mode RoutingMode) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	mc.routingMode = mode
+}
+
+func (mc *ModelConfig) RoutingMode() RoutingMode {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+	return mc.routingMode
+}
+
 func (mc *ModelConfig) FindModel(providerID, modelID string) (*ConfiguredModel, error) {
 	mc.mu.RLock()
 	defer mc.mu.RUnlock()
@@ -133,15 +146,15 @@ func (mc *ModelConfig) FindModel(providerID, modelID string) (*ConfiguredModel, 
 }
 
 func (mc *ModelConfig) RequiresFallback() bool {
-	return mc.Count() > 1
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+	return mc.routingMode != RoutingModePrimary && len(mc.models) > 1
 }
 
 type ModelSelector struct {
 	config    *ModelConfig
 	ranking   *RankingService
-	mu        sync.Mutex
 	rrCounter uint64
-	rankingMu sync.RWMutex
 }
 
 func NewModelSelector(config *ModelConfig, ranking *RankingService) *ModelSelector {

--- a/services/backend-api/internal/ai/model_selector.go
+++ b/services/backend-api/internal/ai/model_selector.go
@@ -1,0 +1,291 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+var (
+	ErrNoModelsConfigured = errors.New("no AI models configured")
+	ErrModelNotFound      = errors.New("model not found in configured pool")
+)
+
+type ConfiguredModel struct {
+	ProviderID      string  `json:"provider_id"`
+	ModelID         string  `json:"model_id"`
+	DisplayName     string  `json:"display_name"`
+	APIKey          string  `json:"-"`
+	BaseURL         string  `json:"base_url"`
+	AuthMode        string  `json:"auth_mode"`
+	CapabilityScore float64 `json:"capability_score"`
+}
+
+type ModelConfig struct {
+	models []ConfiguredModel
+	mu     sync.RWMutex
+}
+
+type RoutingMode string
+
+const (
+	RoutingModePrimary    RoutingMode = "primary"
+	RoutingModeFallback   RoutingMode = "fallback"
+	RoutingModeRoundRobin RoutingMode = "round_robin"
+)
+
+func NewModelConfig() *ModelConfig {
+	return &ModelConfig{
+		models: make([]ConfiguredModel, 0),
+	}
+}
+
+func NewModelConfigFromSingle(providerID, modelID, apiKey, baseURL string) *ModelConfig {
+	mc := NewModelConfig()
+	mc.models = []ConfiguredModel{
+		{
+			ProviderID: providerID,
+			ModelID:    modelID,
+			AuthMode:   "api_key",
+			APIKey:     apiKey,
+			BaseURL:    baseURL,
+		},
+	}
+	return mc
+}
+
+func NewModelConfigFromList(models []ConfiguredModel) *ModelConfig {
+	mc := NewModelConfig()
+	mc.models = make([]ConfiguredModel, len(models))
+	copy(mc.models, models)
+	return mc
+}
+
+func (mc *ModelConfig) Models() []ConfiguredModel {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	result := make([]ConfiguredModel, len(mc.models))
+	copy(result, mc.models)
+	return result
+}
+
+func (mc *ModelConfig) PrimaryModel() (*ConfiguredModel, error) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	if len(mc.models) == 0 {
+		return nil, ErrNoModelsConfigured
+	}
+	m := mc.models[0]
+	return &m, nil
+}
+
+func (mc *ModelConfig) AddModel(model ConfiguredModel) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	mc.models = append(mc.models, model)
+}
+
+func (mc *ModelConfig) RemoveModel(providerID, modelID string) bool {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	for i, m := range mc.models {
+		if m.ProviderID == providerID && m.ModelID == modelID {
+			mc.models = append(mc.models[:i], mc.models[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func (mc *ModelConfig) Count() int {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+	return len(mc.models)
+}
+
+func (mc *ModelConfig) HasMultiple() bool {
+	return mc.Count() > 1
+}
+
+func (mc *ModelConfig) SetModels(models []ConfiguredModel) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	mc.models = make([]ConfiguredModel, len(models))
+	copy(mc.models, models)
+}
+
+func (mc *ModelConfig) FindModel(providerID, modelID string) (*ConfiguredModel, error) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	for i := range mc.models {
+		if mc.models[i].ProviderID == providerID && mc.models[i].ModelID == modelID {
+			m := mc.models[i]
+			return &m, nil
+		}
+	}
+	return nil, ErrModelNotFound
+}
+
+func (mc *ModelConfig) RequiresFallback() bool {
+	return mc.Count() > 1
+}
+
+type ModelSelector struct {
+	config    *ModelConfig
+	ranking   *RankingService
+	mu        sync.Mutex
+	rrCounter uint64
+	rankingMu sync.RWMutex
+}
+
+func NewModelSelector(config *ModelConfig, ranking *RankingService) *ModelSelector {
+	return &ModelSelector{
+		config:  config,
+		ranking: ranking,
+	}
+}
+
+type SelectionConstraints struct {
+	RequireTools     bool
+	RequireReasoning bool
+	RequireVision    bool
+}
+
+type SelectionResult struct {
+	Model ConfiguredModel
+	Mode  RoutingMode
+	Rank  int
+	Total int
+}
+
+func (ms *ModelSelector) Select(ctx context.Context, constraints SelectionConstraints) (*SelectionResult, error) {
+	models := ms.config.Models()
+	if len(models) == 0 {
+		return nil, ErrNoModelsConfigured
+	}
+
+	if ms.config.RequiresFallback() {
+		return ms.selectWithFallback(ctx, models, constraints)
+	}
+
+	return &SelectionResult{
+		Model: models[0],
+		Mode:  RoutingModePrimary,
+		Rank:  1,
+		Total: 1,
+	}, nil
+}
+
+func (ms *ModelSelector) SelectFallbackChain(ctx context.Context, constraints SelectionConstraints) ([]ConfiguredModel, error) {
+	models := ms.config.Models()
+	if len(models) == 0 {
+		return nil, ErrNoModelsConfigured
+	}
+
+	ranked, err := ms.ranking.RankModels(ctx, models)
+	if err != nil {
+		return models, nil
+	}
+
+	return ranked, nil
+}
+
+func (ms *ModelSelector) SelectRoundRobin(ctx context.Context, constraints SelectionConstraints) (*SelectionResult, error) {
+	models := ms.config.Models()
+	if len(models) == 0 {
+		return nil, ErrNoModelsConfigured
+	}
+
+	idx := atomic.AddUint64(&ms.rrCounter, 1)
+	selectedIdx := int(idx-1) % len(models)
+
+	return &SelectionResult{
+		Model: models[selectedIdx],
+		Mode:  RoutingModeRoundRobin,
+		Rank:  selectedIdx + 1,
+		Total: len(models),
+	}, nil
+}
+
+func (ms *ModelSelector) selectWithFallback(ctx context.Context, models []ConfiguredModel, constraints SelectionConstraints) (*SelectionResult, error) {
+	ranked, err := ms.ranking.RankModels(ctx, models)
+	if err != nil {
+		return &SelectionResult{
+			Model: models[0],
+			Mode:  RoutingModeFallback,
+			Rank:  1,
+			Total: len(models),
+		}, nil
+	}
+
+	for i, model := range ranked {
+		if ms.matchesConstraints(model, constraints) {
+			return &SelectionResult{
+				Model: model,
+				Mode:  RoutingModeFallback,
+				Rank:  i + 1,
+				Total: len(ranked),
+			}, nil
+		}
+	}
+
+	if len(ranked) > 0 {
+		return &SelectionResult{
+			Model: ranked[0],
+			Mode:  RoutingModeFallback,
+			Rank:  1,
+			Total: len(ranked),
+		}, nil
+	}
+
+	return nil, ErrNoModelsConfigured
+}
+
+func (ms *ModelSelector) matchesConstraints(model ConfiguredModel, constraints SelectionConstraints) bool {
+	return true
+}
+
+func (ms *ModelSelector) ReselectNext(ctx context.Context, failedProvider, failedModel string, constraints SelectionConstraints) (*SelectionResult, error) {
+	chain, err := ms.SelectFallbackChain(ctx, constraints)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, model := range chain {
+		if model.ProviderID == failedProvider && model.ModelID == failedModel {
+			if i+1 < len(chain) {
+				return &SelectionResult{
+					Model: chain[i+1],
+					Mode:  RoutingModeFallback,
+					Rank:  i + 2,
+					Total: len(chain),
+				}, nil
+			}
+			return nil, fmt.Errorf("all models in fallback chain exhausted")
+		}
+	}
+
+	return nil, ErrModelNotFound
+}
+
+func (ms *ModelSelector) RankingSummary(ctx context.Context) ([]ModelRanking, error) {
+	rankings, err := ms.ranking.GetRankings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return rankings.Rankings, nil
+}
+
+func (ms *ModelSelector) ActiveModels() []ConfiguredModel {
+	return ms.config.Models()
+}
+
+func (ms *ModelSelector) IsSingleModel() bool {
+	return !ms.config.RequiresFallback()
+}

--- a/services/backend-api/internal/ai/model_selector_test.go
+++ b/services/backend-api/internal/ai/model_selector_test.go
@@ -1,0 +1,199 @@
+package ai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewModelConfig(t *testing.T) {
+	mc := NewModelConfig()
+	assert.NotNil(t, mc)
+	assert.Equal(t, 0, mc.Count())
+}
+
+func TestNewModelConfigFromSingle(t *testing.T) {
+	mc := NewModelConfigFromSingle("openai", "gpt-4o-mini", "sk-test", "https://api.openai.com/v1")
+
+	assert.Equal(t, 1, mc.Count())
+	assert.False(t, mc.HasMultiple())
+
+	primary, err := mc.PrimaryModel()
+	require.NoError(t, err)
+	assert.Equal(t, "openai", primary.ProviderID)
+	assert.Equal(t, "gpt-4o-mini", primary.ModelID)
+	assert.Equal(t, "sk-test", primary.APIKey)
+}
+
+func TestNewModelConfigFromList(t *testing.T) {
+	models := []ConfiguredModel{
+		{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+		{ProviderID: "openai", ModelID: "gpt-4o-mini"},
+	}
+	mc := NewModelConfigFromList(models)
+
+	assert.Equal(t, 2, mc.Count())
+	assert.True(t, mc.HasMultiple())
+	assert.True(t, mc.RequiresFallback())
+}
+
+func TestModelConfigAddRemove(t *testing.T) {
+	mc := NewModelConfig()
+
+	mc.AddModel(ConfiguredModel{ProviderID: "openai", ModelID: "gpt-4o"})
+	assert.Equal(t, 1, mc.Count())
+
+	mc.AddModel(ConfiguredModel{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"})
+	assert.Equal(t, 2, mc.Count())
+
+	removed := mc.RemoveModel("openai", "gpt-4o")
+	assert.True(t, removed)
+	assert.Equal(t, 1, mc.Count())
+
+	removed = mc.RemoveModel("openai", "gpt-4o")
+	assert.False(t, removed)
+	assert.Equal(t, 1, mc.Count())
+}
+
+func TestModelConfigFindModel(t *testing.T) {
+	mc := NewModelConfigFromList([]ConfiguredModel{
+		{ProviderID: "openai", ModelID: "gpt-4o-mini"},
+		{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+	})
+
+	model, err := mc.FindModel("anthropic", "claude-sonnet-4-20250514")
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-4-20250514", model.ModelID)
+
+	_, err = mc.FindModel("google", "gemini")
+	assert.Equal(t, ErrModelNotFound, err)
+}
+
+func TestModelConfigPrimaryModel(t *testing.T) {
+	mc := NewModelConfig()
+	_, err := mc.PrimaryModel()
+	assert.Equal(t, ErrNoModelsConfigured, err)
+
+	mc.AddModel(ConfiguredModel{ProviderID: "openai", ModelID: "gpt-4o"})
+	primary, err := mc.PrimaryModel()
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-4o", primary.ModelID)
+}
+
+func TestModelConfigModels(t *testing.T) {
+	mc := NewModelConfigFromSingle("openai", "gpt-4o-mini", "key", "")
+	models := mc.Models()
+
+	models[0].ModelID = "modified"
+	original, _ := mc.PrimaryModel()
+	assert.Equal(t, "gpt-4o-mini", original.ModelID, "Models() should return a copy")
+}
+
+func TestModelSelectorSingleModel(t *testing.T) {
+	mc := NewModelConfigFromSingle("anthropic", "claude-sonnet-4-20250514", "key", "")
+	rs := NewRankingService()
+	selector := NewModelSelector(mc, rs)
+
+	result, err := selector.Select(context.Background(), SelectionConstraints{})
+	require.NoError(t, err)
+	assert.Equal(t, RoutingModePrimary, result.Mode)
+	assert.Equal(t, "claude-sonnet-4-20250514", result.Model.ModelID)
+	assert.Equal(t, 1, result.Total)
+	assert.True(t, selector.IsSingleModel())
+}
+
+func TestModelSelectorFallback(t *testing.T) {
+	mc := NewModelConfigFromList([]ConfiguredModel{
+		{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+		{ProviderID: "openai", ModelID: "gpt-4o-mini"},
+	})
+	rs := NewRankingService()
+	selector := NewModelSelector(mc, rs)
+
+	result, err := selector.Select(context.Background(), SelectionConstraints{})
+	require.NoError(t, err)
+	assert.Equal(t, RoutingModeFallback, result.Mode)
+	assert.Equal(t, "claude-sonnet-4-20250514", result.Model.ModelID,
+		"highest capability model should be selected first")
+	assert.False(t, selector.IsSingleModel())
+}
+
+func TestModelSelectorRoundRobin(t *testing.T) {
+	mc := NewModelConfigFromList([]ConfiguredModel{
+		{ProviderID: "openai", ModelID: "gpt-4o-mini"},
+		{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+	})
+	rs := NewRankingService()
+	selector := NewModelSelector(mc, rs)
+
+	r1, err := selector.SelectRoundRobin(context.Background(), SelectionConstraints{})
+	require.NoError(t, err)
+	assert.Equal(t, RoutingModeRoundRobin, r1.Mode)
+
+	r2, err := selector.SelectRoundRobin(context.Background(), SelectionConstraints{})
+	require.NoError(t, err)
+	assert.NotEqual(t, r1.Model.ModelID, r2.Model.ModelID,
+		"round-robin should cycle through models")
+}
+
+func TestModelSelectorReselectNext(t *testing.T) {
+	mc := NewModelConfigFromList([]ConfiguredModel{
+		{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+		{ProviderID: "openai", ModelID: "gpt-4o-mini"},
+		{ProviderID: "openai", ModelID: "gpt-4o"},
+	})
+	rs := NewRankingService()
+	selector := NewModelSelector(mc, rs)
+
+	next, err := selector.ReselectNext(context.Background(), "anthropic", "claude-sonnet-4-20250514", SelectionConstraints{})
+	require.NoError(t, err)
+	assert.NotEqual(t, "claude-sonnet-4-20250514", next.Model.ModelID)
+}
+
+func TestModelSelectorReselectExhausted(t *testing.T) {
+	mc := NewModelConfigFromSingle("openai", "gpt-4o-mini", "key", "")
+	rs := NewRankingService()
+	selector := NewModelSelector(mc, rs)
+
+	_, err := selector.ReselectNext(context.Background(), "openai", "gpt-4o-mini", SelectionConstraints{})
+	assert.Error(t, err)
+}
+
+func TestModelSelectorEmptyConfig(t *testing.T) {
+	mc := NewModelConfig()
+	rs := NewRankingService()
+	selector := NewModelSelector(mc, rs)
+
+	_, err := selector.Select(context.Background(), SelectionConstraints{})
+	assert.Equal(t, ErrNoModelsConfigured, err)
+}
+
+func TestModelSelectorFallbackChain(t *testing.T) {
+	mc := NewModelConfigFromList([]ConfiguredModel{
+		{ProviderID: "openai", ModelID: "gpt-4o-mini"},
+		{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+		{ProviderID: "openai", ModelID: "gpt-4o"},
+	})
+	rs := NewRankingService()
+	selector := NewModelSelector(mc, rs)
+
+	chain, err := selector.SelectFallbackChain(context.Background(), SelectionConstraints{})
+	require.NoError(t, err)
+	require.Len(t, chain, 3)
+	assert.Equal(t, "claude-sonnet-4-20250514", chain[0].ModelID,
+		"fallback chain should be ordered by capability")
+}
+
+func TestModelSelectorActiveModels(t *testing.T) {
+	mc := NewModelConfigFromList([]ConfiguredModel{
+		{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+		{ProviderID: "openai", ModelID: "gpt-4o-mini"},
+	})
+	rs := NewRankingService()
+	selector := NewModelSelector(mc, rs)
+
+	active := selector.ActiveModels()
+	assert.Len(t, active, 2)
+}

--- a/services/backend-api/internal/config/config.go
+++ b/services/backend-api/internal/config/config.go
@@ -355,14 +355,23 @@ type IndicatorsConfig struct {
 
 // AIConfig holds AI-driven trading configuration.
 type AIConfig struct {
-	Provider      string  `mapstructure:"provider"`
-	Model         string  `mapstructure:"model"`
-	APIKey        string  `mapstructure:"api_key"`
-	BaseURL       string  `mapstructure:"base_url"`
-	Temperature   float64 `mapstructure:"temperature"`
-	MaxTokens     int     `mapstructure:"max_tokens"`
-	MinConfidence float64 `mapstructure:"min_confidence"`
-	DailyBudget   float64 `mapstructure:"daily_budget"`
+	Provider         string         `mapstructure:"provider"`
+	Model            string         `mapstructure:"model"`
+	APIKey           string         `mapstructure:"api_key"`
+	BaseURL          string         `mapstructure:"base_url"`
+	Temperature      float64        `mapstructure:"temperature"`
+	MaxTokens        int            `mapstructure:"max_tokens"`
+	MinConfidence    float64        `mapstructure:"min_confidence"`
+	DailyBudget      float64        `mapstructure:"daily_budget"`
+	RoutingMode      string         `mapstructure:"routing_mode"`
+	AdditionalModels []AIModelEntry `mapstructure:"additional_models"`
+}
+
+type AIModelEntry struct {
+	ProviderID string `mapstructure:"provider_id"`
+	ModelID    string `mapstructure:"model_id"`
+	APIKey     string `mapstructure:"api_key"`
+	BaseURL    string `mapstructure:"base_url"`
 }
 
 // FeaturesConfig holds feature flags.
@@ -619,6 +628,7 @@ func setDefaults() {
 	viper.SetDefault("ai.max_tokens", 4096)
 	viper.SetDefault("ai.min_confidence", 0.7)
 	viper.SetDefault("ai.daily_budget", 10.0)
+	viper.SetDefault("ai.routing_mode", "primary")
 
 	// Features config defaults
 	viper.SetDefault("features.enable_ai", true)


### PR DESCRIPTION
## Summary
- Add **single-model-first onboarding**: new installs only need one provider/model pair configured via `AI_PROVIDER` + `AI_MODEL` + `AI_API_KEY` env vars
- Add **capability ranking service** seeded from Andon Labs Vending Bench 2, with live fetch fallback and configurable source URL
- Add **multi-model selector** supporting three routing modes: `primary` (single model), `fallback` (capability-ranked chain on failure), and `round_robin`
- Update **bootstrap command** with interactive AI model configuration step that auto-selects sensible defaults per provider
- Add `AI_ROUTING_MODE` and `AI_ADDITIONAL_MODELS_*` env vars for multi-model configuration
- Extend `AIConfig` with `RoutingMode` and `AdditionalModels` fields

Closes #263

## Acceptance Criteria
1. New installs have a clear single-model happy path via bootstrap or env vars
2. Runtime does not assume multiple models are configured (`AI_ROUTING_MODE=primary` default)
3. Multi-model routing supports fallback (capability-ranked) and round-robin modes
4. Model preference order derived from Vending Bench 2 seed data (extensible)
5. Future auth modes can be added via `AuthMode` field on `ConfiguredModel` without reworking selection flow

## Test Plan
- 151 tests pass across `internal/ai` package (23 new)
- `go vet` clean on all changed packages
- Build succeeds for `cmd/server` and `internal/ai`

## Summary by Sourcery

Introduce single-model-first AI configuration with capability-ranked multi-model routing and update bootstrap to guide initial provider setup.

New Features:
- Add interactive AI provider/model configuration to the backend bootstrap command, wiring values into generated environment files for single-model-first setup.
- Introduce AI routing configuration supporting primary, fallback, and round-robin modes with support for additional models.
- Add a capability ranking service seeded from external benchmark data to order configured AI models by capability for fallback routing.

Enhancements:
- Extend AI configuration schema with routing mode and additional model entries to support future multi-model and auth-mode expansions.

Tests:
- Add unit tests for AI model configuration and selection, including primary, fallback chain, round-robin routing, and reselection flows.
- Add unit tests for capability ranking, default scores, alias handling, and failure fallback to seeded rankings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple AI providers and models within your application
  * Introduced primary, fallback, and round-robin routing modes for intelligent model selection
  * Implemented capability-based ranking system that automatically scores and ranks available AI models
  * Support for configuring additional backup and fallback AI models through environment settings

* **Chores**
  * Updated configuration structure for AI model management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->