### PR TITLE
fix: allow paper scalping runtime execution

### DIFF
--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -1408,7 +1408,9 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 				}
 				return decision, nil
 			}
-			if gateState != nil && !gateState.IsOpen {
+			if shouldAllowPaperModeAutonomyExecution(ctx, rolloutState, gateState) {
+				log.Printf("[AI-SCALPING] Paper mode permits simulated execution for %s while rollout stage is paper", scope.StrategyID)
+			} else if gateState != nil && !gateState.IsOpen {
 				reason := strings.Join(gateState.BlockReasons, "; ")
 				if strings.TrimSpace(reason) == "" {
 					reason = "autonomy live gate closed"
@@ -2169,6 +2171,32 @@ func (s *AIScalpingService) executeDecision(ctx context.Context, decision *AITra
 	s.recordSymbolGuardResult(decision.Symbol, nil)
 	log.Printf("[AI-SCALPING] Order placed: %s", orderID)
 	return nil
+}
+
+func shouldAllowPaperModeAutonomyExecution(ctx context.Context, rolloutState *autonomous.RolloutState, gateState *autonomous.GateState) bool {
+	mode, ok := operationalModeFromContext(ctx)
+	if !ok || mode != ModePaper || rolloutState == nil || gateState == nil || gateState.IsOpen {
+		return false
+	}
+	if rolloutState.CurrentStage != autonomous.StagePaper || rolloutState.Status != autonomous.StatusActive {
+		return false
+	}
+	if !gateState.Checks.SafeModeOff ||
+		!gateState.Checks.KillSwitchOff ||
+		!gateState.Checks.RiskBudgetAvailable ||
+		!gateState.Checks.ExchangeConnected {
+		return false
+	}
+	if len(gateState.BlockReasons) == 0 {
+		return !gateState.Checks.StrategyLive
+	}
+	for _, reason := range gateState.BlockReasons {
+		lower := strings.ToLower(strings.TrimSpace(reason))
+		if !strings.Contains(lower, "strategy_not_live") || !strings.Contains(lower, "stage: paper") {
+			return false
+		}
+	}
+	return true
 }
 
 func sumDecimalOrderVolume(orders []ccxt.OrderBookEntry, limit int) float64 {

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -2187,8 +2187,11 @@ func shouldAllowPaperModeAutonomyExecution(ctx context.Context, rolloutState *au
 		!gateState.Checks.ExchangeConnected {
 		return false
 	}
+	if gateState.Checks.StrategyLive {
+		return false
+	}
 	if len(gateState.BlockReasons) == 0 {
-		return !gateState.Checks.StrategyLive
+		return true
 	}
 	for _, reason := range gateState.BlockReasons {
 		lower := strings.ToLower(strings.TrimSpace(reason))

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -1792,6 +1792,23 @@ func TestShouldAllowPaperModeAutonomyExecution(t *testing.T) {
 		paperRollout,
 		paperGate,
 	))
+
+	emptyReasonsGate := *paperGate
+	emptyReasonsGate.BlockReasons = nil
+	assert.True(t, shouldAllowPaperModeAutonomyExecution(
+		WithOperationalMode(context.Background(), ModePaper),
+		paperRollout,
+		&emptyReasonsGate,
+	))
+
+	strategyLiveGate := *paperGate
+	strategyLiveGate.Checks.StrategyLive = true
+	assert.False(t, shouldAllowPaperModeAutonomyExecution(
+		WithOperationalMode(context.Background(), ModePaper),
+		paperRollout,
+		&strategyLiveGate,
+	))
+
 	assert.False(t, shouldAllowPaperModeAutonomyExecution(
 		WithOperationalMode(context.Background(), OpModeDry),
 		paperRollout,

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/irfndi/neuratrade/internal/ai/llm"
 	appautonomy "github.com/irfndi/neuratrade/internal/app/autonomy"
+	"github.com/irfndi/neuratrade/internal/autonomous"
 	"github.com/irfndi/neuratrade/internal/ccxt"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -1767,6 +1768,47 @@ func TestAutonomyGateBlockCode_MapsOperatorActionableReasons(t *testing.T) {
 			assert.Equal(t, tc.expected, autonomyGateBlockCode(tc.reason))
 		})
 	}
+}
+
+func TestShouldAllowPaperModeAutonomyExecution(t *testing.T) {
+	paperRollout := &autonomous.RolloutState{
+		CurrentStage: autonomous.StagePaper,
+		Status:       autonomous.StatusActive,
+	}
+	paperGate := &autonomous.GateState{
+		IsOpen:       false,
+		BlockReasons: []string{"strategy_not_live (stage: paper, status: active)"},
+		Checks: autonomous.GateChecks{
+			SafeModeOff:         true,
+			KillSwitchOff:       true,
+			RiskBudgetAvailable: true,
+			ExchangeConnected:   true,
+			StrategyLive:        false,
+		},
+	}
+
+	assert.True(t, shouldAllowPaperModeAutonomyExecution(
+		WithOperationalMode(context.Background(), ModePaper),
+		paperRollout,
+		paperGate,
+	))
+	assert.False(t, shouldAllowPaperModeAutonomyExecution(
+		WithOperationalMode(context.Background(), OpModeDry),
+		paperRollout,
+		paperGate,
+	))
+
+	connectivityBlocked := *paperGate
+	connectivityBlocked.Checks.ExchangeConnected = false
+	connectivityBlocked.BlockReasons = []string{
+		"strategy_not_live (stage: paper, status: active)",
+		"exchange_not_connected",
+	}
+	assert.False(t, shouldAllowPaperModeAutonomyExecution(
+		WithOperationalMode(context.Background(), ModePaper),
+		paperRollout,
+		&connectivityBlocked,
+	))
 }
 
 func TestClassifyExecutionBlockCode_MapsRetryableErrors(t *testing.T) {

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -430,7 +430,7 @@ func (h *IntegratedQuestHandlers) rejectNonLiveModeTransitionWithExposure(ctx co
 	}
 
 	exchange := strings.TrimSpace(scalpingExchangeFromContext(ctx))
-	positions, err := h.lifecycleStore.ListManagedOpenPositions(ctx, chatID, exchange, 20)
+	positions, err := h.lifecycleStore.ListManagedOpenPositions(ctx, chatID, exchange, 0)
 	if err != nil {
 		return fmt.Errorf("check managed positions before non-live transition for %s: %w", strategyID, err)
 	}

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -1561,30 +1561,33 @@ func (h *IntegratedQuestHandlers) persistScalpingExecutionLifecycle(
 		return
 	}
 
-	if h.lifecycleStore == nil {
-		return
+	lifecyclePersisted := false
+	if h.lifecycleStore != nil {
+		entryPrice := decimal.Zero
+		if decision.EntryPrice != nil {
+			entryPrice = *decision.EntryPrice
+		}
+		if err := h.lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
+			OrderID:    decision.OrderID,
+			ChatID:     chatID,
+			Exchange:   userExchange,
+			Symbol:     decision.Symbol,
+			Side:       decision.Action,
+			OrderType:  "market",
+			MarketType: "futures",
+			Amount:     walletBasis(portfolio).Mul(decimal.NewFromFloat(decision.SizePercent)).Div(decimal.NewFromInt(100)).Round(2),
+			EntryPrice: entryPrice,
+			StopLoss:   decimalValueOrZero(decision.StopLoss),
+			TakeProfit: decimalValueOrZero(decision.TakeProfit),
+			Source:     scalpingExecutionLifecycleSource(currentMode),
+			OpenedAt:   time.Now().UTC(),
+		}); err != nil {
+			log.Printf("[SCALPING] Failed to persist execution lifecycle for %s: %v", decision.OrderID, err)
+		} else {
+			lifecyclePersisted = true
+		}
 	}
-
-	entryPrice := decimal.Zero
-	if decision.EntryPrice != nil {
-		entryPrice = *decision.EntryPrice
-	}
-	if err := h.lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
-		OrderID:    decision.OrderID,
-		ChatID:     chatID,
-		Exchange:   userExchange,
-		Symbol:     decision.Symbol,
-		Side:       decision.Action,
-		OrderType:  "market",
-		MarketType: "futures",
-		Amount:     walletBasis(portfolio).Mul(decimal.NewFromFloat(decision.SizePercent)).Div(decimal.NewFromInt(100)).Round(2),
-		EntryPrice: entryPrice,
-		StopLoss:   decimalValueOrZero(decision.StopLoss),
-		TakeProfit: decimalValueOrZero(decision.TakeProfit),
-		Source:     scalpingExecutionLifecycleSource(currentMode),
-		OpenedAt:   time.Now().UTC(),
-	}); err != nil {
-		log.Printf("[SCALPING] Failed to persist execution lifecycle for %s: %v", decision.OrderID, err)
+	if currentMode == ModePaper && !lifecyclePersisted {
 		return
 	}
 

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -1486,39 +1486,9 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 	quest.CurrentCount++
 	quest.Checkpoint["last_scalp_time"] = time.Now().UTC().Format(time.RFC3339)
 	quest.Checkpoint["chat_id"] = chatID
-	if currentMode == OpModeLive && h.lifecycleStore != nil && strings.TrimSpace(decision.OrderID) != "" {
-		entryPrice := decimal.Zero
-		if decision.EntryPrice != nil {
-			entryPrice = *decision.EntryPrice
-		}
-		if err := h.lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
-			OrderID:    decision.OrderID,
-			ChatID:     chatID,
-			Exchange:   userExchange,
-			Symbol:     decision.Symbol,
-			Side:       decision.Action,
-			OrderType:  "market",
-			MarketType: "futures",
-			Amount:     walletBasis(portfolio).Mul(decimal.NewFromFloat(decision.SizePercent)).Div(decimal.NewFromInt(100)),
-			EntryPrice: entryPrice,
-			StopLoss:   decimalValueOrZero(decision.StopLoss),
-			TakeProfit: decimalValueOrZero(decision.TakeProfit),
-			Source:     "autonomous_scalping",
-			OpenedAt:   time.Now().UTC(),
-		}); err != nil {
-			log.Printf("[SCALPING] Failed to persist execution lifecycle for %s: %v", decision.OrderID, err)
-		}
-	}
+	h.persistScalpingExecutionLifecycle(ctx, currentMode, decision, chatID, userExchange, portfolio, telemetryInserted, cycleID)
 	if currentMode == OpModeLive {
 		h.recordTradeDecision(ctx, quest, decision, userExchange, portfolio)
-	}
-	if currentMode == OpModeLive && h.telemetryStore != nil && telemetryInserted && strings.TrimSpace(decision.OrderID) != "" {
-		writeCtx, writeCancel := telemetryWriteContext()
-		err := h.telemetryStore.LinkOrderToCycle(writeCtx, cycleID, strings.TrimSpace(decision.OrderID))
-		writeCancel()
-		if err != nil {
-			log.Printf("[TELEMETRY] Failed to link order %s to cycle: %v", decision.OrderID, err)
-		}
 	}
 	if currentMode == OpModeLive {
 		h.ingestClosedOrderFeedback(ctx, quest, userExchange, decision.Symbol)
@@ -1544,6 +1514,59 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 	}
 
 	return nil
+}
+
+func shouldPersistScalpingExecutionLifecycle(mode OperationalMode) bool {
+	return mode == OpModeLive || mode == ModePaper
+}
+
+func (h *IntegratedQuestHandlers) persistScalpingExecutionLifecycle(
+	ctx context.Context,
+	currentMode OperationalMode,
+	decision *AITradingDecision,
+	chatID string,
+	userExchange string,
+	portfolio TradingPortfolio,
+	telemetryInserted bool,
+	cycleID string,
+) {
+	if decision == nil || !shouldPersistScalpingExecutionLifecycle(currentMode) || strings.TrimSpace(decision.OrderID) == "" {
+		return
+	}
+
+	if h.lifecycleStore != nil {
+		entryPrice := decimal.Zero
+		if decision.EntryPrice != nil {
+			entryPrice = *decision.EntryPrice
+		}
+		if err := h.lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
+			OrderID:    decision.OrderID,
+			ChatID:     chatID,
+			Exchange:   userExchange,
+			Symbol:     decision.Symbol,
+			Side:       decision.Action,
+			OrderType:  "market",
+			MarketType: "futures",
+			Amount:     walletBasis(portfolio).Mul(decimal.NewFromFloat(decision.SizePercent)).Div(decimal.NewFromInt(100)),
+			EntryPrice: entryPrice,
+			StopLoss:   decimalValueOrZero(decision.StopLoss),
+			TakeProfit: decimalValueOrZero(decision.TakeProfit),
+			Source:     "autonomous_scalping",
+			OpenedAt:   time.Now().UTC(),
+		}); err != nil {
+			log.Printf("[SCALPING] Failed to persist execution lifecycle for %s: %v", decision.OrderID, err)
+		}
+	}
+
+	if h.telemetryStore == nil || !telemetryInserted {
+		return
+	}
+	writeCtx, writeCancel := telemetryWriteContext()
+	err := h.telemetryStore.LinkOrderToCycle(writeCtx, cycleID, strings.TrimSpace(decision.OrderID))
+	writeCancel()
+	if err != nil {
+		log.Printf("[TELEMETRY] Failed to link order %s to cycle: %v", decision.OrderID, err)
+	}
 }
 
 func (h *IntegratedQuestHandlers) autoDeriskBlockedExposure(

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -1534,28 +1534,31 @@ func (h *IntegratedQuestHandlers) persistScalpingExecutionLifecycle(
 		return
 	}
 
-	if h.lifecycleStore != nil {
-		entryPrice := decimal.Zero
-		if decision.EntryPrice != nil {
-			entryPrice = *decision.EntryPrice
-		}
-		if err := h.lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
-			OrderID:    decision.OrderID,
-			ChatID:     chatID,
-			Exchange:   userExchange,
-			Symbol:     decision.Symbol,
-			Side:       decision.Action,
-			OrderType:  "market",
-			MarketType: "futures",
-			Amount:     walletBasis(portfolio).Mul(decimal.NewFromFloat(decision.SizePercent)).Div(decimal.NewFromInt(100)),
-			EntryPrice: entryPrice,
-			StopLoss:   decimalValueOrZero(decision.StopLoss),
-			TakeProfit: decimalValueOrZero(decision.TakeProfit),
-			Source:     "autonomous_scalping",
-			OpenedAt:   time.Now().UTC(),
-		}); err != nil {
-			log.Printf("[SCALPING] Failed to persist execution lifecycle for %s: %v", decision.OrderID, err)
-		}
+	if h.lifecycleStore == nil {
+		return
+	}
+
+	entryPrice := decimal.Zero
+	if decision.EntryPrice != nil {
+		entryPrice = *decision.EntryPrice
+	}
+	if err := h.lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
+		OrderID:    decision.OrderID,
+		ChatID:     chatID,
+		Exchange:   userExchange,
+		Symbol:     decision.Symbol,
+		Side:       decision.Action,
+		OrderType:  "market",
+		MarketType: "futures",
+		Amount:     walletBasis(portfolio).Mul(decimal.NewFromFloat(decision.SizePercent)).Div(decimal.NewFromInt(100)).Round(2),
+		EntryPrice: entryPrice,
+		StopLoss:   decimalValueOrZero(decision.StopLoss),
+		TakeProfit: decimalValueOrZero(decision.TakeProfit),
+		Source:     "autonomous_scalping",
+		OpenedAt:   time.Now().UTC(),
+	}); err != nil {
+		log.Printf("[SCALPING] Failed to persist execution lifecycle for %s: %v", decision.OrderID, err)
+		return
 	}
 
 	if h.telemetryStore == nil || !telemetryInserted {

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -434,7 +434,8 @@ func (h *IntegratedQuestHandlers) rejectNonLiveModeTransitionWithExposure(ctx co
 	if err != nil {
 		return fmt.Errorf("check managed positions before non-live transition for %s: %w", strategyID, err)
 	}
-	openOrders, err := h.lifecycleStore.CountOpenOrders(ctx, chatID, exchange)
+	positions = nonPaperManagedPositions(positions)
+	openOrders, err := h.lifecycleStore.CountOpenOrdersExcludingSources(ctx, chatID, exchange, []string{scalpingPaperLifecycleSource})
 	if err != nil {
 		return fmt.Errorf("check open orders before non-live transition for %s: %w", strategyID, err)
 	}
@@ -453,6 +454,32 @@ func (h *IntegratedQuestHandlers) rejectNonLiveModeTransitionWithExposure(ctx co
 		openOrders,
 		targetExchange,
 	)
+}
+
+const (
+	scalpingLifecycleSource      = "autonomous_scalping"
+	scalpingPaperLifecycleSource = "autonomous_scalping_paper"
+)
+
+func scalpingExecutionLifecycleSource(mode OperationalMode) string {
+	if mode == ModePaper {
+		return scalpingPaperLifecycleSource
+	}
+	return scalpingLifecycleSource
+}
+
+func nonPaperManagedPositions(positions []ManagedOpenPosition) []ManagedOpenPosition {
+	if len(positions) == 0 {
+		return positions
+	}
+	filtered := positions[:0]
+	for _, position := range positions {
+		if strings.EqualFold(strings.TrimSpace(position.Source), scalpingPaperLifecycleSource) {
+			continue
+		}
+		filtered = append(filtered, position)
+	}
+	return filtered
 }
 
 // recordQuestResult records quest execution result for monitoring
@@ -1554,7 +1581,7 @@ func (h *IntegratedQuestHandlers) persistScalpingExecutionLifecycle(
 		EntryPrice: entryPrice,
 		StopLoss:   decimalValueOrZero(decision.StopLoss),
 		TakeProfit: decimalValueOrZero(decision.TakeProfit),
-		Source:     "autonomous_scalping",
+		Source:     scalpingExecutionLifecycleSource(currentMode),
 		OpenedAt:   time.Now().UTC(),
 	}); err != nil {
 		log.Printf("[SCALPING] Failed to persist execution lifecycle for %s: %v", decision.OrderID, err)

--- a/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -258,6 +259,73 @@ func TestIntegratedQuestHandlersSyncScalpingStrategyMode_IgnoresPaperLifecycleEx
 	require.NoError(t, err)
 	require.NotNil(t, state)
 	assert.Equal(t, autonomous.StagePaper, state.CurrentStage)
+}
+
+func TestIntegratedQuestHandlersSyncScalpingStrategyMode_DetectsLiveExposureHiddenBehindPaperLimit(t *testing.T) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "rollout-sync-live-hidden-by-paper.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	store := NewAutonomousRolloutStore(sqliteDB.DB)
+	require.NoError(t, store.InitSchema(context.Background()))
+
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	handlers := &IntegratedQuestHandlers{
+		autonomyCoordinator: NewScalpingAutonomyCoordinator(store, AIScalpingConfig{}),
+		lifecycleStore:      lifecycleStore,
+	}
+
+	chatID := "1082762347"
+	ctx := WithScalpingAutonomyScope(context.Background(), ScalpingAutonomyScope{
+		ChatID:     chatID,
+		StrategyID: ScalpingStrategyID(chatID),
+		Exchange:   "bitget",
+	})
+
+	require.NoError(t, handlers.syncScalpingStrategyMode(ctx, chatID, OpModeLive))
+	require.NoError(t, lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
+		OrderID:    "live-hidden-behind-paper",
+		ChatID:     chatID,
+		Exchange:   "bitget",
+		Symbol:     "BTC/USDT",
+		Side:       "buy",
+		OrderType:  "market",
+		MarketType: "futures",
+		Amount:     decimal.NewFromFloat(0.01),
+		EntryPrice: decimal.NewFromFloat(50000),
+		Source:     scalpingLifecycleSource,
+		OpenedAt:   time.Now().UTC().Add(-time.Hour),
+	}))
+	_, err = sqliteDB.DB.ExecContext(ctx, `
+		UPDATE trading_orders
+		SET status = 'closed'
+		WHERE order_id = $1
+	`, "live-hidden-behind-paper")
+	require.NoError(t, err)
+
+	for i := 0; i < 25; i++ {
+		require.NoError(t, lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
+			OrderID:    fmt.Sprintf("paper-ord-hidden-%02d", i),
+			ChatID:     chatID,
+			Exchange:   "bitget",
+			Symbol:     fmt.Sprintf("PAPER%02d/USDT", i),
+			Side:       "buy",
+			OrderType:  "market",
+			MarketType: "futures",
+			Amount:     decimal.NewFromFloat(0.01),
+			EntryPrice: decimal.NewFromFloat(1 + float64(i)),
+			Source:     scalpingPaperLifecycleSource,
+			OpenedAt:   time.Now().UTC(),
+		}))
+	}
+
+	err = handlers.syncScalpingStrategyMode(ctx, chatID, ModePaper)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot switch scalping:1082762347:default to non-live mode")
 }
 
 type syncFailureBalanceFetcher struct{}

