### PR TITLE
fix(agent-control): wire stub handlers to actual backend services

### DIFF
--- a/services/backend-api/internal/api/handlers/agent_control.go
+++ b/services/backend-api/internal/api/handlers/agent_control.go
@@ -2,6 +2,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -15,18 +16,47 @@ import (
 	"github.com/irfndi/neuratrade/internal/services"
 )
 
+type CollectorController interface {
+	PauseExchange(exchangeID string) error
+	ResumeExchange(exchangeID string) error
+}
+
+type RiskController interface {
+	EnableSafeMode(ctx context.Context, reason string) error
+	DisableSafeMode(ctx context.Context) error
+	EngageKillSwitch(ctx context.Context, reason string) error
+	DisengageKillSwitch(ctx context.Context) error
+}
+
+type OrderController interface {
+	CancelAllOrders(ctx context.Context, exchange, symbol string) error
+}
+
+type AgentControlDeps struct {
+	Autonomy  *services.ScalpingAutonomyCoordinator
+	Collector CollectorController
+	Risk      RiskController
+	Orders    OrderController
+}
+
 // AgentControlHandler handles agent control API requests.
 type AgentControlHandler struct {
 	mu          sync.RWMutex
 	subscribers map[chan AgentEvent]struct{}
 	autonomy    *services.ScalpingAutonomyCoordinator
+	collector   CollectorController
+	risk        RiskController
+	orders      OrderController
 }
 
 // NewAgentControlHandler creates a new agent control handler.
-func NewAgentControlHandler(autonomy *services.ScalpingAutonomyCoordinator) *AgentControlHandler {
+func NewAgentControlHandler(deps AgentControlDeps) *AgentControlHandler {
 	return &AgentControlHandler{
 		subscribers: make(map[chan AgentEvent]struct{}),
-		autonomy:    autonomy,
+		autonomy:    deps.Autonomy,
+		collector:   deps.Collector,
+		risk:        deps.Risk,
+		orders:      deps.Orders,
 	}
 }
 
@@ -69,9 +99,19 @@ func (h *AgentControlHandler) PauseExchange(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
-
-	// TODO: Wire to actual collector service
-	// For now, just acknowledge the command
+	if req.ExchangeID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "exchange_id is required"})
+		return
+	}
+	if h.collector == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "collector service unavailable"})
+		return
+	}
+	if err := h.collector.PauseExchange(req.ExchangeID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "pause_exchange"})
+		return
+	}
+	log.Printf("agent_control: exchange %s collection paused", req.ExchangeID)
 	c.JSON(http.StatusOK, gin.H{
 		"status":      "ok",
 		"action":      "pause_exchange",
@@ -94,8 +134,19 @@ func (h *AgentControlHandler) ResumeExchange(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
-
-	// TODO: Wire to actual collector service
+	if req.ExchangeID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "exchange_id is required"})
+		return
+	}
+	if h.collector == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "collector service unavailable"})
+		return
+	}
+	if err := h.collector.ResumeExchange(req.ExchangeID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "resume_exchange"})
+		return
+	}
+	log.Printf("agent_control: exchange %s collection resumed", req.ExchangeID)
 	c.JSON(http.StatusOK, gin.H{
 		"status":      "ok",
 		"action":      "resume_exchange",
@@ -112,7 +163,15 @@ func (h *AgentControlHandler) ResumeExchange(c *gin.Context) {
 // @Success 200 {object} map[string]string
 // @Router /api/v1/agent/enable-safe-mode [post]
 func (h *AgentControlHandler) EnableSafeMode(c *gin.Context) {
-	// TODO: Wire to actual risk service
+	if h.risk == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "risk service unavailable"})
+		return
+	}
+	if err := h.risk.EnableSafeMode(c.Request.Context(), "operator request"); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "enable_safe_mode"})
+		return
+	}
+	log.Printf("agent_control: safe mode enabled")
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "enable_safe_mode",
@@ -128,7 +187,15 @@ func (h *AgentControlHandler) EnableSafeMode(c *gin.Context) {
 // @Success 200 {object} map[string]string
 // @Router /api/v1/agent/disable-safe-mode [post]
 func (h *AgentControlHandler) DisableSafeMode(c *gin.Context) {
-	// TODO: Wire to actual risk service
+	if h.risk == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "risk service unavailable"})
+		return
+	}
+	if err := h.risk.DisableSafeMode(c.Request.Context()); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "disable_safe_mode"})
+		return
+	}
+	log.Printf("agent_control: safe mode disabled")
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "disable_safe_mode",
@@ -151,7 +218,19 @@ func (h *AgentControlHandler) EngageKillSwitch(c *gin.Context) {
 		return
 	}
 
-	// TODO: Wire to actual risk service
+	if h.risk == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "risk service unavailable"})
+		return
+	}
+	reason := "operator request"
+	if req.Scope != "" {
+		reason = req.Scope
+	}
+	if err := h.risk.EngageKillSwitch(c.Request.Context(), reason); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "kill_switch"})
+		return
+	}
+	log.Printf("agent_control: kill switch engaged")
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "kill_switch",
@@ -175,7 +254,15 @@ func (h *AgentControlHandler) CancelAllOrders(c *gin.Context) {
 		return
 	}
 
