### PR TITLE
fix: close paper scalping positions with realized pnl

### DIFF
--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -64,13 +64,14 @@ func (m mockMarketPrice) GetPriceChange24h() float64 { return m.change24h }
 
 type mockAIScalpingCCXT struct {
 	mockCCXTForPortfolioSafety
-	markets      *ccxt.MarketsResponse
-	marketData   []ccxt.MarketPriceInterface
-	orderBooks   map[string]*ccxt.OrderBookResponse
-	orderBookOps []string
-	marketsErr   error
-	marketErr    error
-	orderBookErr error
+	markets       *ccxt.MarketsResponse
+	marketData    []ccxt.MarketPriceInterface
+	singleTickers map[string]ccxt.MarketPriceInterface
+	orderBooks    map[string]*ccxt.OrderBookResponse
+	orderBookOps  []string
+	marketsErr    error
+	marketErr     error
+	orderBookErr  error
 }
 
 func (m *mockAIScalpingCCXT) FetchMarkets(ctx context.Context, exchange string) (*ccxt.MarketsResponse, error) {
@@ -85,6 +86,16 @@ func (m *mockAIScalpingCCXT) FetchMarketData(ctx context.Context, exchanges []st
 		return nil, m.marketErr
 	}
 	return m.marketData, nil
+}
+
+func (m *mockAIScalpingCCXT) FetchSingleTicker(ctx context.Context, exchange, symbol string) (ccxt.MarketPriceInterface, error) {
+	if m.marketErr != nil {
+		return nil, m.marketErr
+	}
+	if m.singleTickers == nil {
+		return nil, nil
+	}
+	return m.singleTickers[normalizeSymbolForComparison(symbol)], nil
 }
 
 func (m *mockAIScalpingCCXT) FetchOrderBook(ctx context.Context, exchange, symbol string, limit int) (*ccxt.OrderBookResponse, error) {

--- a/services/backend-api/internal/services/paper_scalping_close.go
+++ b/services/backend-api/internal/services/paper_scalping_close.go
@@ -1,0 +1,256 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/irfndi/neuratrade/internal/ccxt"
+	"github.com/shopspring/decimal"
+)
+
+const (
+	scalpingPaperTakeProfitCloseSource = "autonomous_scalping_paper_take_profit"
+	scalpingPaperStopLossCloseSource   = "autonomous_scalping_paper_stop_loss"
+	defaultPaperScalpingCloseLimit     = 100
+)
+
+var defaultPaperScalpingTakerFeeRate = decimal.RequireFromString("0.0006")
+
+func (h *IntegratedQuestHandlers) closeTriggeredPaperScalpingPositions(
+	ctx context.Context,
+	quest *Quest,
+	chatID, exchange string,
+) (int, error) {
+	if h == nil || h.lifecycleStore == nil {
+		return 0, nil
+	}
+	positions, err := h.lifecycleStore.ListManagedOpenPositions(ctx, chatID, exchange, paperScalpingClosePositionLimit())
+	if err != nil {
+		return 0, fmt.Errorf("list paper scalping positions: %w", err)
+	}
+	if len(positions) == 0 {
+		return 0, nil
+	}
+	if quest != nil && quest.Checkpoint == nil {
+		quest.Checkpoint = make(map[string]interface{})
+	}
+
+	closed := 0
+	evaluated := 0
+	missingPrices := 0
+	for _, position := range positions {
+		if !strings.EqualFold(strings.TrimSpace(position.Source), scalpingPaperLifecycleSource) {
+			continue
+		}
+		evaluated++
+		exitPrice, ok := h.resolvePaperScalpingMarkPrice(ctx, position)
+		if !ok {
+			missingPrices++
+			continue
+		}
+		triggerSource := paperScalpingCloseTrigger(position, exitPrice)
+		if triggerSource == "" {
+			continue
+		}
+
+		baseFilled := paperScalpingBaseFilled(position)
+		if baseFilled.LessThanOrEqual(decimal.Zero) {
+			baseFilled = position.Size.Abs()
+		}
+		grossPnL := paperScalpingGrossPnL(position.Side, position.EntryPrice, exitPrice, baseFilled)
+		fees := paperScalpingRoundTripFees(position.EntryPrice, exitPrice, baseFilled)
+		netPnL := adjustedLifecyclePnL(grossPnL, fees, position.Exchange, triggerSource)
+		outcome := paperScalpingOutcomeFromNetPnL(netPnL)
+		orderID := strings.TrimSpace(position.OrderID)
+		if orderID == "" {
+			orderID = strings.TrimSpace(position.PositionID)
+		}
+		if orderID == "" {
+			return closed, fmt.Errorf("paper scalping position %s has no order id", position.PositionID)
+		}
+		closedAt := time.Now().UTC()
+
+		if err := h.lifecycleStore.RecordClosedOrder(ctx, LifecycleCloseRecord{
+			OrderID:     orderID,
+			ChatID:      position.ChatID,
+			Exchange:    position.Exchange,
+			Symbol:      position.Symbol,
+			Side:        position.Side,
+			MarketType:  position.MarketType,
+			Filled:      baseFilled,
+			EntryPrice:  position.EntryPrice,
+			ExitPrice:   exitPrice,
+			RealizedPnL: grossPnL,
+			Fees:        fees,
+			Source:      triggerSource,
+			ClosedAt:    closedAt,
+		}); err != nil {
+			return closed, fmt.Errorf("record paper scalping close for %s: %w", orderID, err)
+		}
+
+		h.updatePaperScalpingTelemetryOutcome(ctx, orderID, outcome, netPnL, position.OpenedAt, closedAt)
+		closed++
+		log.Printf(
+			"[SCALPING] Paper %s closed by %s at %s (entry=%s gross_pnl=%s fees=%s)",
+			position.Symbol,
+			triggerSource,
+			exitPrice.String(),
+			position.EntryPrice.String(),
+			grossPnL.String(),
+			fees.String(),
+		)
+	}
+
+	if quest != nil && quest.Checkpoint != nil {
+		quest.Checkpoint["paper_close_positions_evaluated"] = evaluated
+		if closed > 0 {
+			quest.Checkpoint["paper_close_triggered_positions"] = closed
+		}
+		if missingPrices > 0 {
+			quest.Checkpoint["paper_close_missing_prices"] = missingPrices
+		}
+	}
+
+	return closed, nil
+}
+
+func (h *IntegratedQuestHandlers) resolvePaperScalpingMarkPrice(
+	ctx context.Context,
+	position ManagedOpenPosition,
+) (decimal.Decimal, bool) {
+	if h != nil {
+		tickerSource, ok := h.ccxtService.(interface {
+			FetchSingleTicker(ctx context.Context, exchange, symbol string) (ccxt.MarketPriceInterface, error)
+		})
+		if ok {
+			ticker, err := tickerSource.FetchSingleTicker(ctx, position.Exchange, position.Symbol)
+			if err == nil && ticker != nil && ticker.GetPrice() > 0 {
+				return decimal.NewFromFloat(ticker.GetPrice()), true
+			}
+		}
+	}
+	if position.LastPrice.GreaterThan(decimal.Zero) {
+		return position.LastPrice, true
+	}
+	return decimal.Zero, false
+}
+
+func paperScalpingCloseTrigger(position ManagedOpenPosition, exitPrice decimal.Decimal) string {
+	if exitPrice.LessThanOrEqual(decimal.Zero) || position.EntryPrice.LessThanOrEqual(decimal.Zero) {
+		return ""
+	}
+	side := normalizeLifecycleSide(position.Side)
+	switch side {
+	case "buy":
+		if position.TakeProfit.GreaterThan(decimal.Zero) && exitPrice.GreaterThanOrEqual(position.TakeProfit) {
+			return scalpingPaperTakeProfitCloseSource
+		}
+		if position.StopLoss.GreaterThan(decimal.Zero) && exitPrice.LessThanOrEqual(position.StopLoss) {
+			return scalpingPaperStopLossCloseSource
+		}
+	case "sell":
+		if position.TakeProfit.GreaterThan(decimal.Zero) && exitPrice.LessThanOrEqual(position.TakeProfit) {
+			return scalpingPaperTakeProfitCloseSource
+		}
+		if position.StopLoss.GreaterThan(decimal.Zero) && exitPrice.GreaterThanOrEqual(position.StopLoss) {
+			return scalpingPaperStopLossCloseSource
+		}
+	}
+	return ""
+}
+
+func paperScalpingBaseFilled(position ManagedOpenPosition) decimal.Decimal {
+	if position.EntryPrice.LessThanOrEqual(decimal.Zero) {
+		return decimal.Zero
+	}
+	return position.Size.Abs().Div(position.EntryPrice)
+}
+
+func paperScalpingGrossPnL(side string, entryPrice, exitPrice, baseFilled decimal.Decimal) decimal.Decimal {
+	if entryPrice.LessThanOrEqual(decimal.Zero) || exitPrice.LessThanOrEqual(decimal.Zero) || baseFilled.LessThanOrEqual(decimal.Zero) {
+		return decimal.Zero
+	}
+	delta := exitPrice.Sub(entryPrice)
+	if normalizeLifecycleSide(side) == "sell" {
+		delta = entryPrice.Sub(exitPrice)
+	}
+	return delta.Mul(baseFilled)
+}
+
+func paperScalpingRoundTripFees(entryPrice, exitPrice, baseFilled decimal.Decimal) decimal.Decimal {
+	if entryPrice.LessThanOrEqual(decimal.Zero) || exitPrice.LessThanOrEqual(decimal.Zero) || baseFilled.LessThanOrEqual(decimal.Zero) {
+		return decimal.Zero
+	}
+	rate := defaultPaperScalpingTakerFeeRate
+	if configured, ok := paperScalpingTakerFeeRateFromEnv(); ok {
+		rate = configured
+	}
+	entryNotional := entryPrice.Mul(baseFilled).Abs()
+	exitNotional := exitPrice.Mul(baseFilled).Abs()
+	return entryNotional.Add(exitNotional).Mul(rate)
+}
+
+func paperScalpingClosePositionLimit() int {
+	if configured := getEnvInt("NEURATRADE_PAPER_SCALPING_CLOSE_POSITION_LIMIT"); configured > 0 {
+		return configured
+	}
+	return defaultPaperScalpingCloseLimit
+}
+
+func paperScalpingTakerFeeRateFromEnv() (decimal.Decimal, bool) {
+	raw := strings.TrimSpace(os.Getenv("NEURATRADE_PAPER_SCALPING_TAKER_FEE_RATE"))
+	if raw == "" {
+		return decimal.Zero, false
+	}
+	configured, err := decimal.NewFromString(raw)
+	if err != nil || configured.IsNegative() {
+		log.Printf("[SCALPING] Invalid paper scalping taker fee rate %q", raw)
+		return decimal.Zero, false
+	}
+	return configured, true
+}
+
+func paperScalpingOutcomeFromNetPnL(netPnL decimal.Decimal) string {
+	if netPnL.GreaterThan(decimal.Zero) {
+		return "win"
+	}
+	if netPnL.LessThan(decimal.Zero) {
+		return "loss"
+	}
+	return "breakeven"
+}
+
+func (h *IntegratedQuestHandlers) updatePaperScalpingTelemetryOutcome(
+	ctx context.Context,
+	orderID string,
+	outcome string,
+	netPnL decimal.Decimal,
+	openedAt time.Time,
+	closedAt time.Time,
+) {
+	if h == nil || h.telemetryStore == nil {
+		return
+	}
+	holdSeconds := 0
+	if !openedAt.IsZero() {
+		holdSeconds = int(closedAt.Sub(openedAt).Seconds())
+		if holdSeconds < 0 {
+			holdSeconds = 0
+		}
+	}
+	writeCtx, writeCancel := telemetryWriteContext()
+	err := h.telemetryStore.UpdateCycleOutcome(writeCtx, orderID, ScalpingOutcomeRecord{
+		Outcome:             outcome,
+		PnL:                 netPnL.String(),
+		HoldDurationSeconds: holdSeconds,
+		ClosedAt:            closedAt,
+	})
+	writeCancel()
+	if err != nil {
+		log.Printf("[TELEMETRY] Failed to update paper outcome for order %s: %v", orderID, err)
+	}
+}

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -917,6 +917,28 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 
 	log.Printf("[SCALPING] Portfolio: %.2f USDT available", usdtBalance)
 