--- a/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
@@ -448,3 +448,52 @@ func TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle_LinksPaperOrde
 	require.NoError(t, err)
 	assert.Equal(t, "paper-order-aaa-buy", telemetryOrderID)
 }
+
+func TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle_LinksLiveTelemetryWithoutLifecycleStore(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "live-scalping-telemetry.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	telemetryStore := NewScalpingTelemetryStore(sqliteDB, nil)
+	require.NoError(t, telemetryStore.EnsureSchema(ctx))
+
+	cycleID, err := telemetryStore.InsertCycleRecord(ctx, CycleRecord{
+		ID:         "live-cycle-1",
+		ChatID:     "live-chat",
+		Exchange:   "bitget",
+		CycleAt:    time.Now().UTC(),
+		Symbol:     "AAA/USDT",
+		Action:     "buy",
+		Confidence: 0.92,
+	})
+	require.NoError(t, err)
+
+	handlers := &IntegratedQuestHandlers{telemetryStore: telemetryStore}
+	handlers.persistScalpingExecutionLifecycle(
+		ctx,
+		OpModeLive,
+		&AITradingDecision{
+			Action:      "buy",
+			Symbol:      "AAA/USDT",
+			SizePercent: 2.5,
+			OrderID:     "live-order-aaa-buy",
+		},
+		"live-chat",
+		"bitget",
+		TradingPortfolio{USDTBalance: 1000},
+		true,
+		cycleID,
+	)
+
+	var telemetryOrderID string
+	err = sqliteDB.DB.QueryRowContext(ctx, `
+		SELECT order_id
+		FROM scalping_cycle_telemetry
+		WHERE id = $1
+	`, cycleID).Scan(&telemetryOrderID)
+	require.NoError(t, err)
+	assert.Equal(t, "live-order-aaa-buy", telemetryOrderID)
+}