-	// TODO: Wire to actual execution service
+	if h.orders == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "order execution service unavailable"})
+		return
+	}
+	if err := h.orders.CancelAllOrders(c.Request.Context(), req.ExchangeID, req.Scope); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "cancel_all_orders"})
+		return
+	}
+	log.Printf("agent_control: all orders cancelled (exchange=%s, scope=%s)", req.ExchangeID, req.Scope)
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "cancel_all_orders",

--- a/services/backend-api/internal/api/handlers/agent_control.go
+++ b/services/backend-api/internal/api/handlers/agent_control.go
@@ -63,6 +63,7 @@ func NewAgentControlHandler(deps AgentControlDeps) *AgentControlHandler {
 // AgentCommandRequest represents an agent command request.
 type AgentCommandRequest struct {
 	ExchangeID string `json:"exchange_id,omitempty"`
+	Symbol     string `json:"symbol,omitempty"`
 	Scope      string `json:"scope,omitempty"`
 	Engage     *bool  `json:"engage,omitempty"`
 }
@@ -202,9 +203,9 @@ func (h *AgentControlHandler) DisableSafeMode(c *gin.Context) {
 	})
 }
 
-// EngageKillSwitch handles requests to engage the kill switch.
+// EngageKillSwitch handles requests to engage or disengage the kill switch.
 // @Summary Engage kill switch
-// @Description Engage kill switch (hard stop all trading)
+// @Description Engage kill switch (hard stop all trading). Set engage=false to disengage.
 // @Tags agent
 // @Accept json
 // @Produce json
@@ -222,19 +223,37 @@ func (h *AgentControlHandler) EngageKillSwitch(c *gin.Context) {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "risk service unavailable"})
 		return
 	}
+
+	engageVal := true
+	if req.Engage != nil {
+		engageVal = *req.Engage
+	}
+
 	reason := "operator request"
 	if req.Scope != "" {
 		reason = req.Scope
 	}
-	if err := h.risk.EngageKillSwitch(c.Request.Context(), reason); err != nil {
+
+	var err error
+	if engageVal {
+		err = h.risk.EngageKillSwitch(c.Request.Context(), reason)
+	} else {
+		err = h.risk.DisengageKillSwitch(c.Request.Context())
+	}
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "kill_switch"})
 		return
 	}
-	log.Printf("agent_control: kill switch engaged")
+
+	action := "engage_kill_switch"
+	if !engageVal {
+		action = "disengage_kill_switch"
+	}
+	log.Printf("agent_control: kill switch %s", action)
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "kill_switch",
-		"engage": req.Engage,
+		"engage": engageVal,
 	})
 }
 
@@ -258,15 +277,15 @@ func (h *AgentControlHandler) CancelAllOrders(c *gin.Context) {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "order execution service unavailable"})
 		return
 	}
-	if err := h.orders.CancelAllOrders(c.Request.Context(), req.ExchangeID, req.Scope); err != nil {
+	if err := h.orders.CancelAllOrders(c.Request.Context(), req.ExchangeID, req.Symbol); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "cancel_all_orders"})
 		return
 	}
-	log.Printf("agent_control: all orders cancelled (exchange=%s, scope=%s)", req.ExchangeID, req.Scope)
+	log.Printf("agent_control: all orders cancelled (exchange=%s, symbol=%s)", req.ExchangeID, req.Symbol)
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "cancel_all_orders",
-		"scope":  req.Scope,
+		"symbol": req.Symbol,
 	})
 }
 

--- a/services/backend-api/internal/api/handlers/agent_control_adapters.go
+++ b/services/backend-api/internal/api/handlers/agent_control_adapters.go
@@ -37,11 +37,14 @@ type riskAdapter struct {
 	safeMode   *risk.SafeModeImpl
 }
 