+	if currentMode == ModePaper {
+		paperClosed, paperCloseErr := h.closeTriggeredPaperScalpingPositions(ctx, quest, chatID, userExchange)
+		if paperCloseErr != nil {
+			log.Printf("[SCALPING] Paper close check failed: %v", paperCloseErr)
+			quest.Checkpoint["paper_close_error"] = paperCloseErr.Error()
+		} else if paperClosed > 0 {
+			quest.Checkpoint["status"] = "paper_close"
+			quest.Checkpoint["paper_close_closed_positions"] = paperClosed
+			h.notifyScalpingDecision(ctx, chatID, AIReasoningNotification{
+				DecisionType: "paper_close",
+				Summary:      "Paper scalping closed positions at configured protection levels",
+				Confidence:   1,
+				Reasons: []string{
+					fmt.Sprintf("Closed %d paper position(s) after take-profit/stop-loss evaluation", paperClosed),
+					"Realized PnL and telemetry outcome were recorded without live exchange execution",
+				},
+				Action: "hold",
+			})
+			return nil
+		}
+	}
+
 	if !isDryRun {
 		timeStopClosed, timeStopErr := h.enforceAdaptiveTimeStop(ctx, quest, chatID, userExchange, portfolio.StrategyPhase)
 		if timeStopErr != nil {
@@ -5767,7 +5789,7 @@ func shouldSendScalpingDecisionNotification(notif AIReasoningNotification) bool 
 		return true
 	}
 	switch decisionType {
-	case "pnl_reconciliation", "risk_reduction", "scalping_digest":
+	case "pnl_reconciliation", "risk_reduction", "scalping_digest", "paper_close":
 		return true
 	default:
 		return false

--- a/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
@@ -517,6 +517,175 @@ func TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle_LinksPaperOrde
 	assert.Equal(t, "paper-order-aaa-buy", telemetryOrderID)
 }
 
+func TestIntegratedQuestHandlersCloseTriggeredPaperScalpingPositions_TakeProfitRecordsPnLAndTelemetry(t *testing.T) {
+	t.Setenv("NEURATRADE_PAPER_SCALPING_TAKER_FEE_RATE", "0.001")
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "paper-scalping-close-tp.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+	telemetryStore := NewScalpingTelemetryStore(sqliteDB, nil)
+	require.NoError(t, telemetryStore.EnsureSchema(ctx))
+
+	cycleID, err := telemetryStore.InsertCycleRecord(ctx, CycleRecord{
+		ID:         "paper-cycle-tp",
+		ChatID:     "paper-chat",
+		Exchange:   "bitget",
+		CycleAt:    time.Now().UTC().Add(-2 * time.Minute),
+		Symbol:     "AAA/USDT",
+		Action:     "buy",
+		Confidence: 0.91,
+	})
+	require.NoError(t, err)
+
+	openedAt := time.Now().UTC().Add(-2 * time.Minute)
+	require.NoError(t, lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
+		OrderID:    "paper-order-tp",
+		ChatID:     "paper-chat",
+		Exchange:   "bitget",
+		Symbol:     "AAA/USDT",
+		Side:       "buy",
+		OrderType:  "market",
+		MarketType: "futures",
+		Amount:     decimal.NewFromInt(1000),
+		EntryPrice: decimal.NewFromInt(100),
+		StopLoss:   decimal.NewFromInt(95),
+		TakeProfit: decimal.NewFromInt(110),
+		Source:     scalpingPaperLifecycleSource,
+		OpenedAt:   openedAt,
+	}))
+	require.NoError(t, telemetryStore.LinkOrderToCycle(ctx, cycleID, "paper-order-tp"))
+
+	handlers := &IntegratedQuestHandlers{
+		ccxtService: &mockAIScalpingCCXT{
+			singleTickers: map[string]ccxt.MarketPriceInterface{
+				"AAA/USDT": mockMarketPrice{symbol: "AAA/USDT", price: 111, exchange: "bitget"},
+			},
+		},
+		lifecycleStore: lifecycleStore,
+		telemetryStore: telemetryStore,
+	}
+	quest := &Quest{Checkpoint: map[string]interface{}{}}
+
+	closed, err := handlers.closeTriggeredPaperScalpingPositions(ctx, quest, "paper-chat", "bitget")
+	require.NoError(t, err)
+	assert.Equal(t, 1, closed)
+	assert.Equal(t, 1, quest.Checkpoint["paper_close_triggered_positions"])
+
+	var positionStatus string
+	var closePrice, grossPnL decimal.Decimal
+	require.NoError(t, sqliteDB.DB.QueryRowContext(ctx, `
+		SELECT status, close_price, realized_pnl
+		FROM trading_positions
+		WHERE order_id = $1
+	`, "paper-order-tp").Scan(&positionStatus, &closePrice, &grossPnL))
+	assert.Equal(t, "closed", positionStatus)
+	assert.True(t, closePrice.Equal(decimal.NewFromInt(111)))
+	assert.True(t, grossPnL.Equal(decimal.NewFromInt(110)))
+
+	var source, outcome string
+	var fees, telemetryPnL decimal.Decimal
+	var holdSeconds int
+	require.NoError(t, sqliteDB.DB.QueryRowContext(ctx, `
+		SELECT j.source, j.fees, t.outcome, t.pnl, t.hold_duration_seconds
+		FROM realized_pnl_journal j
+		JOIN scalping_cycle_telemetry t ON t.order_id = j.order_id
+		WHERE j.order_id = $1
+	`, "paper-order-tp").Scan(&source, &fees, &outcome, &telemetryPnL, &holdSeconds))
+	assert.Equal(t, scalpingPaperTakeProfitCloseSource, source)
+	assert.True(t, fees.Equal(decimal.RequireFromString("2.110")))
+	assert.Equal(t, "win", outcome)
+	assert.True(t, telemetryPnL.Equal(decimal.RequireFromString("107.890")))
+	assert.GreaterOrEqual(t, holdSeconds, 119)
+
+	perf, err := lifecycleStore.GetRealizedPerformance(ctx, "paper-chat", "bitget", time.Now().UTC().Add(-1*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 1, perf.Trades)
+	assert.Equal(t, 1, perf.Wins)
+	assert.True(t, perf.RealizedPnL.Equal(decimal.RequireFromString("107.890")))
+}
+
+func TestIntegratedQuestHandlersCloseTriggeredPaperScalpingPositions_StopLossRecordsLossAfterFees(t *testing.T) {
+	t.Setenv("NEURATRADE_PAPER_SCALPING_TAKER_FEE_RATE", "0.001")
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "paper-scalping-close-sl.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+	telemetryStore := NewScalpingTelemetryStore(sqliteDB, nil)
+	require.NoError(t, telemetryStore.EnsureSchema(ctx))
+
+	cycleID, err := telemetryStore.InsertCycleRecord(ctx, CycleRecord{
+		ID:         "paper-cycle-sl",
+		ChatID:     "paper-chat",
+		Exchange:   "bitget",
+		CycleAt:    time.Now().UTC().Add(-90 * time.Second),
+		Symbol:     "AAA/USDT",
+		Action:     "sell",
+		Confidence: 0.88,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
+		OrderID:    "paper-order-sl",
+		ChatID:     "paper-chat",
+		Exchange:   "bitget",
+		Symbol:     "AAA/USDT",
+		Side:       "sell",
+		OrderType:  "market",
+		MarketType: "futures",
+		Amount:     decimal.NewFromInt(1000),
+		EntryPrice: decimal.NewFromInt(100),
+		StopLoss:   decimal.NewFromInt(105),
+		TakeProfit: decimal.NewFromInt(95),
+		Source:     scalpingPaperLifecycleSource,
+		OpenedAt:   time.Now().UTC().Add(-90 * time.Second),
+	}))
+	require.NoError(t, telemetryStore.LinkOrderToCycle(ctx, cycleID, "paper-order-sl"))
+
+	handlers := &IntegratedQuestHandlers{
+		ccxtService: &mockAIScalpingCCXT{
+			singleTickers: map[string]ccxt.MarketPriceInterface{
+				"AAA/USDT": mockMarketPrice{symbol: "AAA/USDT", price: 106, exchange: "bitget"},
+			},
+		},
+		lifecycleStore: lifecycleStore,
+		telemetryStore: telemetryStore,
+	}
+
+	closed, err := handlers.closeTriggeredPaperScalpingPositions(ctx, &Quest{Checkpoint: map[string]interface{}{}}, "paper-chat", "bitget")
+	require.NoError(t, err)
+	assert.Equal(t, 1, closed)
+
+	var source, outcome string
+	var grossPnL, fees, telemetryPnL decimal.Decimal
+	require.NoError(t, sqliteDB.DB.QueryRowContext(ctx, `
+		SELECT j.source, j.realized_pnl, j.fees, t.outcome, t.pnl
+		FROM realized_pnl_journal j
+		JOIN scalping_cycle_telemetry t ON t.order_id = j.order_id
+		WHERE j.order_id = $1
+	`, "paper-order-sl").Scan(&source, &grossPnL, &fees, &outcome, &telemetryPnL))
+	assert.Equal(t, scalpingPaperStopLossCloseSource, source)
+	assert.True(t, grossPnL.Equal(decimal.NewFromInt(-60)))
+	assert.True(t, fees.Equal(decimal.RequireFromString("2.060")))
+	assert.Equal(t, "loss", outcome)
+	assert.True(t, telemetryPnL.Equal(decimal.RequireFromString("-62.060")))
+
+	perf, err := lifecycleStore.GetRealizedPerformance(ctx, "paper-chat", "bitget", time.Now().UTC().Add(-1*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 1, perf.Trades)
+	assert.Equal(t, 1, perf.Losses)
+	assert.True(t, perf.RealizedPnL.Equal(decimal.RequireFromString("-62.060")))
+}
+
 func TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle_LinksLiveTelemetryWithoutLifecycleStore(t *testing.T) {
 	ctx := context.Background()
 	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "live-scalping-telemetry.db"))