--- a/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
@@ -321,3 +321,83 @@ func TestIntegratedQuestHandlersExecuteAIScalping_PaperModeUsesVirtualBalanceAnd
 	assert.Equal(t, 1, mockLLM.CallCount)
 	assert.Zero(t, mockCCXT.fetchCalls, "paper mode should not fetch live balance")
 }
+
+func TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle_LinksPaperOrder(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "paper-scalping-lifecycle.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+	telemetryStore := NewScalpingTelemetryStore(sqliteDB, nil)
+	require.NoError(t, telemetryStore.EnsureSchema(ctx))
+
+	cycleID, err := telemetryStore.InsertCycleRecord(ctx, CycleRecord{
+		ID:         "paper-cycle-1",
+		ChatID:     "paper-chat",
+		Exchange:   "bitget",
+		CycleAt:    time.Now().UTC(),
+		Symbol:     "AAA/USDT",
+		Action:     "buy",
+		Confidence: 0.92,
+	})
+	require.NoError(t, err)
+
+	entry := decimal.NewFromFloat(1.23)
+	stop := decimal.NewFromFloat(1.20)
+	take := decimal.NewFromFloat(1.29)
+	handlers := &IntegratedQuestHandlers{
+		lifecycleStore: lifecycleStore,
+		telemetryStore: telemetryStore,
+	}
+
+	handlers.persistScalpingExecutionLifecycle(
+		ctx,
+		ModePaper,
+		&AITradingDecision{
+			Action:      "buy",
+			Symbol:      "AAA/USDT",
+			SizePercent: 2.5,
+			OrderID:     "paper-order-aaa-buy",
+			EntryPrice:  &entry,
+			StopLoss:    &stop,
+			TakeProfit:  &take,
+		},
+		"paper-chat",
+		"bitget",
+		TradingPortfolio{USDTBalance: 1000},
+		true,
+		cycleID,
+	)
+
+	var orderStatus, orderSource, positionStatus, telemetryOrderID string
+	var amount decimal.Decimal
+	err = sqliteDB.DB.QueryRowContext(ctx, `
+		SELECT status, source, amount
+		FROM trading_orders
+		WHERE order_id = ?
+	`, "paper-order-aaa-buy").Scan(&orderStatus, &orderSource, &amount)
+	require.NoError(t, err)
+	assert.Equal(t, "open", orderStatus)
+	assert.Equal(t, "autonomous_scalping", orderSource)
+	assert.True(t, amount.Equal(decimal.NewFromInt(25)), "amount should use paper portfolio size percentage")
+
+	err = sqliteDB.DB.QueryRowContext(ctx, `
+		SELECT status
+		FROM trading_positions
+		WHERE order_id = ?
+	`, "paper-order-aaa-buy").Scan(&positionStatus)
+	require.NoError(t, err)
+	assert.Equal(t, "open", positionStatus)
+
+	err = sqliteDB.DB.QueryRowContext(ctx, `
+		SELECT order_id
+		FROM scalping_cycle_telemetry
+		WHERE id = ?
+	`, cycleID).Scan(&telemetryOrderID)
+	require.NoError(t, err)
+	assert.Equal(t, "paper-order-aaa-buy", telemetryOrderID)
+}