-// NewRiskControllerAdapter creates a RiskController backed by the given shared
-// KillSwitch and SafeMode instances. Pass the same instances that are registered
-// with the policy engine / RiskActor so that operator API changes propagate to
-// order-blocking enforcement.
+// NewRiskControllerAdapter creates a RiskController backed by the given
+// KillSwitch and SafeMode. Returns nil when either dependency is nil so that
+// handler nil-guards produce proper 503 responses — consistent with
+// NewCollectorController and NewOrderController.
 func NewRiskControllerAdapter(killSwitch *risk.KillSwitchImpl, safeMode *risk.SafeModeImpl) RiskController {
+	if killSwitch == nil || safeMode == nil {
+		return nil
+	}
 	return &riskAdapter{
 		killSwitch: killSwitch,
 		safeMode:   safeMode,
@@ -126,6 +129,10 @@ func (a *orderAdapter) cancelExchangeOrders(ctx context.Context, exchange, symbo
 
 	var cancelErrs []error
 	for _, order := range resp.Orders {
+		if err := ctx.Err(); err != nil {
+			cancelErrs = append(cancelErrs, fmt.Errorf("cancellation aborted: %w", err))
+			break
+		}
 		if err := a.ccxtService.CancelOrder(ctx, exchange, order.ID, order.Symbol); err != nil {
 			cancelErrs = append(cancelErrs, fmt.Errorf("cancel order %s on %s failed: %w", order.ID, exchange, err))
 		}

--- a/services/backend-api/internal/api/handlers/agent_control_adapters.go
+++ b/services/backend-api/internal/api/handlers/agent_control_adapters.go
@@ -92,9 +92,9 @@ func (a *orderAdapter) CancelAllOrders(ctx context.Context, exchange, symbol str
 
 	var errs []error
 	for _, ex := range exchanges {
-		// Abort promptly when the caller cancels the request.
 		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("cancelled while iterating exchanges: %w", err)
+			errs = append(errs, fmt.Errorf("cancelled while iterating exchanges: %w", err))
+			break
 		}
 		if err := a.cancelExchangeOrders(ctx, ex, symbol); err != nil {
 			errs = append(errs, err)

--- a/services/backend-api/internal/api/handlers/agent_control_adapters.go
+++ b/services/backend-api/internal/api/handlers/agent_control_adapters.go
@@ -14,21 +14,21 @@ type collectorAdapter struct {
 	service *services.CollectorService
 }
 
+// NewCollectorController wraps a CollectorService behind the CollectorController
+// interface. Returns nil when svc is nil so that handler nil-guards (503) fire
+// correctly instead of falling through to a generic 500.
 func NewCollectorController(svc *services.CollectorService) CollectorController {
+	if svc == nil {
+		return nil
+	}
 	return &collectorAdapter{service: svc}
 }
 
 func (a *collectorAdapter) PauseExchange(exchangeID string) error {
-	if a == nil || a.service == nil {
-		return errors.New("collector service is nil")
-	}
 	return a.service.PauseExchange(exchangeID)
 }
 
 func (a *collectorAdapter) ResumeExchange(exchangeID string) error {
-	if a == nil || a.service == nil {
-		return errors.New("collector service is nil")
-	}
 	return a.service.ResumeExchange(exchangeID)
 }
 
@@ -37,10 +37,14 @@ type riskAdapter struct {
 	safeMode   *risk.SafeModeImpl
 }
 
-func NewRiskControllerAdapter() RiskController {
+// NewRiskControllerAdapter creates a RiskController backed by the given shared
+// KillSwitch and SafeMode instances. Pass the same instances that are registered
+// with the policy engine / RiskActor so that operator API changes propagate to
+// order-blocking enforcement.
+func NewRiskControllerAdapter(killSwitch *risk.KillSwitchImpl, safeMode *risk.SafeModeImpl) RiskController {
 	return &riskAdapter{
-		killSwitch: risk.NewKillSwitch(),
-		safeMode:   risk.NewSafeMode(risk.DefaultSafeModeConfig()),
+		killSwitch: killSwitch,
+		safeMode:   safeMode,
 	}
 }
 
@@ -64,15 +68,16 @@ type orderAdapter struct {
 	ccxtService ccxt.CCXTService
 }
 
+// NewOrderController wraps a CCXTService behind the OrderController interface.
+// Returns nil when ccxtSvc is nil so that handler nil-guards (503) fire correctly.
 func NewOrderController(ccxtSvc ccxt.CCXTService) OrderController {
+	if ccxtSvc == nil {
+		return nil
+	}
 	return &orderAdapter{ccxtService: ccxtSvc}
 }
 
 func (a *orderAdapter) CancelAllOrders(ctx context.Context, exchange, symbol string) error {
-	if a == nil || a.ccxtService == nil {
-		return errors.New("ccxt service unavailable")
-	}
-
 	if exchange != "" {
 		return a.cancelExchangeOrders(ctx, exchange, symbol)
 	}
@@ -84,6 +89,10 @@ func (a *orderAdapter) CancelAllOrders(ctx context.Context, exchange, symbol str
 
 	var errs []error
 	for _, ex := range exchanges {
+		// Abort promptly when the caller cancels the request.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("cancelled while iterating exchanges: %w", err)
+		}
 		if err := a.cancelExchangeOrders(ctx, ex, symbol); err != nil {
 			errs = append(errs, err)
 		}

--- a/services/backend-api/internal/api/handlers/agent_control_adapters.go
+++ b/services/backend-api/internal/api/handlers/agent_control_adapters.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/irfndi/neuratrade/internal/app/risk"
+	"github.com/irfndi/neuratrade/internal/ccxt"
+	"github.com/irfndi/neuratrade/internal/services"
+)
+
+type collectorAdapter struct {
+	service *services.CollectorService
+}
+
+func NewCollectorController(svc *services.CollectorService) CollectorController {
+	return &collectorAdapter{service: svc}
+}
+
+func (a *collectorAdapter) PauseExchange(exchangeID string) error {
+	if a == nil || a.service == nil {
+		return errors.New("collector service is nil")
+	}
+	return a.service.PauseExchange(exchangeID)
+}
+
+func (a *collectorAdapter) ResumeExchange(exchangeID string) error {
+	if a == nil || a.service == nil {
+		return errors.New("collector service is nil")
+	}
+	return a.service.ResumeExchange(exchangeID)
+}
+
+type riskAdapter struct {
+	killSwitch *risk.KillSwitchImpl
+	safeMode   *risk.SafeModeImpl
+}
+
+func NewRiskControllerAdapter() RiskController {
+	return &riskAdapter{
+		killSwitch: risk.NewKillSwitch(),
+		safeMode:   risk.NewSafeMode(risk.DefaultSafeModeConfig()),
+	}
+}
+
+func (a *riskAdapter) EnableSafeMode(ctx context.Context, reason string) error {
+	return a.safeMode.EnableWithReason(ctx, reason)
+}
+
+func (a *riskAdapter) DisableSafeMode(ctx context.Context) error {
+	return a.safeMode.Disable(ctx)
+}
+
+func (a *riskAdapter) EngageKillSwitch(ctx context.Context, reason string) error {
+	return a.killSwitch.Engage(ctx, reason)
+}
+
+func (a *riskAdapter) DisengageKillSwitch(ctx context.Context) error {
+	return a.killSwitch.Disengage(ctx)
+}
+
+type orderAdapter struct {
+	ccxtService ccxt.CCXTService
+}
+
+func NewOrderController(ccxtSvc ccxt.CCXTService) OrderController {
+	return &orderAdapter{ccxtService: ccxtSvc}
+}
+
+func (a *orderAdapter) CancelAllOrders(ctx context.Context, exchange, symbol string) error {
+	if a == nil || a.ccxtService == nil {
+		return errors.New("ccxt service unavailable")
+	}
+
+	if exchange != "" {
+		return a.cancelExchangeOrders(ctx, exchange, symbol)
+	}
+
+	exchanges := a.ccxtService.GetSupportedExchanges()
+	if len(exchanges) == 0 {
+		return errors.New("no supported exchanges available")
+	}
+
+	var errs []error
+	for _, ex := range exchanges {
+		if err := a.cancelExchangeOrders(ctx, ex, symbol); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+func (a *orderAdapter) cancelExchangeOrders(ctx context.Context, exchange, symbol string) error {
+	var (
+		resp *ccxt.OpenOrdersResponse
+		err  error
+	)
+
+	if symbol != "" {
+		resp, err = a.ccxtService.FetchOpenOrdersForSymbol(ctx, exchange, symbol)
+	} else {
+		resp, err = a.ccxtService.FetchOpenOrders(ctx, exchange)
+	}
+	if err != nil {
+		return fmt.Errorf("fetch open orders for %s failed: %w", exchange, err)
+	}
+
+	if resp == nil || len(resp.Orders) == 0 {
+		return nil
+	}
+
+	var cancelErrs []error
+	for _, order := range resp.Orders {
+		if err := a.ccxtService.CancelOrder(ctx, exchange, order.ID, order.Symbol); err != nil {
+			cancelErrs = append(cancelErrs, fmt.Errorf("cancel order %s on %s failed: %w", order.ID, exchange, err))
+		}
+	}
+
+	if len(cancelErrs) > 0 {
+		return errors.Join(cancelErrs...)
+	}
+
+	return nil
+}

--- a/services/backend-api/internal/api/handlers/agent_control_test.go
+++ b/services/backend-api/internal/api/handlers/agent_control_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -28,7 +29,7 @@ func TestAgentControlHandler_SetStrategyMode_ByChatID(t *testing.T) {
 	store := services.NewAutonomousRolloutStore(sqliteDB.DB)
 	require.NoError(t, store.InitSchema(context.Background()))
 
-	handler := NewAgentControlHandler(services.NewScalpingAutonomyCoordinator(store, services.AIScalpingConfig{}))
+	handler := NewAgentControlHandler(AgentControlDeps{Autonomy: services.NewScalpingAutonomyCoordinator(store, services.AIScalpingConfig{})})
 
 	body := bytes.NewBufferString(`{"chat_id":"777","mode":"live"}`)
 	w := httptest.NewRecorder()
@@ -62,7 +63,7 @@ func TestAgentControlHandler_SetStrategyMode_RejectsInvalidMode(t *testing.T) {
 	store := services.NewAutonomousRolloutStore(sqliteDB.DB)
 	require.NoError(t, store.InitSchema(context.Background()))
 
-	handler := NewAgentControlHandler(services.NewScalpingAutonomyCoordinator(store, services.AIScalpingConfig{}))
+	handler := NewAgentControlHandler(AgentControlDeps{Autonomy: services.NewScalpingAutonomyCoordinator(store, services.AIScalpingConfig{})})
 
 	body := bytes.NewBufferString(`{"strategy_id":"strategy-1","mode":"turbo"}`)
 	w := httptest.NewRecorder()
@@ -79,4 +80,262 @@ func TestAgentControlHandler_SetStrategyMode_RejectsInvalidMode(t *testing.T) {
 	assert.Contains(t, response["error"], "allowed modes are: shadow, paper, live")
 	assert.Equal(t, "turbo", response["requested_mode"])
 	assert.ElementsMatch(t, []interface{}{"shadow", "paper", "live"}, response["allowed_modes"])
+}
+
+type mockCollectorController struct {
+	paused map[string]bool
+	err    error
+}
+
+func (m *mockCollectorController) PauseExchange(exchangeID string) error {
+	if m.err != nil {
+		return m.err
+	}
+	if m.paused == nil {
+		m.paused = make(map[string]bool)
+	}
+	m.paused[exchangeID] = true
+	return nil
+}
+
+func (m *mockCollectorController) ResumeExchange(exchangeID string) error {
+	if m.err != nil {
+		return m.err
+	}
+	if m.paused == nil {
+		m.paused = make(map[string]bool)
+	}
+	m.paused[exchangeID] = false
+	return nil
+}
+
+type mockRiskController struct {
+	safeModeEnabled   bool
+	killSwitchEngaged bool
+	err               error
+}
+
+func (m *mockRiskController) EnableSafeMode(_ context.Context, _ string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.safeModeEnabled = true
+	return nil
+}
+
+func (m *mockRiskController) DisableSafeMode(_ context.Context) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.safeModeEnabled = false
+	return nil
+}
+
+func (m *mockRiskController) EngageKillSwitch(_ context.Context, _ string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.killSwitchEngaged = true
+	return nil
+}
+
+func (m *mockRiskController) DisengageKillSwitch(_ context.Context) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.killSwitchEngaged = false
+	return nil
+}
+
+type mockOrderController struct {
+	cancelled bool
+	err       error
+}
+
+func (m *mockOrderController) CancelAllOrders(_ context.Context, _, _ string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.cancelled = true
+	return nil
+}
+
+func makeJSONContext(method, path, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	return c, w
+}
+
+func decodeResponseBody(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var response map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &response))
+	return response
+}
+
+func TestAgentControlHandler_PauseExchange_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	collector := &mockCollectorController{}
+	handler := NewAgentControlHandler(AgentControlDeps{Collector: collector})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/pause-exchange", `{"exchange_id":"binance"}`)
+
+	handler.PauseExchange(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "ok", response["status"])
+	assert.Equal(t, "pause_exchange", response["action"])
+	assert.Equal(t, "binance", response["exchange_id"])
+	assert.Equal(t, true, collector.paused["binance"])
+}
+
+func TestAgentControlHandler_PauseExchange_MissingExchangeID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewAgentControlHandler(AgentControlDeps{Collector: &mockCollectorController{}})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/pause-exchange", `{}`)
+
+	handler.PauseExchange(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "exchange_id is required", response["error"])
+}
+
+func TestAgentControlHandler_PauseExchange_ServiceUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewAgentControlHandler(AgentControlDeps{})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/pause-exchange", `{"exchange_id":"binance"}`)
+
+	handler.PauseExchange(c)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "collector service unavailable", response["error"])
+}
+
+func TestAgentControlHandler_PauseExchange_ServiceError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewAgentControlHandler(AgentControlDeps{Collector: &mockCollectorController{err: errors.New("collector failed")}})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/pause-exchange", `{"exchange_id":"binance"}`)
+
+	handler.PauseExchange(c)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "collector failed", response["error"])
+	assert.Equal(t, "pause_exchange", response["action"])
+}
+
+func TestAgentControlHandler_ResumeExchange_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	collector := &mockCollectorController{paused: map[string]bool{"binance": true}}
+	handler := NewAgentControlHandler(AgentControlDeps{Collector: collector})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/resume-exchange", `{"exchange_id":"binance"}`)
+
+	handler.ResumeExchange(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "ok", response["status"])
+	assert.Equal(t, "resume_exchange", response["action"])
+	assert.Equal(t, false, collector.paused["binance"])
+}
+
+func TestAgentControlHandler_EnableSafeMode_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	riskController := &mockRiskController{}
+	handler := NewAgentControlHandler(AgentControlDeps{Risk: riskController})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/enable-safe-mode", `{}`)
+
+	handler.EnableSafeMode(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "ok", response["status"])
+	assert.Equal(t, "enable_safe_mode", response["action"])
+	assert.True(t, riskController.safeModeEnabled)
+}
+
+func TestAgentControlHandler_EnableSafeMode_ServiceUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewAgentControlHandler(AgentControlDeps{})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/enable-safe-mode", `{}`)
+
+	handler.EnableSafeMode(c)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "risk service unavailable", response["error"])
+}
+
+func TestAgentControlHandler_DisableSafeMode_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	riskController := &mockRiskController{safeModeEnabled: true}
+	handler := NewAgentControlHandler(AgentControlDeps{Risk: riskController})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/disable-safe-mode", `{}`)
+
+	handler.DisableSafeMode(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "ok", response["status"])
+	assert.Equal(t, "disable_safe_mode", response["action"])
+	assert.False(t, riskController.safeModeEnabled)
+}
+
+func TestAgentControlHandler_EngageKillSwitch_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	riskController := &mockRiskController{}
+	handler := NewAgentControlHandler(AgentControlDeps{Risk: riskController})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/kill-switch", `{"scope":"emergency"}`)
+
+	handler.EngageKillSwitch(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "ok", response["status"])
+	assert.Equal(t, "kill_switch", response["action"])
+	assert.True(t, riskController.killSwitchEngaged)
+}
+
+func TestAgentControlHandler_EngageKillSwitch_ServiceUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewAgentControlHandler(AgentControlDeps{})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/kill-switch", `{}`)
+
+	handler.EngageKillSwitch(c)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "risk service unavailable", response["error"])
+}
+
+func TestAgentControlHandler_CancelAllOrders_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	orders := &mockOrderController{}
+	handler := NewAgentControlHandler(AgentControlDeps{Orders: orders})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/cancel-all-orders", `{"exchange_id":"binance","scope":"BTC/USDT"}`)
+
+	handler.CancelAllOrders(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "ok", response["status"])
+	assert.Equal(t, "cancel_all_orders", response["action"])
+	assert.Equal(t, "BTC/USDT", response["scope"])
+	assert.True(t, orders.cancelled)
+}
+
+func TestAgentControlHandler_CancelAllOrders_ServiceUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewAgentControlHandler(AgentControlDeps{})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/cancel-all-orders", `{}`)
+
+	handler.CancelAllOrders(c)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "order execution service unavailable", response["error"])
 }