--- a/services/backend-api/internal/services/quest_handlers_integrated_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_test.go
@@ -404,6 +404,10 @@ func TestShouldSendScalpingDecisionNotification_DefaultActionableOnly(t *testing
 		DecisionType: "scalping_digest",
 		Action:       "hold",
 	}))
+	assert.True(t, shouldSendScalpingDecisionNotification(AIReasoningNotification{
+		DecisionType: "paper_close",
+		Action:       "hold",
+	}))
 }
 
 func TestShouldSendScalpingDecisionNotification_EnvOverrides(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds a paper-only scalping close evaluator that closes open paper lifecycle positions when ticker price crosses configured take-profit or stop-loss levels.
- Records closed paper positions through `TradingLifecycleStore.RecordClosedOrder`, including gross PnL, round-trip taker fees, realized performance metrics, and scalping telemetry outcomes.
- Hooks the evaluator into paper-mode `executeAIScalping` before new entries so paper round trips can complete without live exchange order placement.

## Root Cause
Paper scalping entries were persisted by the prior runtime fix, but paper mode had no close/TP/SL feedback path. As a result `realized_pnl_journal` stayed empty, win/loss metrics could not update, and paper validation could not prove complete strategy economics.

## Validation
- `rtk env GOCACHE=/private/tmp/nt-go-cache-paper-close go -C services/backend-api test ./internal/services -run 'TestIntegratedQuestHandlersCloseTriggeredPaperScalpingPositions|TestIntegratedQuestHandlersExecuteAIScalping_PaperModeUsesVirtualBalanceAndPaperMetadata|TestIntegratedQuestHandlersPersistScalpingExecutionLifecycle' -count=1`
- `rtk env GOCACHE=/private/tmp/nt-go-cache-paper-close go -C services/backend-api test ./internal/services -count=1`
- `rtk env GOCACHE=/private/tmp/nt-go-cache-paper-close go -C services/backend-api test ./... -count=1`
- `rtk env GOCACHE=/private/tmp/nt-go-cache-paper-close make build`

Stacked on #341 (`fix/scalping-paper-runtime-execution`) and should not be merged before that PR.

## Summary by Sourcery

Ensure paper-mode scalping positions are automatically closed and recorded with realized PnL and telemetry when take-profit or stop-loss levels are hit.

Bug Fixes:
- Populate realized PnL journal and performance metrics for paper scalping positions by closing them on TP/SL instead of leaving them perpetually open.

Enhancements:
- Add a paper scalping close evaluator that derives mark prices, computes round-trip fees and PnL, and updates scalping telemetry outcomes.
- Integrate paper scalping close evaluation into AI scalping execution so paper round trips can complete without live exchange orders.

Tests:
- Add integrated tests verifying paper scalping take-profit and stop-loss closures record positions, journal entries, telemetry outcomes, and realized performance as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated closing of paper trading positions when take-profit or stop-loss triggers are activated
  * Enhanced tracking and recording of closed position metrics, including realized profit/loss and fees

* **Bug Fixes**
  * Improved error handling during position auto-close operations with fallback mechanisms for exit price resolution

* **Tests**
  * Added integration tests for paper position closing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->