### PR TITLE
feat: stabilize scalping confidence reporting for infrastructure holds

### DIFF
--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -654,6 +654,8 @@ type AITradingDecision struct {
 	PreTradeRegime                  string                              `json:"-"`
 	PreTradeExpectancy              float64                             `json:"-"`
 	PreTradeExpectancySampleSize    int                                 `json:"-"`
+	OriginalConfidence              float64                             `json:"-"`
+	OriginalConfidenceKnown         bool                                `json:"-"`
 }
 
 type TradingPortfolio struct {
@@ -732,6 +734,23 @@ const (
 	reasonCategoryDeterministicFallback = "deterministic_fallback"
 	reasonCategoryStrategyHold          = "strategy_hold"
 )
+
+const (
+	runtimeStatusHealthy          = "healthy"
+	runtimeStatusStateDrift       = "state_drift_active"
+	runtimeStatusReconcileBlocked = "reconcile_in_progress"
+	runtimeStatusCircuitOpen      = "circuit_open"
+	runtimeStatusLLMDegraded      = "llm_degraded"
+)
+
+func isInfrastructureRuntimeStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case runtimeStatusStateDrift, runtimeStatusReconcileBlocked, runtimeStatusCircuitOpen:
+		return true
+	default:
+		return false
+	}
+}
 
 type AIScalpingRuntimeState struct {
 	LastProvider           string    `json:"last_provider"`

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -1168,6 +1168,8 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 	if decision.Action == "hold" {
 		decision.ReasonCategory = normalizeHoldReasonCategory(decision.ReasonCategory, decision.Reasoning)
 		if isRuntimeReasonCategory(decision.ReasonCategory) {
+			decision.OriginalConfidence = decision.Confidence
+			decision.OriginalConfidenceKnown = true
 			decision.ConfidenceKnown = false
 			decision.Confidence = 0
 		} else if !decision.ConfidenceKnown {
@@ -1222,6 +1224,8 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 	gate := s.evaluatePreTradeGate(ctx, decision, signals)
 	if !gate.Allowed {
 		attemptedAction := decision.Action
+		decision.OriginalConfidence = decision.Confidence
+		decision.OriginalConfidenceKnown = true
 		decision.Action = "hold"
 		decision.Confidence = 0
 		decision.OrderID = ""
@@ -1270,6 +1274,8 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 	if decision.Action == "hold" {
 		decision.ReasonCategory = normalizeHoldReasonCategory(decision.ReasonCategory, decision.Reasoning)
 		if isRuntimeReasonCategory(decision.ReasonCategory) {
+			decision.OriginalConfidence = decision.Confidence
+			decision.OriginalConfidenceKnown = true
 			decision.ConfidenceKnown = false
 			decision.Confidence = 0
 		} else {
@@ -1408,6 +1414,8 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 		}
 		if executionErr != nil {
 			if shouldDowngradeExecutionErrorToHold(executionErr) {
+				decision.OriginalConfidence = decision.Confidence
+				decision.OriginalConfidenceKnown = true
 				decision.Action = "hold"
 				decision.Confidence = 0
 				decision.OrderID = ""
@@ -1836,6 +1844,8 @@ func (s *AIScalpingService) getAIDecision(ctx context.Context, signals []aiMarke
 	if decision.Action == "hold" {
 		decision.ReasonCategory = normalizeHoldReasonCategory(decision.ReasonCategory, decision.Reasoning)
 		if isRuntimeReasonCategory(decision.ReasonCategory) {
+			decision.OriginalConfidence = decision.Confidence
+			decision.OriginalConfidenceKnown = true
 			decision.ConfidenceKnown = false
 			decision.Confidence = 0
 		}

--- a/services/backend-api/internal/services/notification_ops_alerts.go
+++ b/services/backend-api/internal/services/notification_ops_alerts.go
@@ -352,12 +352,12 @@ func buildAIReasoningMessageLines(reasoning AIReasoningNotification, category st
 	}
 	if reasoning.RuntimeStatus != "" {
 		var statusEmoji string
-		switch {
-		case reasoning.RuntimeStatus == runtimeStatusStateDrift || reasoning.RuntimeStatus == runtimeStatusReconcileBlocked:
+		switch reasoning.RuntimeStatus {
+		case runtimeStatusStateDrift, runtimeStatusReconcileBlocked:
 			statusEmoji = "🔄"
-		case reasoning.RuntimeStatus == runtimeStatusCircuitOpen:
+		case runtimeStatusCircuitOpen:
 			statusEmoji = "⚠️"
-		case reasoning.RuntimeStatus == runtimeStatusLLMDegraded:
+		case runtimeStatusLLMDegraded:
 			statusEmoji = "🛑"
 		default:
 			statusEmoji = "ℹ️"

--- a/services/backend-api/internal/services/notification_ops_alerts.go
+++ b/services/backend-api/internal/services/notification_ops_alerts.go
@@ -255,15 +255,21 @@ func (ns *NotificationService) formatAIReasoningMessage(reasoning AIReasoningNot
 	if category == "" {
 		category = strings.TrimSpace(reasoning.HoldCategory)
 	}
-	if !confidenceKnown && (category == "" || strings.EqualFold(category, "strategy_hold")) {
-		evidence := strings.TrimSpace(reasoning.Summary + " " + strings.Join(reasoning.Reasons, " "))
-		category = classifyAIRuntimeReason(evidence, "execution_unavailable")
-	}
-	if isRuntimeReasonCategory(category) {
-		confidenceKnown = false
-	}
-	if !confidenceKnown && strings.EqualFold(category, "strategy_hold") {
-		category = "execution_unavailable"
+	if reasoning.RuntimeStatus != "" && isInfrastructureRuntimeStatus(reasoning.RuntimeStatus) {
+		if category == "" {
+			category = "execution_unavailable"
+		}
+	} else {
+		if !confidenceKnown && (category == "" || strings.EqualFold(category, "strategy_hold")) {
+			evidence := strings.TrimSpace(reasoning.Summary + " " + strings.Join(reasoning.Reasons, " "))
+			category = classifyAIRuntimeReason(evidence, "execution_unavailable")
+		}
+		if isRuntimeReasonCategory(category) {
+			confidenceKnown = false
+		}
+		if !confidenceKnown && strings.EqualFold(category, "strategy_hold") {
+			category = "execution_unavailable"
+		}
 	}
 
 	reasonsToShow := len(reasoning.Reasons)
@@ -311,7 +317,17 @@ func buildAIReasoningMessageLines(reasoning AIReasoningNotification, category st
 		fmt.Sprintf("Type: %s", reasoning.DecisionType),
 	}
 
-	if confidenceKnown {
+	infraHold := isInfrastructureRuntimeStatus(reasoning.RuntimeStatus)
+	llmDegraded := reasoning.RuntimeStatus == runtimeStatusLLMDegraded
+	switch {
+	case confidenceKnown && infraHold:
+		confidencePercent := int(reasoning.Confidence * 100)
+		lines = append(lines, fmt.Sprintf("Confidence: 🟡 %d%% (gated)", confidencePercent))
+	case infraHold && !confidenceKnown && reasoning.Confidence == 0 && !reasoning.ConfidenceKnown:
+		lines = append(lines, "Confidence: ⏸️ (infrastructure hold)")
+	case llmDegraded:
+		lines = append(lines, "Confidence: ⚪ N/A (runtime-degraded)")
+	case confidenceKnown:
 		confidencePercent := int(reasoning.Confidence * 100)
 		var confidenceEmoji string
 		switch {
@@ -323,7 +339,7 @@ func buildAIReasoningMessageLines(reasoning AIReasoningNotification, category st
 			confidenceEmoji = "🔴"
 		}
 		lines = append(lines, fmt.Sprintf("Confidence: %s %d%%", confidenceEmoji, confidencePercent))
-	} else {
+	default:
 		lines = append(lines, "Confidence: ⚪ N/A (runtime-degraded)")
 	}
 
@@ -333,6 +349,33 @@ func buildAIReasoningMessageLines(reasoning AIReasoningNotification, category st
 	)
 	if category != "" {
 		lines = append(lines, fmt.Sprintf("Reason Category: %s", category))
+	}
+	if reasoning.RuntimeStatus != "" {
+		var statusEmoji string
+		switch {
+		case reasoning.RuntimeStatus == runtimeStatusStateDrift || reasoning.RuntimeStatus == runtimeStatusReconcileBlocked:
+			statusEmoji = "🔄"
+		case reasoning.RuntimeStatus == runtimeStatusCircuitOpen:
+			statusEmoji = "⚠️"
+		case reasoning.RuntimeStatus == runtimeStatusLLMDegraded:
+			statusEmoji = "🛑"
+		default:
+			statusEmoji = "ℹ️"
+		}
+		lines = append(lines, fmt.Sprintf("Runtime Status: %s %s", statusEmoji, reasoning.RuntimeStatus))
+	}
+	if reasoning.RuntimeDetails != nil {
+		if current, ok := reasoning.RuntimeDetails["clean_passes_current"]; ok {
+			if required, rok := reasoning.RuntimeDetails["clean_passes_required"]; rok {
+				lines = append(lines, fmt.Sprintf("Reconcile Progress: %s/%s clean passes", current, required))
+			}
+		}
+		if driftPos, ok := reasoning.RuntimeDetails["drift_positions"]; ok {
+			lines = append(lines, fmt.Sprintf("Drift Positions: %s stale", driftPos))
+		}
+		if recoveryAction, ok := reasoning.RuntimeDetails["recovery_action"]; ok {
+			lines = append(lines, fmt.Sprintf("Recovery Action: %s", recoveryAction))
+		}
 	}
 	if strings.TrimSpace(reasoning.UnblockCondition) != "" {
 		lines = append(lines, fmt.Sprintf("Unblock Condition: %s", strings.TrimSpace(reasoning.UnblockCondition)))

--- a/services/backend-api/internal/services/notification_test.go
+++ b/services/backend-api/internal/services/notification_test.go
@@ -2437,3 +2437,98 @@ func TestQuestProgressNotification_Integration(t *testing.T) {
 		assert.Equal(t, current*10, progress.Percent)
 	}
 }
+
+func TestNotificationService_RuntimeStatusRendering(t *testing.T) {
+	ns := NewNotificationService(nil, nil, "", "", "")
+
+	t.Run("state drift with runtime details", func(t *testing.T) {
+		message := ns.formatAIReasoningMessage(AIReasoningNotification{
+			DecisionType:  "scalping_cycle",
+			Summary:       "State drift gate active",
+			RuntimeStatus: runtimeStatusStateDrift,
+			RuntimeDetails: map[string]string{
+				"drift_positions":       "3",
+				"clean_passes_current":  "1",
+				"clean_passes_required": "2",
+			},
+			Reasons: []string{"Drift detected"},
+			Action:  "hold",
+		})
+		assert.Contains(t, message, "Runtime Status:")
+		assert.Contains(t, message, "🔄")
+		assert.Contains(t, message, "Reconcile Progress: 1/2 clean passes")
+		assert.Contains(t, message, "Drift Positions: 3 stale")
+	})
+
+	t.Run("LLM degraded confidence", func(t *testing.T) {
+		message := ns.formatAIReasoningMessage(AIReasoningNotification{
+			DecisionType:   "scalping_cycle",
+			Summary:        "LLM runtime degraded",
+			RuntimeStatus:  runtimeStatusLLMDegraded,
+			ReasonCategory: "execution_unavailable",
+			Reasons:        []string{"LLM timeout"},
+			Action:         "hold",
+		})
+		assert.Contains(t, message, "Confidence: ⚪ N/A (runtime-degraded)")
+		assert.Contains(t, message, "Runtime Status:")
+	})
+
+	t.Run("infrastructure hold with original confidence gated", func(t *testing.T) {
+		message := ns.formatAIReasoningMessage(AIReasoningNotification{
+			DecisionType:    "scalping_cycle",
+			Summary:         "State drift gate active",
+			Confidence:      0.72,
+			ConfidenceKnown: true,
+			RuntimeStatus:   runtimeStatusStateDrift,
+			ReasonCategory:  "execution_unavailable",
+			Reasons:         []string{"Drift detected"},
+			Action:          "hold",
+		})
+		assert.Contains(t, message, "Confidence: 🟡 72% (gated)")
+	})
+
+	t.Run("infrastructure hold with no confidence ever produced", func(t *testing.T) {
+		message := ns.formatAIReasoningMessage(AIReasoningNotification{
+			DecisionType:   "scalping_cycle",
+			Summary:        "State drift gate active",
+			RuntimeStatus:  runtimeStatusStateDrift,
+			ReasonCategory: "execution_unavailable",
+			Reasons:        []string{"Drift detected"},
+			Action:         "hold",
+		})
+		assert.Contains(t, message, "Confidence: ⏸️ (infrastructure hold)")
+	})
+
+	t.Run("circuit open with warning emoji", func(t *testing.T) {
+		message := ns.formatAIReasoningMessage(AIReasoningNotification{
+			DecisionType:  "scalping_cycle",
+			Summary:       "Circuit breaker active",
+			RuntimeStatus: runtimeStatusCircuitOpen,
+			RuntimeDetails: map[string]string{
+				"recovery_action": "force_repair_pending",
+			},
+			Reasons: []string{"Circuit open"},
+			Action:  "hold",
+		})
+		assert.Contains(t, message, "Runtime Status:")
+		assert.Contains(t, message, "⚠️")
+		assert.Contains(t, message, "Recovery Action: force_repair_pending")
+	})
+
+	t.Run("reconcile blocked with progress emoji", func(t *testing.T) {
+		message := ns.formatAIReasoningMessage(AIReasoningNotification{
+			DecisionType:  "scalping_cycle",
+			Summary:       "Reconcile in progress",
+			RuntimeStatus: runtimeStatusReconcileBlocked,
+			RuntimeDetails: map[string]string{
+				"clean_passes_current":  "0",
+				"clean_passes_required": "2",
+			},
+			Reasons: []string{"Waiting for reconcile"},
+			Action:  "hold",
+		})
+		assert.Contains(t, message, "Runtime Status:")
+		assert.Contains(t, message, "🔄")
+		assert.Contains(t, message, "Reconcile Progress: 0/2 clean passes")
+	})
+}

--- a/services/backend-api/internal/services/notification_types.go
+++ b/services/backend-api/internal/services/notification_types.go
@@ -136,4 +136,6 @@ type AIReasoningNotification struct {
 	AttemptWindowProgress string
 	Reasons               []string
 	Action                string
+	RuntimeStatus         string
+	RuntimeDetails        map[string]string
 }

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -1011,8 +1011,8 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		if checkpointBool(quest.Checkpoint["state_drift_deadlock_cleared"]) {
 			runtimeDetails["recovery_action"] = "deadlock_clear_triggered"
 		}
-		if deadlockCleared, ok := quest.Checkpoint["state_drift_deadlock_cleared"]; ok {
-			runtimeDetails["force_repair_eligible"] = fmt.Sprintf("%t", deadlockCleared != nil)
+		if _, ok := quest.Checkpoint["state_drift_deadlock_cleared"]; ok {
+			runtimeDetails["force_repair_eligible"] = fmt.Sprintf("%t", checkpointBool(quest.Checkpoint["state_drift_deadlock_cleared"]))
 		}
 		h.notifyScalpingDecision(gateCtx, chatID, AIReasoningNotification{
 			DecisionType:     "scalping_cycle",
@@ -3046,9 +3046,18 @@ func (h *IntegratedQuestHandlers) maybeSendHoldDigest(
 		reasons = append(reasons, fmt.Sprintf("Next condition: %s", unblockCondition))
 	}
 
+	var digestRuntimeStatus string
+	if checkpointBool(quest.Checkpoint["state_drift_active"]) {
+		digestRuntimeStatus = runtimeStatusStateDrift
+	} else if circuitRemaining > 0 {
+		digestRuntimeStatus = runtimeStatusCircuitOpen
+	} else if errorRate > 0.5 {
+		digestRuntimeStatus = runtimeStatusLLMDegraded
+	}
+
 	h.notifyScalpingDecision(ctx, chatID, AIReasoningNotification{
 		DecisionType:          "scalping_digest",
-		Summary:               holdDigestSummary(decision, reasonCategory, ""),
+		Summary:               holdDigestSummary(decision, reasonCategory, digestRuntimeStatus),
 		Confidence:            decision.Confidence,
 		ConfidenceKnown:       confidenceKnown,
 		ReasonCategory:        reasonCategory,

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -976,22 +976,54 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		}
 
 		holdDecision := &AITradingDecision{
-			Action:          "hold",
-			Confidence:      0,
-			Reasoning:       "entry paused by state drift gate",
-			ReasonCategory:  aiReasonExecutionUnavailable,
-			ConfidenceKnown: false,
+			Action:         "hold",
+			Confidence:     0,
+			Reasoning:      "entry paused by state drift gate",
+			ReasonCategory: aiReasonExecutionUnavailable,
+		}
+		cleanPassesCurrent := checkpointInt(quest.Checkpoint["state_drift_clean_passes"])
+		cleanPassesRequired := stateDriftClearPassTarget()
+		stalePositionIDs := checkpointStringSlice(quest.Checkpoint["state_drift_stale_position_ids"])
+		runtimeDetails := map[string]string{
+			"drift_positions":       fmt.Sprintf("%d", checkpointInt(quest.Checkpoint["state_drift_positions"])),
+			"clean_passes_current":  fmt.Sprintf("%d", cleanPassesCurrent),
+			"clean_passes_required": fmt.Sprintf("%d", cleanPassesRequired),
+			"stale_position_ids":    strings.Join(stalePositionIDs, ","),
+		}
+		if repairAt, ok := quest.Checkpoint["state_drift_last_repair_at"].(string); ok && strings.TrimSpace(repairAt) != "" {
+			runtimeDetails["last_repair_at"] = repairAt
+		}
+		if cleanReconcileAt, ok := quest.Checkpoint["state_drift_last_clean_reconcile_at"].(string); ok && strings.TrimSpace(cleanReconcileAt) != "" {
+			runtimeDetails["last_clean_reconcile_at"] = cleanReconcileAt
+		}
+		persistenceCycles := checkpointInt(quest.Checkpoint["state_drift_persistence_cycles"])
+		forceThreshold := stateDriftPersistenceForceRepairCycles()
+		cooldownElapsed := h.shouldRunForcedDriftRepair(quest, time.Now().UTC())
+		if persistenceCycles >= forceThreshold {
+			if cooldownElapsed {
+				runtimeDetails["recovery_action"] = "force_repair_pending"
+				runtimeDetails["force_repair_eligible"] = "true"
+			} else {
+				runtimeDetails["recovery_action"] = "force_repair_cooling_down"
+				runtimeDetails["force_repair_eligible"] = "false"
+			}
+		}
+		if checkpointBool(quest.Checkpoint["state_drift_deadlock_cleared"]) {
+			runtimeDetails["recovery_action"] = "deadlock_clear_triggered"
+		}
+		if deadlockCleared, ok := quest.Checkpoint["state_drift_deadlock_cleared"]; ok {
+			runtimeDetails["force_repair_eligible"] = fmt.Sprintf("%t", deadlockCleared != nil)
 		}
 		h.notifyScalpingDecision(gateCtx, chatID, AIReasoningNotification{
 			DecisionType:     "scalping_cycle",
 			Summary:          "State drift gate active: reconciling lifecycle with exchange before new entries",
-			Confidence:       0,
-			ConfidenceKnown:  false,
 			ReasonCategory:   aiReasonExecutionUnavailable,
 			HoldCategory:     aiReasonExecutionUnavailable,
 			UnblockCondition: checkpointString(quest.Checkpoint["runtime_next_unblock_condition"]),
 			Reasons:          reasons,
 			Action:           "hold",
+			RuntimeStatus:    runtimeStatusStateDrift,
+			RuntimeDetails:   runtimeDetails,
 		})
 		h.maybeSendHoldDigest(gateCtx, quest, chatID, holdDecision, portfolio)
 		return nil
@@ -1289,7 +1321,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			reasons = append(reasons, fmt.Sprintf("Cooldown applied: %s", cooldown.Round(time.Second).String()))
 		}
 		recordAIRuntimeEvent(quest, time.Now().UTC(), reasonCategory, false, h.getAIScalpingRuntimeSnapshot())
-		h.notifyScalpingDecision(ctx, chatID, AIReasoningNotification{
+		notif := AIReasoningNotification{
 			DecisionType:    "scalping_cycle",
 			Summary:         "Scalping cycle skipped due to AI/runtime error",
 			Confidence:      0,
@@ -1298,7 +1330,8 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			HoldCategory:    reasonCategory,
 			Reasons:         reasons,
 			Action:          "hold",
-		})
+		}
+		h.notifyScalpingDecision(ctx, chatID, notif)
 		// Return nil instead of err to prevent panic - quest continues with hold status
 		return nil
 	}
@@ -1409,11 +1442,18 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			reasons = append(reasons, fmt.Sprintf("Attempt window: %s", strings.TrimSpace(raw)))
 		}
 		unblockCondition := checkpointString(quest.Checkpoint["runtime_next_unblock_condition"])
+		confidenceKnown := !runtimeHold && !runtimeCategory && decision.ConfidenceKnown
+		notifConfidence := decision.Confidence
+		notifConfidenceKnown := confidenceKnown
+		if !confidenceKnown && decision.OriginalConfidenceKnown {
+			notifConfidence = decision.OriginalConfidence
+			notifConfidenceKnown = true
+		}
 		h.notifyScalpingDecision(ctx, chatID, AIReasoningNotification{
 			DecisionType:          "scalping_cycle",
 			Summary:               "AI held position this cycle",
-			Confidence:            decision.Confidence,
-			ConfidenceKnown:       !runtimeHold && !runtimeCategory && decision.ConfidenceKnown,
+			Confidence:            notifConfidence,
+			ConfidenceKnown:       notifConfidenceKnown,
 			ReasonCategory:        reasonCategory,
 			HoldCategory:          reasonCategory,
 			UnblockCondition:      unblockCondition,
@@ -2733,6 +2773,19 @@ func (h *IntegratedQuestHandlers) withGatePathContext(ctx context.Context) (cont
 }
 
 func normalizeAINotificationSemantics(notif AIReasoningNotification) AIReasoningNotification {
+	if notif.RuntimeStatus != "" && isInfrastructureRuntimeStatus(notif.RuntimeStatus) {
+		category := strings.TrimSpace(notif.ReasonCategory)
+		if category == "" {
+			category = strings.TrimSpace(notif.HoldCategory)
+		}
+		if category == "" {
+			category = aiReasonExecutionUnavailable
+		}
+		notif.ReasonCategory = category
+		notif.HoldCategory = category
+		return notif
+	}
+
 	category := strings.TrimSpace(notif.ReasonCategory)
 	if category == "" {
 		category = strings.TrimSpace(notif.HoldCategory)
@@ -2771,21 +2824,25 @@ func normalizeAINotificationSemantics(notif AIReasoningNotification) AIReasoning
 	return notif
 }
 
-func holdDigestSummary(decision *AITradingDecision, reasonCategory string) string {
+func holdDigestSummary(decision *AITradingDecision, reasonCategory string, runtimeStatus string) string {
 	reasonCategory = strings.ToLower(strings.TrimSpace(reasonCategory))
 	reasoning := ""
 	if decision != nil {
 		reasoning = strings.ToLower(strings.TrimSpace(decision.Reasoning))
 	}
 
-	switch reasonCategory {
-	case aiReasonLLMParseContract:
+	switch {
+	case runtimeStatus == runtimeStatusStateDrift:
+		return "Hold digest: paused for lifecycle reconciliation"
+	case runtimeStatus == runtimeStatusReconcileBlocked:
+		return "Hold digest: waiting for clean reconcile passes"
+	case reasonCategory == aiReasonLLMParseContract:
 		return "Hold digest: AI output incomplete, no reliable trade decision"
-	case aiReasonLLMTimeout:
+	case reasonCategory == aiReasonLLMTimeout:
 		return "Hold digest: AI response timed out, no reliable trade decision"
-	case aiReasonExecutionUnavailable:
+	case reasonCategory == aiReasonExecutionUnavailable:
 		return "Hold digest: AI runtime degraded, waiting for stable decisioning"
-	case reasonCategoryDeterministicFallback:
+	case reasonCategory == reasonCategoryDeterministicFallback:
 		if strings.Contains(reasoning, "no eligible candidate") || strings.Contains(reasoning, "no qualified setup") {
 			return "Hold digest: fallback found no qualified setup"
 		}
@@ -2991,7 +3048,7 @@ func (h *IntegratedQuestHandlers) maybeSendHoldDigest(
 
 	h.notifyScalpingDecision(ctx, chatID, AIReasoningNotification{
 		DecisionType:          "scalping_digest",
-		Summary:               holdDigestSummary(decision, reasonCategory),
+		Summary:               holdDigestSummary(decision, reasonCategory, ""),
 		Confidence:            decision.Confidence,
 		ConfidenceKnown:       confidenceKnown,
 		ReasonCategory:        reasonCategory,
@@ -5458,6 +5515,26 @@ func checkpointString(v interface{}) string {
 		return strconv.FormatFloat(value, 'f', -1, 64)
 	default:
 		return ""
+	}
+}
+
+func checkpointStringSlice(v interface{}) []string {
+	switch value := v.(type) {
+	case []string:
+		return value
+	case []interface{}:
+		result := make([]string, 0, len(value))
+		for _, item := range value {
+			if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+				result = append(result, s)
+			}
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	default:
+		return nil
 	}
 }
 

--- a/services/backend-api/internal/services/quest_handlers_integrated_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_test.go
@@ -1224,19 +1224,171 @@ func TestNormalizeAINotificationSemantics_IndecisiveRuntimeEvidenceUsesParseCont
 func TestHoldDigestSummary_RuntimeParseContractUsesRuntimeSummary(t *testing.T) {
 	summary := holdDigestSummary(&AITradingDecision{
 		Reasoning: "Model output was incomplete and indecisive, ending with 'I'm torn' without committing to a trade.",
-	}, aiReasonLLMParseContract)
+	}, aiReasonLLMParseContract, "")
 	assert.Equal(t, "Hold digest: AI output incomplete, no reliable trade decision", summary)
 }
 
-func TestShouldNotifyPnLReconciliation(t *testing.T) {
-	now := time.Now().UTC()
-	quest := &Quest{Checkpoint: map[string]interface{}{}}
+func TestHoldDigestSummary_TableDriven(t *testing.T) {
+	tests := []struct {
+		name           string
+		decision       *AITradingDecision
+		reasonCategory string
+		runtimeStatus  string
+		expected       string
+	}{
+		{
+			name:           "LLM timeout",
+			decision:       &AITradingDecision{Reasoning: "timeout occurred"},
+			reasonCategory: aiReasonLLMTimeout,
+			expected:       "Hold digest: AI response timed out, no reliable trade decision",
+		},
+		{
+			name:           "LLM parse contract",
+			decision:       &AITradingDecision{Reasoning: "parse failed"},
+			reasonCategory: aiReasonLLMParseContract,
+			expected:       "Hold digest: AI output incomplete, no reliable trade decision",
+		},
+		{
+			name:           "execution unavailable",
+			decision:       &AITradingDecision{Reasoning: "runtime degraded"},
+			reasonCategory: aiReasonExecutionUnavailable,
+			expected:       "Hold digest: AI runtime degraded, waiting for stable decisioning",
+		},
+		{
+			name:           "deterministic fallback no eligible candidate",
+			decision:       &AITradingDecision{Reasoning: "no eligible candidate passed filters"},
+			reasonCategory: reasonCategoryDeterministicFallback,
+			expected:       "Hold digest: fallback found no qualified setup",
+		},
+		{
+			name:           "deterministic fallback no qualified setup",
+			decision:       &AITradingDecision{Reasoning: "no qualified setup found"},
+			reasonCategory: reasonCategoryDeterministicFallback,
+			expected:       "Hold digest: fallback found no qualified setup",
+		},
+		{
+			name:           "deterministic fallback hold",
+			decision:       &AITradingDecision{Reasoning: "conditions not met"},
+			reasonCategory: reasonCategoryDeterministicFallback,
+			expected:       "Hold digest: AI fallback selected hold",
+		},
+		{
+			name:           "strategy hold",
+			decision:       &AITradingDecision{Reasoning: "holding"},
+			reasonCategory: aiReasonStrategyHold,
+			expected:       "Hold digest: waiting for qualified setup",
+		},
+		{
+			name:           "state drift runtime status",
+			decision:       &AITradingDecision{Reasoning: "drift detected"},
+			reasonCategory: aiReasonExecutionUnavailable,
+			runtimeStatus:  runtimeStatusStateDrift,
+			expected:       "Hold digest: paused for lifecycle reconciliation",
+		},
+		{
+			name:           "reconcile blocked runtime status",
+			decision:       &AITradingDecision{Reasoning: "reconcile in progress"},
+			reasonCategory: aiReasonExecutionUnavailable,
+			runtimeStatus:  runtimeStatusReconcileBlocked,
+			expected:       "Hold digest: waiting for clean reconcile passes",
+		},
+		{
+			name:           "nil decision",
+			decision:       nil,
+			reasonCategory: aiReasonStrategyHold,
+			expected:       "Hold digest: waiting for qualified setup",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := holdDigestSummary(tt.decision, tt.reasonCategory, tt.runtimeStatus)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
 
-	assert.True(t, shouldNotifyPnLReconciliation(quest, "summary-a", now))
-	recordPnLReconciliationNotification(quest, "summary-a", now)
-	assert.False(t, shouldNotifyPnLReconciliation(quest, "summary-a", now.Add(5*time.Minute)))
-	assert.True(t, shouldNotifyPnLReconciliation(quest, "summary-b", now.Add(5*time.Minute)))
-	assert.True(t, shouldNotifyPnLReconciliation(quest, "summary-a", now.Add(16*time.Minute)))
+func TestNormalizeAINotificationSemantics_RuntimeStatusPreservesConfidence(t *testing.T) {
+	t.Run("infrastructure status state drift preserves ConfidenceKnown true", func(t *testing.T) {
+		notif := AIReasoningNotification{
+			DecisionType:    "scalping_cycle",
+			Summary:         "State drift gate active",
+			Confidence:      0.75,
+			ConfidenceKnown: true,
+			RuntimeStatus:   runtimeStatusStateDrift,
+			ReasonCategory:  aiReasonExecutionUnavailable,
+		}
+		normalized := normalizeAINotificationSemantics(notif)
+		assert.True(t, normalized.ConfidenceKnown, "ConfidenceKnown should remain true for infrastructure runtime status")
+		assert.Equal(t, aiReasonExecutionUnavailable, normalized.ReasonCategory)
+	})
+
+	t.Run("infrastructure status reconcile blocked preserves ConfidenceKnown true", func(t *testing.T) {
+		notif := AIReasoningNotification{
+			DecisionType:    "scalping_cycle",
+			Summary:         "Reconcile in progress",
+			Confidence:      0.65,
+			ConfidenceKnown: true,
+			RuntimeStatus:   runtimeStatusReconcileBlocked,
+			ReasonCategory:  aiReasonExecutionUnavailable,
+		}
+		normalized := normalizeAINotificationSemantics(notif)
+		assert.True(t, normalized.ConfidenceKnown)
+	})
+
+	t.Run("infrastructure status circuit open preserves ConfidenceKnown true", func(t *testing.T) {
+		notif := AIReasoningNotification{
+			DecisionType:    "scalping_cycle",
+			Summary:         "Circuit breaker active",
+			Confidence:      0.80,
+			ConfidenceKnown: true,
+			RuntimeStatus:   runtimeStatusCircuitOpen,
+			ReasonCategory:  aiReasonExecutionUnavailable,
+		}
+		normalized := normalizeAINotificationSemantics(notif)
+		assert.True(t, normalized.ConfidenceKnown)
+	})
+
+	t.Run("LLM degraded still forces ConfidenceKnown false", func(t *testing.T) {
+		notif := AIReasoningNotification{
+			DecisionType:    "scalping_cycle",
+			Summary:         "LLM runtime degraded",
+			Confidence:      0.70,
+			ConfidenceKnown: true,
+			RuntimeStatus:   runtimeStatusLLMDegraded,
+			ReasonCategory:  aiReasonExecutionUnavailable,
+		}
+		normalized := normalizeAINotificationSemantics(notif)
+		assert.False(t, normalized.ConfidenceKnown, "ConfidenceKnown should be forced to false for LLM degraded")
+	})
+
+	t.Run("no runtime status existing behavior preserved", func(t *testing.T) {
+		notif := AIReasoningNotification{
+			DecisionType:    "scalping_cycle",
+			Summary:         "Runtime error",
+			ConfidenceKnown: true,
+			ReasonCategory:  aiReasonExecutionUnavailable,
+		}
+		normalized := normalizeAINotificationSemantics(notif)
+		assert.False(t, normalized.ConfidenceKnown, "Existing behavior: runtime category forces ConfidenceKnown false")
+	})
+}
+
+func TestIsInfrastructureRuntimeStatus(t *testing.T) {
+	assert.True(t, isInfrastructureRuntimeStatus(runtimeStatusStateDrift))
+	assert.True(t, isInfrastructureRuntimeStatus(runtimeStatusReconcileBlocked))
+	assert.True(t, isInfrastructureRuntimeStatus(runtimeStatusCircuitOpen))
+	assert.False(t, isInfrastructureRuntimeStatus(runtimeStatusLLMDegraded))
+	assert.False(t, isInfrastructureRuntimeStatus(runtimeStatusHealthy))
+	assert.False(t, isInfrastructureRuntimeStatus(""))
+	assert.False(t, isInfrastructureRuntimeStatus("unknown_status"))
+}
+
+func TestCheckpointStringSlice(t *testing.T) {
+	assert.Equal(t, []string{"a", "b"}, checkpointStringSlice([]string{"a", "b"}))
+	assert.Equal(t, []string{"a", "b"}, checkpointStringSlice([]interface{}{"a", "", "b"}))
+	assert.Nil(t, checkpointStringSlice(nil))
+	assert.Nil(t, checkpointStringSlice(42))
+	assert.Nil(t, checkpointStringSlice([]interface{}{"", "  "}))
 }
 
 func TestRecordPnLReconciliationNotification_InitializesCheckpoint(t *testing.T) {


### PR DESCRIPTION
## Summary
- Extend `AIReasoningNotification` with `RuntimeStatus` and `RuntimeDetails` fields to distinguish infrastructure-level holds (state drift, reconcile blocked, circuit open) from AI-layer failures (LLM degraded)
- Normalizer (`normalizeAINotificationSemantics`) now skips confidence demotion for infrastructure runtime statuses, preserving pre-gate confidence values
- `AITradingDecision` gains `OriginalConfidence`/`OriginalConfidenceKnown` fields for preserving confidence before gate zeroing
- Telegram formatter displays runtime health indicators (🔄 drift/reconcile, ⚠️ circuit open, 🛑 LLM degraded), reconcile progress, drift position counts, and recovery action status
- `holdDigestSummary` accepts `runtimeStatus` parameter with dedicated digest messages for state drift and reconcile blocked
- `refreshStateDriftGate` checkpoint enriched with `state_drift_stale_position_ids`, `state_drift_persistence_cycles`, `state_drift_deadlock_cycles`
- Recovery mechanism status surfaced via `RuntimeDetails["recovery_action"]` (`force_repair_pending`, `force_repair_cooling_down`, `deadlock_clear_triggered`)

## Test coverage
- Table-driven `TestHoldDigestSummary_TableDriven` (10 cases covering all reason categories and runtime statuses)
- `TestNormalizeAINotificationSemantics_RuntimeStatusPreservesConfidence` (5 cases: infra preserves, LLM degrades, no-status backward compat)
- `TestIsInfrastructureRuntimeStatus` (7 cases)
- `TestCheckpointStringSlice` (5 cases)
- `TestNotificationService_RuntimeStatusRendering` (6 subtests: drift+details, LLM degraded, gated confidence, infrastructure hold, circuit open, reconcile blocked)

All 2238 tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/irfndi/neuratrade/pull/283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Stabilize scalping hold/confidence reporting by distinguishing infrastructure runtime holds from AI-layer failures and surfacing runtime health metadata in notifications.

New Features:
- Add runtime status and detail fields to AI reasoning notifications and wire them through scalping decision flow.
- Introduce runtime status enums and infrastructure-status detection to separate state drift, reconcile blocked, circuit open, and LLM-degraded conditions.
- Extend AI trading decisions with fields to preserve original confidence before gating and expose it in notifications when applicable.

Enhancements:
- Refine hold digest summaries and notification formatting to produce dedicated messages and emojis for infrastructure holds, reconcile progress, drift positions, and recovery actions.
- Adjust confidence normalization logic so infrastructure runtime statuses preserve confidence while AI/runtime failures still demote it.

Tests:
- Replace and expand hold digest tests with table-driven coverage for reason categories and runtime statuses, and add focused tests for runtime status semantics, infrastructure detection, checkpoint helpers, and notification rendering.