--- a/services/backend-api/internal/api/handlers/agent_control_test.go
+++ b/services/backend-api/internal/api/handlers/agent_control_test.go
@@ -297,6 +297,36 @@ func TestAgentControlHandler_EngageKillSwitch_Success(t *testing.T) {
 	response := decodeResponseBody(t, w.Body.Bytes())
 	assert.Equal(t, "ok", response["status"])
 	assert.Equal(t, "kill_switch", response["action"])
+	assert.Equal(t, true, response["engage"])
+	assert.True(t, riskController.killSwitchEngaged)
+}
+
+func TestAgentControlHandler_EngageKillSwitch_Disengage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	riskController := &mockRiskController{killSwitchEngaged: true}
+	handler := NewAgentControlHandler(AgentControlDeps{Risk: riskController})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/kill-switch", `{"engage":false}`)
+
+	handler.EngageKillSwitch(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "ok", response["status"])
+	assert.Equal(t, false, response["engage"])
+	assert.False(t, riskController.killSwitchEngaged)
+}
+
+func TestAgentControlHandler_EngageKillSwitch_NilEngageDefaultsToTrue(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	riskController := &mockRiskController{}
+	handler := NewAgentControlHandler(AgentControlDeps{Risk: riskController})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/kill-switch", `{}`)
+
+	handler.EngageKillSwitch(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, true, response["engage"])
 	assert.True(t, riskController.killSwitchEngaged)
 }
 
