### PR TITLE
feat(scalping): persist portfolio performance snapshots

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -7,6 +7,7 @@ bd.sock
 bd.sock.startlock
 sync-state.json
 last-touched
+.beads-credential-key
 
 # Local version tracking (prevents upgrade notification spam after git ops)
 .local_version

--- a/.beads/export-state.json
+++ b/.beads/export-state.json
@@ -1,0 +1,1 @@
+{"last_dolt_commit":"8mlofrhhhr9h9nma71m970p2i3nck862","timestamp":"2026-04-22T18:23:54.697264+07:00","issues":389,"memories":0}

--- a/services/backend-api/database/migrations/080_create_scalping_portfolio_snapshots.sql
+++ b/services/backend-api/database/migrations/080_create_scalping_portfolio_snapshots.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS scalping_portfolio_snapshots (
+    id TEXT PRIMARY KEY,
+    chat_id TEXT,
+    exchange TEXT,
+    snapshot_at TIMESTAMP NOT NULL,
+    usdt_balance NUMERIC NOT NULL DEFAULT 0,
+    total_value NUMERIC NOT NULL DEFAULT 0,
+    open_positions INT NOT NULL DEFAULT 0,
+    unrealized_pnl NUMERIC NOT NULL DEFAULT 0,
+    current_drawdown NUMERIC NOT NULL DEFAULT 0,
+    risk_sharpe NUMERIC NOT NULL DEFAULT 0,
+    risk_sortino NUMERIC NOT NULL DEFAULT 0,
+    risk_drawdown NUMERIC NOT NULL DEFAULT 0,
+    risk_max_drawdown NUMERIC NOT NULL DEFAULT 0,
+    risk_expectancy NUMERIC NOT NULL DEFAULT 0,
+    risk_expectancy_gross NUMERIC NOT NULL DEFAULT 0,
+    risk_fee_drag_expectancy NUMERIC NOT NULL DEFAULT 0,
+    risk_sample_size INT NOT NULL DEFAULT 0,
+    strategy_phase TEXT,
+    account_tier TEXT,
+    recent_consecutive_losses INT NOT NULL DEFAULT 0,
+    recovery_mode TEXT,
+    drift_active BOOLEAN NOT NULL DEFAULT FALSE,
+    no_fill_minutes NUMERIC NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_scalping_portfolio_snapshots_chat_time
+    ON scalping_portfolio_snapshots(chat_id, snapshot_at DESC);
+CREATE INDEX IF NOT EXISTS idx_scalping_portfolio_snapshots_exchange_time
+    ON scalping_portfolio_snapshots(exchange, snapshot_at DESC);

--- a/services/backend-api/database/sqlite_migrations/080_create_scalping_portfolio_snapshots.sql
+++ b/services/backend-api/database/sqlite_migrations/080_create_scalping_portfolio_snapshots.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS scalping_portfolio_snapshots (
+    id TEXT PRIMARY KEY,
+    chat_id TEXT,
+    exchange TEXT,
+    snapshot_at TIMESTAMP NOT NULL,
+    usdt_balance NUMERIC NOT NULL DEFAULT 0,
+    total_value NUMERIC NOT NULL DEFAULT 0,
+    open_positions INT NOT NULL DEFAULT 0,
+    unrealized_pnl NUMERIC NOT NULL DEFAULT 0,
+    current_drawdown NUMERIC NOT NULL DEFAULT 0,
+    risk_sharpe NUMERIC NOT NULL DEFAULT 0,
+    risk_sortino NUMERIC NOT NULL DEFAULT 0,
+    risk_drawdown NUMERIC NOT NULL DEFAULT 0,
+    risk_max_drawdown NUMERIC NOT NULL DEFAULT 0,
+    risk_expectancy NUMERIC NOT NULL DEFAULT 0,
+    risk_expectancy_gross NUMERIC NOT NULL DEFAULT 0,
+    risk_fee_drag_expectancy NUMERIC NOT NULL DEFAULT 0,
+    risk_sample_size INT NOT NULL DEFAULT 0,
+    strategy_phase TEXT,
+    account_tier TEXT,
+    recent_consecutive_losses INT NOT NULL DEFAULT 0,
+    recovery_mode TEXT,
+    drift_active BOOLEAN NOT NULL DEFAULT FALSE,
+    no_fill_minutes NUMERIC NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_scalping_portfolio_snapshots_chat_time
+    ON scalping_portfolio_snapshots(chat_id, snapshot_at DESC);
+CREATE INDEX IF NOT EXISTS idx_scalping_portfolio_snapshots_exchange_time
+    ON scalping_portfolio_snapshots(exchange, snapshot_at DESC);

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -665,6 +665,7 @@ type TradingPortfolio struct {
 	TotalValueDecimal               decimal.Decimal  `json:"-"`
 	OpenPositions                   int              `json:"open_positions"`
 	UnrealizedPnL                   float64          `json:"unrealized_pnl"`
+	UnrealizedPnLDecimal            decimal.Decimal  `json:"-"`
 	CurrentDrawdown                 float64          `json:"current_drawdown"`
 	RiskSharpe                      float64          `json:"risk_sharpe"`
 	RiskSortino                     float64          `json:"risk_sortino"`

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -2516,6 +2516,60 @@ func (h *IntegratedQuestHandlers) enrichPortfolioControlPlane(
 		quest.Checkpoint["phase_max_capital_pct"] = portfolio.PhaseMaxCapitalPct
 		quest.Checkpoint["milestone_progress_pct"] = portfolio.MilestoneProgress
 	}
+
+	h.recordScalpingPortfolioSnapshot(ctx, chatID, exchange, *portfolio)
+}
+
+func (h *IntegratedQuestHandlers) recordScalpingPortfolioSnapshot(
+	ctx context.Context,
+	chatID, exchange string,
+	portfolio TradingPortfolio,
+) {
+	if h == nil || h.lifecycleStore == nil {
+		return
+	}
+	totalValue := portfolio.TotalValueDecimal
+	if totalValue.LessThanOrEqual(decimal.Zero) {
+		totalValue = finiteDecimalFromFloat(portfolio.TotalValue)
+	}
+	usdtBalance := portfolio.USDTBalanceDecimal
+	if usdtBalance.LessThanOrEqual(decimal.Zero) {
+		usdtBalance = finiteDecimalFromFloat(portfolio.USDTBalance)
+	}
+	err := h.lifecycleStore.RecordScalpingPortfolioSnapshot(ctx, ScalpingPortfolioSnapshotRecord{
+		ChatID:                  chatID,
+		Exchange:                exchange,
+		SnapshotAt:              time.Now().UTC(),
+		USDTBalance:             usdtBalance,
+		TotalValue:              totalValue,
+		OpenPositions:           portfolio.OpenPositions,
+		UnrealizedPnL:           finiteDecimalFromFloat(portfolio.UnrealizedPnL),
+		CurrentDrawdown:         finiteDecimalFromFloat(portfolio.CurrentDrawdown),
+		RiskSharpe:              finiteDecimalFromFloat(portfolio.RiskSharpe),
+		RiskSortino:             finiteDecimalFromFloat(portfolio.RiskSortino),
+		RiskDrawdown:            finiteDecimalFromFloat(portfolio.RiskDrawdown),
+		RiskMaxDrawdown:         finiteDecimalFromFloat(portfolio.RiskMaxDrawdown),
+		RiskExpectancy:          finiteDecimalFromFloat(portfolio.RiskExpectancy),
+		RiskExpectancyGross:     finiteDecimalFromFloat(portfolio.RiskExpectancyGross),
+		RiskFeeDragExpectancy:   finiteDecimalFromFloat(portfolio.RiskFeeDragExpectancy),
+		RiskSampleSize:          portfolio.RiskSampleSize,
+		StrategyPhase:           portfolio.StrategyPhase,
+		AccountTier:             portfolio.AccountTier,
+		RecentConsecutiveLosses: portfolio.RecentConsecutiveLosses,
+		RecoveryMode:            portfolio.RecoveryMode,
+		DriftActive:             portfolio.DriftActive,
+		NoFillMinutes:           finiteDecimalFromFloat(portfolio.NoFillMinutes),
+	})
+	if err != nil {
+		log.Printf("[SCALPING] Portfolio snapshot persist failed for chat %s exchange %s: %v", chatID, exchange, err)
+	}
+}
+
+func finiteDecimalFromFloat(value float64) decimal.Decimal {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return decimal.Zero
+	}
+	return decimal.NewFromFloat(value)
 }
 
 func oppositeCloseSide(positionSide string) string {

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -886,6 +886,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		recoveryState = h.evaluateRecoveryGateStateForScope(ctx, quest, portfolio, chatID, userExchange)
 		h.applyRecoveryStateCheckpoint(quest, &portfolio, recoveryState, time.Now().UTC())
 	}
+	h.recordScalpingPortfolioSnapshot(ctx, chatID, userExchange, portfolio)
 
 	log.Printf("[SCALPING] Portfolio: %.2f USDT available", usdtBalance)
 
@@ -2370,6 +2371,7 @@ func (h *IntegratedQuestHandlers) enrichPortfolioControlPlane(
 				unrealized = unrealized.Add(pos.UnrealizedPnL)
 			}
 			portfolio.UnrealizedPnL = unrealized.InexactFloat64()
+			portfolio.UnrealizedPnLDecimal = unrealized
 			portfolio.TotalValue = portfolio.USDTBalance + portfolio.UnrealizedPnL
 			portfolio.TotalValueDecimal = portfolio.USDTBalanceDecimal.Add(unrealized)
 			if quest != nil {
@@ -2516,8 +2518,6 @@ func (h *IntegratedQuestHandlers) enrichPortfolioControlPlane(
 		quest.Checkpoint["phase_max_capital_pct"] = portfolio.PhaseMaxCapitalPct
 		quest.Checkpoint["milestone_progress_pct"] = portfolio.MilestoneProgress
 	}
-
-	h.recordScalpingPortfolioSnapshot(ctx, chatID, exchange, *portfolio)
 }
 
 func (h *IntegratedQuestHandlers) recordScalpingPortfolioSnapshot(
@@ -2536,6 +2536,10 @@ func (h *IntegratedQuestHandlers) recordScalpingPortfolioSnapshot(
 	if usdtBalance.LessThanOrEqual(decimal.Zero) {
 		usdtBalance = finiteDecimalFromFloat(portfolio.USDTBalance)
 	}
+	unrealizedPnL := portfolio.UnrealizedPnLDecimal
+	if unrealizedPnL.IsZero() && portfolio.UnrealizedPnL != 0 {
+		unrealizedPnL = finiteDecimalFromFloat(portfolio.UnrealizedPnL)
+	}
 	err := h.lifecycleStore.RecordScalpingPortfolioSnapshot(ctx, ScalpingPortfolioSnapshotRecord{
 		ChatID:                  chatID,
 		Exchange:                exchange,
@@ -2543,7 +2547,7 @@ func (h *IntegratedQuestHandlers) recordScalpingPortfolioSnapshot(
 		USDTBalance:             usdtBalance,
 		TotalValue:              totalValue,
 		OpenPositions:           portfolio.OpenPositions,
-		UnrealizedPnL:           finiteDecimalFromFloat(portfolio.UnrealizedPnL),
+		UnrealizedPnL:           unrealizedPnL,
 		CurrentDrawdown:         finiteDecimalFromFloat(portfolio.CurrentDrawdown),
 		RiskSharpe:              finiteDecimalFromFloat(portfolio.RiskSharpe),
 		RiskSortino:             finiteDecimalFromFloat(portfolio.RiskSortino),

--- a/services/backend-api/internal/services/trading_lifecycle_store.go
+++ b/services/backend-api/internal/services/trading_lifecycle_store.go
@@ -72,18 +72,50 @@ type ManagedOpenPosition struct {
 }
 
 type LifecyclePerformanceSummary struct {
-	Trades      int
-	Wins        int
-	Losses      int
-	Breakeven   int
-	RealizedPnL decimal.Decimal
-	BestTrade   decimal.Decimal
-	WorstTrade  decimal.Decimal
+	Trades         int
+	Wins           int
+	Losses         int
+	Breakeven      int
+	RealizedPnL    decimal.Decimal
+	GrossPnL       decimal.Decimal
+	Fees           decimal.Decimal
+	AvgNetPnL      decimal.Decimal
+	WinRate        decimal.Decimal
+	FeeDragPct     decimal.Decimal
+	BestTrade      decimal.Decimal
+	WorstTrade     decimal.Decimal
+	AvgGrossPnL    decimal.Decimal
+	AvgFeePerTrade decimal.Decimal
 }
 
 type RecentLossStreakSummary struct {
 	ConsecutiveLosses int
 	LastTradeAt       time.Time
+}
+
+type ScalpingPortfolioSnapshotRecord struct {
+	ChatID                  string
+	Exchange                string
+	SnapshotAt              time.Time
+	USDTBalance             decimal.Decimal
+	TotalValue              decimal.Decimal
+	OpenPositions           int
+	UnrealizedPnL           decimal.Decimal
+	CurrentDrawdown         decimal.Decimal
+	RiskSharpe              decimal.Decimal
+	RiskSortino             decimal.Decimal
+	RiskDrawdown            decimal.Decimal
+	RiskMaxDrawdown         decimal.Decimal
+	RiskExpectancy          decimal.Decimal
+	RiskExpectancyGross     decimal.Decimal
+	RiskFeeDragExpectancy   decimal.Decimal
+	RiskSampleSize          int
+	StrategyPhase           string
+	AccountTier             string
+	RecentConsecutiveLosses int
+	RecoveryMode            string
+	DriftActive             bool
+	NoFillMinutes           decimal.Decimal
 }
 
 type LifecycleExchangeSnapshot struct {
@@ -179,6 +211,32 @@ func (s *TradingLifecycleStore) EnsureSchema(ctx context.Context) error {
 			closed_at TIMESTAMP NOT NULL,
 			created_at TIMESTAMP NOT NULL
 		)`,
+		`CREATE TABLE IF NOT EXISTS scalping_portfolio_snapshots (
+			id TEXT PRIMARY KEY,
+			chat_id TEXT,
+			exchange TEXT,
+			snapshot_at TIMESTAMP NOT NULL,
+			usdt_balance NUMERIC NOT NULL DEFAULT 0,
+			total_value NUMERIC NOT NULL DEFAULT 0,
+			open_positions INT NOT NULL DEFAULT 0,
+			unrealized_pnl NUMERIC NOT NULL DEFAULT 0,
+			current_drawdown NUMERIC NOT NULL DEFAULT 0,
+			risk_sharpe NUMERIC NOT NULL DEFAULT 0,
+			risk_sortino NUMERIC NOT NULL DEFAULT 0,
+			risk_drawdown NUMERIC NOT NULL DEFAULT 0,
+			risk_max_drawdown NUMERIC NOT NULL DEFAULT 0,
+			risk_expectancy NUMERIC NOT NULL DEFAULT 0,
+			risk_expectancy_gross NUMERIC NOT NULL DEFAULT 0,
+			risk_fee_drag_expectancy NUMERIC NOT NULL DEFAULT 0,
+			risk_sample_size INT NOT NULL DEFAULT 0,
+			strategy_phase TEXT,
+			account_tier TEXT,
+			recent_consecutive_losses INT NOT NULL DEFAULT 0,
+			recovery_mode TEXT,
+			drift_active BOOLEAN NOT NULL DEFAULT FALSE,
+			no_fill_minutes NUMERIC NOT NULL DEFAULT 0,
+			created_at TIMESTAMP NOT NULL
+		)`,
 	}
 	for _, stmt := range statements {
 		if _, err := s.db.Exec(ctx, stmt); err != nil {
@@ -219,6 +277,8 @@ func (s *TradingLifecycleStore) EnsureSchema(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS idx_realized_pnl_journal_chat_closed ON realized_pnl_journal(chat_id, closed_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_realized_pnl_journal_exchange_closed ON realized_pnl_journal(exchange, closed_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_realized_pnl_journal_symbol_closed ON realized_pnl_journal(symbol, closed_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_scalping_portfolio_snapshots_chat_time ON scalping_portfolio_snapshots(chat_id, snapshot_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_scalping_portfolio_snapshots_exchange_time ON scalping_portfolio_snapshots(exchange, snapshot_at DESC)`,
 	}
 	for _, stmt := range indexStatements {
 		if _, err := s.db.Exec(ctx, stmt); err != nil {
@@ -1281,6 +1341,8 @@ func (s *TradingLifecycleStore) GetRealizedPerformance(
 		SELECT
 			COUNT(*),
 			COALESCE(SUM(%[1]s), 0),
+			COALESCE(SUM(realized_pnl), 0),
+			COALESCE(SUM(COALESCE(fees, 0)), 0),
 			COALESCE(SUM(CASE WHEN %[1]s > 0 THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN %[1]s < 0 THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN %[1]s = 0 THEN 1 ELSE 0 END), 0),
@@ -1307,6 +1369,8 @@ func (s *TradingLifecycleStore) GetRealizedPerformance(
 	if err := s.db.QueryRow(ctx, query, args...).Scan(
 		&summary.Trades,
 		&summary.RealizedPnL,
+		&summary.GrossPnL,
+		&summary.Fees,
 		&wins,
 		&losses,
 		&breakeven,
@@ -1321,8 +1385,81 @@ func (s *TradingLifecycleStore) GetRealizedPerformance(
 	if summary.Trades == 0 {
 		summary.BestTrade = decimal.Zero
 		summary.WorstTrade = decimal.Zero
+		return summary, nil
+	}
+	trades := decimal.NewFromInt(int64(summary.Trades))
+	summary.AvgNetPnL = summary.RealizedPnL.Div(trades)
+	summary.AvgGrossPnL = summary.GrossPnL.Div(trades)
+	summary.AvgFeePerTrade = summary.Fees.Div(trades)
+	summary.WinRate = decimal.NewFromInt(int64(summary.Wins)).Div(trades)
+	if summary.GrossPnL.Abs().GreaterThan(decimal.Zero) {
+		summary.FeeDragPct = summary.GrossPnL.Sub(summary.RealizedPnL).Abs().Div(summary.GrossPnL.Abs())
 	}
 	return summary, nil
+}
+
+func (s *TradingLifecycleStore) RecordScalpingPortfolioSnapshot(
+	ctx context.Context,
+	rec ScalpingPortfolioSnapshotRecord,
+) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("lifecycle store unavailable")
+	}
+	snapshotAt := rec.SnapshotAt.UTC()
+	if snapshotAt.IsZero() {
+		snapshotAt = time.Now().UTC()
+	}
+	id := fmt.Sprintf(
+		"scalp-portfolio-%s-%s-%d",
+		safeIDPart(strings.TrimSpace(rec.ChatID)),
+		safeIDPart(strings.TrimSpace(rec.Exchange)),
+		snapshotAt.UnixNano(),
+	)
+	_, err := s.db.Exec(ctx, `
+		INSERT INTO scalping_portfolio_snapshots (
+			id, chat_id, exchange, snapshot_at, usdt_balance, total_value,
+			open_positions, unrealized_pnl, current_drawdown, risk_sharpe,
+			risk_sortino, risk_drawdown, risk_max_drawdown, risk_expectancy,
+			risk_expectancy_gross, risk_fee_drag_expectancy, risk_sample_size,
+			strategy_phase, account_tier, recent_consecutive_losses, recovery_mode,
+			drift_active, no_fill_minutes, created_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,
+			$7,$8,$9,$10,
+			$11,$12,$13,$14,
+			$15,$16,$17,
+			$18,$19,$20,$21,
+			$22,$23,$24
+		)
+	`, id,
+		strings.TrimSpace(rec.ChatID),
+		strings.TrimSpace(rec.Exchange),
+		snapshotAt,
+		rec.USDTBalance,
+		rec.TotalValue,
+		rec.OpenPositions,
+		rec.UnrealizedPnL,
+		rec.CurrentDrawdown,
+		rec.RiskSharpe,
+		rec.RiskSortino,
+		rec.RiskDrawdown,
+		rec.RiskMaxDrawdown,
+		rec.RiskExpectancy,
+		rec.RiskExpectancyGross,
+		rec.RiskFeeDragExpectancy,
+		rec.RiskSampleSize,
+		strings.TrimSpace(rec.StrategyPhase),
+		strings.TrimSpace(rec.AccountTier),
+		rec.RecentConsecutiveLosses,
+		strings.TrimSpace(rec.RecoveryMode),
+		rec.DriftActive,
+		rec.NoFillMinutes,
+		snapshotAt,
+	)
+	if err != nil {
+		return fmt.Errorf("record scalping portfolio snapshot failed: %w", err)
+	}
+	return nil
 }
 
 func (s *TradingLifecycleStore) GetRecentLossStreak(

--- a/services/backend-api/internal/services/trading_lifecycle_store_test.go
+++ b/services/backend-api/internal/services/trading_lifecycle_store_test.go
@@ -222,16 +222,37 @@ func TestTradingLifecycleStore_RecordScalpingPortfolioSnapshot(t *testing.T) {
 	var openPositions int
 	var driftActive bool
 	var riskSampleSize int
+	var usdtBalance decimal.Decimal
+	var riskSharpe decimal.Decimal
+	var noFillMinutes decimal.Decimal
+	var strategyPhase string
+	var snapshotAtDB time.Time
 	err = sqliteDB.QueryRow(ctx, `
-		SELECT total_value, open_positions, drift_active, risk_sample_size
+		SELECT total_value, open_positions, drift_active, risk_sample_size,
+			usdt_balance, risk_sharpe, no_fill_minutes, strategy_phase, snapshot_at
 		FROM scalping_portfolio_snapshots
 		WHERE chat_id = $1 AND exchange = $2
-	`, "chat-1", "bitget").Scan(&totalValue, &openPositions, &driftActive, &riskSampleSize)
+	`, "chat-1", "bitget").Scan(
+		&totalValue,
+		&openPositions,
+		&driftActive,
+		&riskSampleSize,
+		&usdtBalance,
+		&riskSharpe,
+		&noFillMinutes,
+		&strategyPhase,
+		&snapshotAtDB,
+	)
 	require.NoError(t, err)
 	assert.True(t, totalValue.Equal(decimal.RequireFromString("47.98")))
 	assert.Equal(t, 2, openPositions)
 	assert.True(t, driftActive)
 	assert.Equal(t, 57, riskSampleSize)
+	assert.True(t, usdtBalance.Equal(decimal.RequireFromString("48.11")))
+	assert.True(t, riskSharpe.Equal(decimal.RequireFromString("-0.12")))
+	assert.True(t, noFillMinutes.Equal(decimal.RequireFromString("17.5")))
+	assert.Equal(t, "micro", strategyPhase)
+	assert.WithinDuration(t, snapshotAt, snapshotAtDB, time.Second)
 }
 
 func BenchmarkTradingLifecycleStore_GetRealizedPerformance(b *testing.B) {

--- a/services/backend-api/internal/services/trading_lifecycle_store_test.go
+++ b/services/backend-api/internal/services/trading_lifecycle_store_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -173,8 +174,104 @@ func TestTradingLifecycleStore_GetRealizedPerformanceAndOpenOrders(t *testing.T)
 	assert.Equal(t, 1, perf.Losses)
 	assert.Equal(t, 1, perf.Breakeven)
 	assert.True(t, perf.RealizedPnL.Round(6).Equal(decimal.NewFromFloat(0.04)))
+	assert.True(t, perf.GrossPnL.Round(6).Equal(decimal.NewFromFloat(0.07)))
+	assert.True(t, perf.Fees.Round(6).Equal(decimal.NewFromFloat(-0.03)))
+	assert.True(t, perf.AvgNetPnL.Round(6).Equal(decimal.RequireFromString("0.013333")))
+	assert.True(t, perf.WinRate.Round(6).Equal(decimal.RequireFromString("0.333333")))
+	assert.True(t, perf.FeeDragPct.Round(6).Equal(decimal.RequireFromString("0.428571")))
 	assert.True(t, perf.BestTrade.Round(6).Equal(decimal.NewFromFloat(0.14)))
 	assert.True(t, perf.WorstTrade.Round(6).Equal(decimal.NewFromFloat(-0.10)))
+}
+
+func TestTradingLifecycleStore_RecordScalpingPortfolioSnapshot(t *testing.T) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "portfolio-snapshots.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqliteDB.Close() })
+
+	store, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	snapshotAt := time.Now().UTC().Add(-time.Minute)
+	require.NoError(t, store.RecordScalpingPortfolioSnapshot(ctx, ScalpingPortfolioSnapshotRecord{
+		ChatID:                  "chat-1",
+		Exchange:                "bitget",
+		SnapshotAt:              snapshotAt,
+		USDTBalance:             decimal.RequireFromString("48.11"),
+		TotalValue:              decimal.RequireFromString("47.98"),
+		OpenPositions:           2,
+		UnrealizedPnL:           decimal.RequireFromString("-0.13"),
+		CurrentDrawdown:         decimal.RequireFromString("0.0042"),
+		RiskSharpe:              decimal.RequireFromString("-0.12"),
+		RiskSortino:             decimal.RequireFromString("-0.22"),
+		RiskDrawdown:            decimal.RequireFromString("0.0042"),
+		RiskMaxDrawdown:         decimal.RequireFromString("0.009"),
+		RiskExpectancy:          decimal.RequireFromString("-0.0007"),
+		RiskExpectancyGross:     decimal.RequireFromString("0.0002"),
+		RiskFeeDragExpectancy:   decimal.RequireFromString("0.0009"),
+		RiskSampleSize:          57,
+		StrategyPhase:           "micro",
+		AccountTier:             "micro",
+		RecentConsecutiveLosses: 5,
+		RecoveryMode:            "cooldown",
+		DriftActive:             true,
+		NoFillMinutes:           decimal.RequireFromString("17.5"),
+	}))
+
+	var totalValue decimal.Decimal
+	var openPositions int
+	var driftActive bool
+	var riskSampleSize int
+	err = sqliteDB.QueryRow(ctx, `
+		SELECT total_value, open_positions, drift_active, risk_sample_size
+		FROM scalping_portfolio_snapshots
+		WHERE chat_id = $1 AND exchange = $2
+	`, "chat-1", "bitget").Scan(&totalValue, &openPositions, &driftActive, &riskSampleSize)
+	require.NoError(t, err)
+	assert.True(t, totalValue.Equal(decimal.RequireFromString("47.98")))
+	assert.Equal(t, 2, openPositions)
+	assert.True(t, driftActive)
+	assert.Equal(t, 57, riskSampleSize)
+}
+
+func BenchmarkTradingLifecycleStore_GetRealizedPerformance(b *testing.B) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(b.TempDir(), "lifecycle-performance-bench.db"))
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = sqliteDB.Close() })
+
+	store, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(b, err)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for i := 0; i < 1000; i++ {
+		pnl := decimal.RequireFromString("-0.003")
+		if i%5 == 0 {
+			pnl = decimal.RequireFromString("0.012")
+		}
+		require.NoError(b, store.RecordClosedOrder(ctx, LifecycleCloseRecord{
+			OrderID:     "bench-ord-" + strconv.Itoa(i),
+			ChatID:      "chat-1",
+			Exchange:    "bitget",
+			Symbol:      "DOGE/USDT",
+			Side:        "buy",
+			MarketType:  "futures",
+			Filled:      decimal.NewFromInt(10),
+			EntryPrice:  decimal.RequireFromString("0.20"),
+			ExitPrice:   decimal.RequireFromString("0.201"),
+			RealizedPnL: pnl,
+			Fees:        decimal.RequireFromString("-0.001"),
+			Source:      "bench",
+			ClosedAt:    now.Add(-time.Duration(i) * time.Minute),
+		}))
+	}
+
+	since := now.Add(-30 * 24 * time.Hour)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.GetRealizedPerformance(ctx, "chat-1", "bitget", since); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 func TestTradingLifecycleStore_GetRealizedPerformance_ExcludesSyntheticLifecycleCloses(t *testing.T) {


### PR DESCRIPTION
## Summary
- persist per-cycle scalping portfolio snapshots for wallet/equity/drawdown/risk state
- expose gross PnL, fee drag, win rate, and average PnL in lifecycle performance summaries
- add SQLite coverage and a lifecycle performance benchmark

## Tests
- go -C services/backend-api test ./internal/services
- go -C services/backend-api test ./internal/services -run '^$' -bench '^BenchmarkTradingLifecycleStore_GetRealizedPerformance$' -benchtime=1x

## Summary by Sourcery

Introduce persistent storage and recording of scalping portfolio snapshots and enhance lifecycle performance summaries with richer PnL and risk metrics.

New Features:
- Persist scalping portfolio snapshots with wallet, equity, risk, and drawdown state per cycle
- Expose additional lifecycle performance metrics including gross PnL, fees, average PnL, win rate, and fee drag in performance summaries

Enhancements:
- Add schema migrations and indexes for scalping portfolio snapshot storage in Postgres and SQLite
- Extend lifecycle performance computation and storage to support fee-aware analytics and averages

Tests:
- Add unit test for recording scalping portfolio snapshots via the lifecycle store
- Add benchmark for GetRealizedPerformance using SQLite-backed data to measure lifecycle performance query efficiency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portfolio snapshot recording for scalping strategies, capturing comprehensive risk and performance data
  * Enhanced realized performance analytics with additional metrics including gross profit/loss, fees, win rate, and fee drag percentage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->