--- a/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
@@ -378,7 +378,7 @@ func TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle_LinksPaperOrde
 	err = sqliteDB.DB.QueryRowContext(ctx, `
 		SELECT status, source, amount
 		FROM trading_orders
-		WHERE order_id = ?
+		WHERE order_id = $1
 	`, "paper-order-aaa-buy").Scan(&orderStatus, &orderSource, &amount)
 	require.NoError(t, err)
 	assert.Equal(t, "open", orderStatus)
@@ -388,7 +388,7 @@ func TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle_LinksPaperOrde
 	err = sqliteDB.DB.QueryRowContext(ctx, `
 		SELECT status
 		FROM trading_positions
-		WHERE order_id = ?
+		WHERE order_id = $1
 	`, "paper-order-aaa-buy").Scan(&positionStatus)
 	require.NoError(t, err)
 	assert.Equal(t, "open", positionStatus)
@@ -396,7 +396,7 @@ func TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle_LinksPaperOrde
 	err = sqliteDB.DB.QueryRowContext(ctx, `
 		SELECT order_id
 		FROM scalping_cycle_telemetry
-		WHERE id = ?
+		WHERE id = $1
 	`, cycleID).Scan(&telemetryOrderID)
 	require.NoError(t, err)
 	assert.Equal(t, "paper-order-aaa-buy", telemetryOrderID)