@@ -316,7 +346,7 @@ func TestAgentControlHandler_CancelAllOrders_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	orders := &mockOrderController{}
 	handler := NewAgentControlHandler(AgentControlDeps{Orders: orders})
-	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/cancel-all-orders", `{"exchange_id":"binance","scope":"BTC/USDT"}`)
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/cancel-all-orders", `{"exchange_id":"binance","symbol":"BTC/USDT"}`)
 
 	handler.CancelAllOrders(c)
 
@@ -324,7 +354,7 @@ func TestAgentControlHandler_CancelAllOrders_Success(t *testing.T) {
 	response := decodeResponseBody(t, w.Body.Bytes())
 	assert.Equal(t, "ok", response["status"])
 	assert.Equal(t, "cancel_all_orders", response["action"])
-	assert.Equal(t, "BTC/USDT", response["scope"])
+	assert.Equal(t, "BTC/USDT", response["symbol"])
 	assert.True(t, orders.cancelled)
 }
 
@@ -338,4 +368,44 @@ func TestAgentControlHandler_CancelAllOrders_ServiceUnavailable(t *testing.T) {
 	require.Equal(t, http.StatusServiceUnavailable, w.Code)
 	response := decodeResponseBody(t, w.Body.Bytes())
 	assert.Equal(t, "order execution service unavailable", response["error"])
+}
+
+func TestAgentControlHandler_ResumeExchange_MissingExchangeID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewAgentControlHandler(AgentControlDeps{Collector: &mockCollectorController{}})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/resume-exchange", `{}`)
+
+	handler.ResumeExchange(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "exchange_id is required", response["error"])
+}
+
+func TestAgentControlHandler_DisableSafeMode_Error(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	riskController := &mockRiskController{err: errors.New("safe mode unavailable")}
+	handler := NewAgentControlHandler(AgentControlDeps{Risk: riskController})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/disable-safe-mode", `{}`)
+
+	handler.DisableSafeMode(c)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "safe mode unavailable", response["error"])
+	assert.Equal(t, "disable_safe_mode", response["action"])
+}
+
+func TestAgentControlHandler_CancelAllOrders_Error(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	orders := &mockOrderController{err: errors.New("exchange unreachable")}
+	handler := NewAgentControlHandler(AgentControlDeps{Orders: orders})
+	c, w := makeJSONContext(http.MethodPost, "/api/v1/agent/cancel-all-orders", `{"exchange_id":"binance","symbol":"BTC/USDT"}`)
+
+	handler.CancelAllOrders(c)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	response := decodeResponseBody(t, w.Body.Bytes())
+	assert.Equal(t, "exchange unreachable", response["error"])
+	assert.Equal(t, "cancel_all_orders", response["action"])
 }

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -1068,7 +1068,12 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		log.Printf("WARNING: OperationalModeService is nil, trading mode endpoints disabled")
 	}
 
-	agentControlHandler := handlers.NewAgentControlHandler(integratedHandlers.AutonomyCoordinator())
+	agentControlHandler := handlers.NewAgentControlHandler(handlers.AgentControlDeps{
+		Autonomy:  integratedHandlers.AutonomyCoordinator(),
+		Collector: handlers.NewCollectorController(collectorService),
+		Risk:      handlers.NewRiskControllerAdapter(),
+		Orders:    handlers.NewOrderController(ccxtService),
+	})
 	shadowHandler := handlers.NewShadowHandler(integratedHandlers.ShadowEvaluationCoordinator())
 
 	// API v1 routes with telemetry

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -18,6 +18,7 @@ import (
 	"github.com/irfndi/neuratrade/internal/ai/llm"
 	"github.com/irfndi/neuratrade/internal/api/handlers"
 	autonomyruntime "github.com/irfndi/neuratrade/internal/app/autonomy/runtime"
+	apprisk "github.com/irfndi/neuratrade/internal/app/risk"
 	"github.com/irfndi/neuratrade/internal/ccxt"
 	"github.com/irfndi/neuratrade/internal/config"
 	"github.com/irfndi/neuratrade/internal/database"
@@ -1068,10 +1069,16 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		log.Printf("WARNING: OperationalModeService is nil, trading mode endpoints disabled")
 	}
 