--- a/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
@@ -213,6 +213,53 @@ func TestIntegratedQuestHandlersSyncScalpingStrategyMode_BlocksNonLiveTransition
 	assert.Equal(t, autonomous.StageLive, state.CurrentStage)
 }
 
+func TestIntegratedQuestHandlersSyncScalpingStrategyMode_IgnoresPaperLifecycleExposure(t *testing.T) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "rollout-sync-paper-exposure.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	store := NewAutonomousRolloutStore(sqliteDB.DB)
+	require.NoError(t, store.InitSchema(context.Background()))
+
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	handlers := &IntegratedQuestHandlers{
+		autonomyCoordinator: NewScalpingAutonomyCoordinator(store, AIScalpingConfig{}),
+		lifecycleStore:      lifecycleStore,
+	}
+
+	chatID := "1082762347"
+	ctx := WithScalpingAutonomyScope(context.Background(), ScalpingAutonomyScope{
+		ChatID:     chatID,
+		StrategyID: ScalpingStrategyID(chatID),
+		Exchange:   "bitget",
+	})
+
+	require.NoError(t, lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
+		OrderID:    "paper-ord-exposure",
+		ChatID:     chatID,
+		Exchange:   "bitget",
+		Symbol:     "BTC/USDT",
+		Side:       "buy",
+		OrderType:  "market",
+		MarketType: "futures",
+		Amount:     decimal.NewFromFloat(0.01),
+		EntryPrice: decimal.NewFromFloat(50000),
+		Source:     scalpingPaperLifecycleSource,
+		OpenedAt:   time.Now().UTC(),
+	}))
+
+	require.NoError(t, handlers.syncScalpingStrategyMode(ctx, chatID, ModePaper))
+
+	state, err := store.GetRolloutState(ctx, ScalpingStrategyID(chatID))
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, autonomous.StagePaper, state.CurrentStage)
+}
+
 type syncFailureBalanceFetcher struct{}
 
 func (syncFailureBalanceFetcher) FetchBalance(context.Context, string) (*ccxt.BalanceResponse, error) {
@@ -382,7 +429,7 @@ func TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle_LinksPaperOrde
 	`, "paper-order-aaa-buy").Scan(&orderStatus, &orderSource, &amount)
 	require.NoError(t, err)
 	assert.Equal(t, "open", orderStatus)
-	assert.Equal(t, "autonomous_scalping", orderSource)
+	assert.Equal(t, scalpingPaperLifecycleSource, orderSource)
 	assert.True(t, amount.Equal(decimal.NewFromInt(25)), "amount should use paper portfolio size percentage")
 
 	err = sqliteDB.DB.QueryRowContext(ctx, `

--- a/services/backend-api/internal/services/safe_order_executor.go
+++ b/services/backend-api/internal/services/safe_order_executor.go
@@ -43,6 +43,9 @@ func (s *SafeOrderExecutor) PlaceOrder(
 	amount decimal.Decimal,
 	price *decimal.Decimal,
 ) (string, error) {
+	if isPaperSafetyBypass(ctx, false) {
+		return s.baseExecutor.PlaceOrder(ctx, exchange, symbol, side, orderType, amount, price)
+	}
 	allowed, reason, err := s.checkSafety(ctx, exchange, symbol, resolveSafetyMarketType(ctx, exchange, symbol), amount)
 	if err != nil {
 		return "", fmt.Errorf("safety check failed: %w", err)
@@ -146,6 +149,9 @@ func (s *SafeOrderExecutor) PlaceOrderWithDetails(ctx context.Context, details T
 	if amount.LessThanOrEqual(decimal.Zero) {
 		return "", fmt.Errorf("invalid order size: amount_usdt must be positive")
 	}
+	if isPaperSafetyBypass(ctx, details.IsPaperTrade) {
+		return s.baseExecutor.PlaceOrderWithDetails(ctx, details)
+	}
 
 	s.mu.RLock()
 	chatID := s.chatID
@@ -209,6 +215,14 @@ func (s *SafeOrderExecutor) PlaceOrderWithDetails(ctx context.Context, details T
 	}
 
 	return s.baseExecutor.PlaceOrderWithDetails(ctx, details)
+}
+
+func isPaperSafetyBypass(ctx context.Context, isPaperTrade bool) bool {
+	if isPaperTrade {
+		return true
+	}
+	mode, ok := operationalModeFromContext(ctx)
+	return ok && mode == ModePaper
 }
 
 // PlaceRiskReductionOrderWithDetails bypasses pre-trade safety checks for forced de-risking actions.

--- a/services/backend-api/internal/services/safe_order_executor.go
+++ b/services/backend-api/internal/services/safe_order_executor.go
@@ -43,7 +43,7 @@ func (s *SafeOrderExecutor) PlaceOrder(
 	amount decimal.Decimal,
 	price *decimal.Decimal,
 ) (string, error) {
-	if isPaperSafetyBypass(ctx, false) {
+	if s.shouldBypassPaperSafety(ctx, false) {
 		return s.baseExecutor.PlaceOrder(ctx, exchange, symbol, side, orderType, amount, price)
 	}
 	allowed, reason, err := s.checkSafety(ctx, exchange, symbol, resolveSafetyMarketType(ctx, exchange, symbol), amount)
@@ -149,7 +149,7 @@ func (s *SafeOrderExecutor) PlaceOrderWithDetails(ctx context.Context, details T
 	if amount.LessThanOrEqual(decimal.Zero) {
 		return "", fmt.Errorf("invalid order size: amount_usdt must be positive")
 	}
-	if isPaperSafetyBypass(ctx, details.IsPaperTrade) {
+	if s.shouldBypassPaperSafety(ctx, details.IsPaperTrade) {
 		return s.baseExecutor.PlaceOrderWithDetails(ctx, details)
 	}
 
@@ -217,12 +217,12 @@ func (s *SafeOrderExecutor) PlaceOrderWithDetails(ctx context.Context, details T
 	return s.baseExecutor.PlaceOrderWithDetails(ctx, details)
 }
 
-func isPaperSafetyBypass(ctx context.Context, isPaperTrade bool) bool {
-	if isPaperTrade {
-		return true
+func (s *SafeOrderExecutor) shouldBypassPaperSafety(ctx context.Context, isPaperTrade bool) bool {
+	mode, hasMode := operationalModeFromContext(ctx)
+	if hasMode {
+		return mode == ModePaper
 	}
-	mode, ok := operationalModeFromContext(ctx)
-	return ok && mode == ModePaper
+	return isPaperTrade && s.baseExecutor != nil && s.baseExecutor.IsPaperTrading()
 }
 
 // PlaceRiskReductionOrderWithDetails bypasses pre-trade safety checks for forced de-risking actions.

--- a/services/backend-api/internal/services/safe_order_executor_test.go
+++ b/services/backend-api/internal/services/safe_order_executor_test.go
@@ -423,6 +423,29 @@ func TestSafeOrderExecutor_PlaceOrderWithDetails_BypassesZeroMaxSafetyForBitgetF
 	mockSafety.AssertExpectations(t)
 }
 
+func TestSafeOrderExecutor_PlaceOrderWithDetails_BypassesSafetyForPaperMode(t *testing.T) {
+	mockExecutor := new(MockScalpingOrderExecutor)
+	mockSafety := &mockDetailedSafetyChecker{}
+	safeExec := NewSafeOrderExecutor(mockExecutor, mockSafety, "test-chat")
+
+	details := TradeDetails{
+		Exchange:   "bitget",
+		MarketType: "futures",
+		Symbol:     "BTC/USDT",
+		AmountUSDT: decimal.NewFromFloat(8.5),
+	}
+
+	mockExecutor.On("PlaceOrderWithDetails", mock.Anything, details).Return("paper-order", nil)
+
+	orderID, err := safeExec.PlaceOrderWithDetails(WithOperationalMode(context.Background(), ModePaper), details)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "paper-order", orderID)
+	mockExecutor.AssertExpectations(t)
+	mockSafety.AssertNotCalled(t, "EvaluateTradeWithLeverage")
+	mockSafety.AssertNotCalled(t, "CanExecuteTrade")
+}
+
 func TestSafeOrderExecutor_PlaceOrderWithDetails_DoesNotBypassWhenAmountExceedsBoundedCap(t *testing.T) {
 	mockExecutor := new(MockScalpingOrderExecutor)
 	mockSafety := &mockDetailedSafetyChecker{}

--- a/services/backend-api/internal/services/safe_order_executor_test.go
+++ b/services/backend-api/internal/services/safe_order_executor_test.go
@@ -446,6 +446,16 @@ func TestSafeOrderExecutor_PlaceOrderWithDetails_BypassesSafetyForPaperMode(t *t
 	mockSafety.AssertNotCalled(t, "CanExecuteTrade")
 }
 
+func TestSafeOrderExecutor_ShouldNotBypassSafetyForPaperFlagWithoutPaperExecutor(t *testing.T) {
+	mockExecutor := new(MockScalpingOrderExecutor)
+	safeExec := NewSafeOrderExecutor(mockExecutor, nil, "test-chat")
+
+	mockExecutor.On("IsPaperTrading").Return(false)
+
+	assert.False(t, safeExec.shouldBypassPaperSafety(context.Background(), true))
+	mockExecutor.AssertExpectations(t)
+}
+
 func TestSafeOrderExecutor_PlaceOrderWithDetails_DoesNotBypassWhenAmountExceedsBoundedCap(t *testing.T) {
 	mockExecutor := new(MockScalpingOrderExecutor)
 	mockSafety := &mockDetailedSafetyChecker{}

--- a/services/backend-api/internal/services/trading_lifecycle_store.go
+++ b/services/backend-api/internal/services/trading_lifecycle_store.go
@@ -1305,6 +1305,10 @@ func (s *TradingLifecycleStore) CloseClosedOrderBackedGhostPositions(ctx context
 }
 
 func (s *TradingLifecycleStore) CountOpenOrders(ctx context.Context, chatID, exchange string) (int, error) {
+	return s.CountOpenOrdersExcludingSources(ctx, chatID, exchange, nil)
+}
+
+func (s *TradingLifecycleStore) CountOpenOrdersExcludingSources(ctx context.Context, chatID, exchange string, excludedSources []string) (int, error) {
 	query := `
 		SELECT COUNT(*)
 		FROM trading_orders
@@ -1318,6 +1322,20 @@ func (s *TradingLifecycleStore) CountOpenOrders(ctx context.Context, chatID, exc
 	if strings.TrimSpace(exchange) != "" {
 		query += fmt.Sprintf(" AND exchange = $%d", len(args)+1)
 		args = append(args, strings.TrimSpace(exchange))
+	}
+	if len(excludedSources) > 0 {
+		placeholders := make([]string, 0, len(excludedSources))
+		for _, source := range excludedSources {
+			source = strings.TrimSpace(source)
+			if source == "" {
+				continue
+			}
+			args = append(args, source)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		if len(placeholders) > 0 {
+			query += fmt.Sprintf(" AND COALESCE(source, '') NOT IN (%s)", strings.Join(placeholders, ","))
+		}
 	}
 
 	var count int


### PR DESCRIPTION
## Summary
- allow paper-mode scalping entries past the paper rollout gate when all other autonomy safety checks pass
- bypass live portfolio safety for explicit paper-mode/paper-trade order placement
- persist paper scalping entries into trading lifecycle tables and link telemetry order IDs

## Runtime validation
- local paper gateway on port 18183 with mock models.dev-compatible OpenAI endpoint on 18281
- /api/v1/telegram/internal/autonomous/begin returned readiness_passed=true for chat_id=paper-validation
- latest paper runtime inserted scalping_cycle_telemetry.order_id=paper-paper-order-bitget-AIGENSYN/USDT-buy
- trading_orders and trading_positions both contain matching open autonomous_scalping rows for paper-validation
- no live credentials were present; order ID is paper-prefixed and FEATURES_REAL_TRADING=false

## Tests
- rtk env GOCACHE=/private/tmp/nt-go-cache-paper-pr go -C services/backend-api test ./internal/services -run 'TestShouldAllowPaperModeAutonomyExecution|TestSafeOrderExecutor_PlaceOrderWithDetails_BypassesSafetyForPaperMode|TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle_LinksPaperOrder|TestIntegratedQuestHandlersExecuteAIScalping_PaperModeUsesVirtualBalanceAndPaperMetadata' -count=1
- rtk env GOCACHE=/private/tmp/nt-go-cache-paper-pr go -C services/backend-api test ./internal/services -count=1
- rtk env GOCACHE=/private/tmp/nt-go-cache-paper-pr make build

## Summary by Sourcery

Allow autonomous scalping to execute and fully record lifecycle data in paper mode while safely bypassing live-only protections where appropriate.

New Features:
- Enable paper-mode autonomous scalping execution when rollout is in active paper stage and all non-strategy safety checks pass.
- Persist paper-mode scalping executions into trading lifecycle and telemetry tables, linking paper order IDs to cycles.

Bug Fixes:
- Bypass live portfolio safety checks for explicitly paper-mode scalping orders to prevent unintended blocking of simulated trades.

Enhancements:
- Refactor scalping execution lifecycle persistence into a reusable helper that handles both live and paper modes.
- Relax pre-trade safety enforcement in the safe order executor for paper-mode and explicit paper-trade orders while leaving live safety intact.
- Expand AIScalping and safe order executor tests to cover paper-mode autonomy gating, lifecycle persistence, and safety bypass behavior.

Tests:
- Add integration tests ensuring paper scalping orders are stored as open orders/positions and linked in telemetry, and unit tests for paper-mode autonomy gating and safety bypass logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Paper trading mode now supports autonomous strategy execution with gating logic that was previously restricted to live trading.
  * Paper trade orders are now persisted with full lifecycle tracking and telemetry linking for better testing and monitoring.
  * Portfolio safety checks are bypassed for paper trades to enable risk-free strategy testing.

* **Tests**
  * Added comprehensive test coverage for paper mode autonomy execution and order persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->