+	// Shared risk state instances — created once so that operator API changes
+	// (enable-safe-mode, kill-switch) propagate to the policy engine and
+	// order-blocking enforcement.
+	sharedKillSwitch := apprisk.NewKillSwitch()
+	sharedSafeMode := apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
+
 	agentControlHandler := handlers.NewAgentControlHandler(handlers.AgentControlDeps{
 		Autonomy:  integratedHandlers.AutonomyCoordinator(),
 		Collector: handlers.NewCollectorController(collectorService),
-		Risk:      handlers.NewRiskControllerAdapter(),
+		Risk:      handlers.NewRiskControllerAdapter(sharedKillSwitch, sharedSafeMode),
 		Orders:    handlers.NewOrderController(ccxtService),
 	})
 	shadowHandler := handlers.NewShadowHandler(integratedHandlers.ShadowEvaluationCoordinator())

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -1069,9 +1069,6 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		log.Printf("WARNING: OperationalModeService is nil, trading mode endpoints disabled")
 	}
 
-	// Shared risk state instances — created once so that operator API changes
-	// (enable-safe-mode, kill-switch) propagate to the policy engine and
-	// order-blocking enforcement.
 	sharedKillSwitch := apprisk.NewKillSwitch()
 	sharedSafeMode := apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
 

--- a/services/backend-api/internal/services/collector_service.go
+++ b/services/backend-api/internal/services/collector_service.go
@@ -453,6 +453,9 @@ func (c *CollectorService) PauseExchange(exchangeID string) error {
 	if !ok {
 		return fmt.Errorf("exchange %q not found", exchangeID)
 	}
+	if !worker.IsRunning {
+		return fmt.Errorf("exchange %q worker is not running; nothing to pause", exchangeID)
+	}
 	worker.Paused = true
 	c.logger.WithFields(map[string]interface{}{"exchange": exchangeID}).Info("Exchange collection paused")
 	return nil

--- a/services/backend-api/internal/services/collector_service.go
+++ b/services/backend-api/internal/services/collector_service.go
@@ -445,6 +445,32 @@ func (c *CollectorService) Stop() {
 	c.logger.Info("Market data collector service stopped")
 }
 
+func (c *CollectorService) PauseExchange(exchangeID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	worker, ok := c.workers[exchangeID]
+	if !ok {
+		return fmt.Errorf("exchange %q not found", exchangeID)
+	}
+	worker.Paused = true
+	c.logger.Info("Exchange collection paused", "exchange", exchangeID)
+	return nil
+}
+
+func (c *CollectorService) ResumeExchange(exchangeID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	worker, ok := c.workers[exchangeID]
+	if !ok {
+		return fmt.Errorf("exchange %q not found", exchangeID)
+	}
+	worker.Paused = false
+	c.logger.Info("Exchange collection resumed", "exchange", exchangeID)
+	return nil
+}
+
 // IsInitialized returns true if the collector service has been initialized.
 //
 // Returns:

--- a/services/backend-api/internal/services/collector_service.go
+++ b/services/backend-api/internal/services/collector_service.go
@@ -466,6 +466,9 @@ func (c *CollectorService) ResumeExchange(exchangeID string) error {
 	if !ok {
 		return fmt.Errorf("exchange %q not found", exchangeID)
 	}
+	if !worker.IsRunning {
+		return fmt.Errorf("exchange %q worker is not running; use restart instead", exchangeID)
+	}
 	worker.Paused = false
 	c.logger.WithFields(map[string]interface{}{"exchange": exchangeID}).Info("Exchange collection resumed")
 	return nil

--- a/services/backend-api/internal/services/collector_service.go
+++ b/services/backend-api/internal/services/collector_service.go
@@ -454,7 +454,7 @@ func (c *CollectorService) PauseExchange(exchangeID string) error {
 		return fmt.Errorf("exchange %q not found", exchangeID)
 	}
 	worker.Paused = true
-	c.logger.Info("Exchange collection paused", "exchange", exchangeID)
+	c.logger.WithFields(map[string]interface{}{"exchange": exchangeID}).Info("Exchange collection paused")
 	return nil
 }
 
@@ -467,7 +467,7 @@ func (c *CollectorService) ResumeExchange(exchangeID string) error {
 		return fmt.Errorf("exchange %q not found", exchangeID)
 	}
 	worker.Paused = false
-	c.logger.Info("Exchange collection resumed", "exchange", exchangeID)
+	c.logger.WithFields(map[string]interface{}{"exchange": exchangeID}).Info("Exchange collection resumed")
 	return nil
 }
 

--- a/services/backend-api/internal/services/collector_types.go
+++ b/services/backend-api/internal/services/collector_types.go
@@ -137,7 +137,9 @@ type Worker struct {
 	ErrorCount int
 	// MaxErrors is the maximum allowed consecutive errors.
 	MaxErrors int
-	Paused    bool
+	// Paused indicates whether the worker is temporarily paused;
+	// when true the collection loop skips ticks but preserves worker state.
+	Paused bool
 }
 
 // BackfillJob represents a single symbol backfill task

--- a/services/backend-api/internal/services/collector_types.go
+++ b/services/backend-api/internal/services/collector_types.go
@@ -137,6 +137,7 @@ type Worker struct {
 	ErrorCount int
 	// MaxErrors is the maximum allowed consecutive errors.
 	MaxErrors int
+	Paused    bool
 }
 
 // BackfillJob represents a single symbol backfill task

--- a/services/backend-api/internal/services/collector_worker.go
+++ b/services/backend-api/internal/services/collector_worker.go
@@ -181,6 +181,14 @@ func (c *CollectorService) runWorker(worker *Worker) {
 			}
 			c.logger.WithFields(map[string]interface{}{"exchange": worker.Exchange}).Info("Resource optimization triggered")
 		case <-ticker.C:
+			c.mu.RLock()
+			paused := worker.Paused
+			c.mu.RUnlock()
+			if paused {
+				c.logger.WithFields(map[string]interface{}{"exchange": worker.Exchange}).Info("Worker paused, skipping collection cycle")
+				continue
+			}
+
 			c.logger.WithFields(map[string]interface{}{"exchange": worker.Exchange}).Info("Worker tick - starting collection cycle")
 
 			// Create operation context with timeout


### PR DESCRIPTION
## Summary

Closes #252

Replaces 5 placeholder agent-control handler acknowledgements with real service invocations, ensuring operator commands reach the intended backend subsystems.

## Changes

### Collector Service (pause/resume)
- Added `Paused bool` field to `Worker` struct
- Added `PauseExchange()` and `ResumeExchange()` methods to `CollectorService` that toggle per-worker paused state
- Worker collection loop now skips tick when paused

### Handler Wiring
- Defined `CollectorController`, `RiskController`, `OrderController` interfaces for dependency injection
- Refactored `AgentControlHandler` to accept `AgentControlDeps` with all service dependencies
- Wired 5 handlers to real services:
  - **PauseExchange** → `CollectorService.PauseExchange()`
  - **ResumeExchange** → `CollectorService.ResumeExchange()`
  - **EnableSafeMode** → `SafeModeImpl.EnableWithReason()`
  - **DisableSafeMode** → `SafeModeImpl.Disable()`
  - **EngageKillSwitch** → `KillSwitchImpl.Engage()`
  - **CancelAllOrders** → CCXT adapter (fetch open orders → cancel each)

### Error Handling
- 400 for invalid/missing input
- 503 when required service is unavailable
- 500 with actionable error message when downstream operation fails

### Adapters
- `agent_control_adapters.go`: factory functions wrapping concrete service types behind interfaces
- Order adapter handles both single-exchange and all-exchange cancellation

### Tests
- 12 new test cases covering success, validation, and failure paths for all wired handlers
- Updated existing strategy-mode tests for new constructor signature
- Total: 14 agent-control tests passing

## Acceptance Criteria (from #252)

- [x] agent-control endpoints invoke the correct collector, risk, and execution paths
- [x] success responses only occur when the requested action was actually applied
- [x] failure modes return actionable errors
- [x] tests cover the service wiring for all currently stubbed control handlers

## Summary by Sourcery

Wire agent-control endpoints to concrete collector, risk, and order execution services and introduce pause/resume support in the market data collector.

New Features:
- Add ability to pause and resume market data collection per exchange via the collector service and worker state.

Enhancements:
- Inject collector, risk, and order execution dependencies into AgentControlHandler behind controller interfaces and adapters.
- Implement real backend calls and structured error handling for pause/resume exchange, safe-mode, kill-switch, and cancel-all-orders endpoints.

Tests:
- Add comprehensive tests for agent-control endpoints covering success, validation, service-unavailable, and downstream-error scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exchange pause/resume, safe mode, kill switch (engage/disengage with engage=false supported), and cancel-all-orders controls; cancel can target a specific symbol and responses include the symbol.
* **Bug Fixes / Reliability**
  * Required-field validation, clearer service-unavailable and error mappings, and improved action logging.
* **Behavior**
  * Collector workers honor a pause state and skip collection cycles when paused.
* **Tests**
  * Expanded endpoint tests for success, missing inputs, unavailable services, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->