### PR TITLE
fix: start autonomous quests with stored mode metadata

### DIFF
--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -767,6 +767,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	integratedHandlers.SetDrawdownHalt(drawdownHalt)
 	integratedHandlers.SetOrderExecutor(orderExecutor)
 	integratedHandlers.SetOperationalModeService(opModeService)
+	questEngine.SetOperationalModeService(opModeService)
 
 	// Set database for user settings lookup
 	var lifecycleStore *services.TradingLifecycleStore

--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -192,6 +192,7 @@ type QuestEngine struct {
 	riskLockReasons           []string
 	aiProviderChainConfigured int
 	aiProviderChainUsable     int
+	opModeService             *OperationalModeService
 	// notificationService is used to send quest progress notifications
 	notificationService *NotificationService
 	// chatIDForQuest maps quest IDs to their owner's chat ID
@@ -352,6 +353,16 @@ func NewQuestEngineWithNotification(store QuestStore, redisClient *redis.Client,
 	engine := NewQuestEngineWithRedis(store, redisClient)
 	engine.notificationService = notifier
 	return engine
+}
+
+// SetOperationalModeService wires operator trading mode lookup for quest startup metadata.
+func (e *QuestEngine) SetOperationalModeService(service *OperationalModeService) {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.opModeService = service
 }
 
 // registerDefaultDefinitions registers the default quest templates
@@ -1629,13 +1640,21 @@ func (e *QuestEngine) BeginAutonomous(chatID string) (*AutonomousState, error) {
 			log.Printf("Failed to create quest %s: %v", defID, err)
 			continue
 		}
-		// Set dry-run mode from config (default to false for live trading)
+		currentMode := e.resolveBeginAutonomousMode(chatID, quest)
+		isDryRun := currentMode != OpModeLive
 		if quest.Metadata == nil {
 			quest.Metadata = make(map[string]string)
 		}
-		quest.Metadata["dry_run"] = "false"
-		quest.Metadata["paper_trading"] = "false"
-		log.Printf("[QUEST] Created quest %s with dry_run=false (LIVE TRADING MODE)", quest.ID)
+		quest.Metadata["dry_run"] = strconv.FormatBool(isDryRun)
+		quest.Metadata["paper_trading"] = strconv.FormatBool(currentMode == ModePaper)
+		quest.Metadata["execution_mode"] = string(currentMode)
+		log.Printf(
+			"[QUEST] Created quest %s with execution_mode=%s dry_run=%t paper_trading=%t",
+			quest.ID,
+			currentMode,
+			isDryRun,
+			currentMode == ModePaper,
+		)
 
 		quest.Status = QuestStatusActive
 		quest.UpdatedAt = time.Now()
@@ -1656,6 +1675,25 @@ func (e *QuestEngine) BeginAutonomous(chatID string) (*AutonomousState, error) {
 	}
 
 	return state, nil
+}
+
+func (e *QuestEngine) resolveBeginAutonomousMode(chatID string, quest *Quest) OperationalMode {
+	if e != nil && e.opModeService != nil {
+		switch mode := e.opModeService.GetMode(chatID); mode {
+		case OpModeLive:
+			return OpModeLive
+		case ModePaper:
+			return ModePaper
+		case OpModeDry, ModeConservative, ModeModerate, ModeAggressive:
+			return mode
+		}
+	}
+	if quest != nil && quest.Metadata != nil {
+		if strings.EqualFold(strings.TrimSpace(quest.Metadata["paper_trading"]), "true") {
+			return ModePaper
+		}
+	}
+	return OpModeDry
 }
 
 func (e *QuestEngine) ensureQuestForChatInternal(definitionID, chatID string) (*Quest, error) {

--- a/services/backend-api/internal/services/quest_engine_test.go
+++ b/services/backend-api/internal/services/quest_engine_test.go
@@ -1466,6 +1466,100 @@ func TestBeginAutonomous_ReusesExistingScalpingQuest(t *testing.T) {
 	}
 }
 
+func TestBeginAutonomous_UsesStoredPaperModeMetadata(t *testing.T) {
+	engine := NewQuestEngine(NewInMemoryQuestStore())
+	engine.SetOperationalModeService(&OperationalModeService{
+		config: DefaultOperationalModeConfig(),
+		states: map[string]*OperationalModeState{
+			"paper-chat": {ChatID: "paper-chat", Mode: ModePaper},
+		},
+	})
+
+	state, err := engine.BeginAutonomous("paper-chat")
+	if err != nil {
+		t.Fatalf("BeginAutonomous returned error: %v", err)
+	}
+	quest := engine.quests[state.ActiveQuests[0]]
+	if quest.Metadata["execution_mode"] != string(ModePaper) {
+		t.Fatalf("expected execution_mode paper, got %q", quest.Metadata["execution_mode"])
+	}
+	if quest.Metadata["dry_run"] != "true" {
+		t.Fatalf("expected dry_run true, got %q", quest.Metadata["dry_run"])
+	}
+	if quest.Metadata["paper_trading"] != "true" {
+		t.Fatalf("expected paper_trading true, got %q", quest.Metadata["paper_trading"])
+	}
+}
+
+func TestBeginAutonomous_DefaultsToDryWhenModeUnavailable(t *testing.T) {
+	engine := NewQuestEngine(NewInMemoryQuestStore())
+
+	state, err := engine.BeginAutonomous("default-chat")
+	if err != nil {
+		t.Fatalf("BeginAutonomous returned error: %v", err)
+	}
+	quest := engine.quests[state.ActiveQuests[0]]
+	if quest.Metadata["execution_mode"] != string(OpModeDry) {
+		t.Fatalf("expected execution_mode dry, got %q", quest.Metadata["execution_mode"])
+	}
+	if quest.Metadata["dry_run"] != "true" {
+		t.Fatalf("expected dry_run true, got %q", quest.Metadata["dry_run"])
+	}
+	if quest.Metadata["paper_trading"] != "false" {
+		t.Fatalf("expected paper_trading false, got %q", quest.Metadata["paper_trading"])
+	}
+}
+
+func TestBeginAutonomous_PreservesStoredNonLiveModeMetadata(t *testing.T) {
+	engine := NewQuestEngine(NewInMemoryQuestStore())
+	engine.SetOperationalModeService(&OperationalModeService{
+		config: DefaultOperationalModeConfig(),
+		states: map[string]*OperationalModeState{
+			"conservative-chat": {ChatID: "conservative-chat", Mode: ModeConservative},
+		},
+	})
+
+	state, err := engine.BeginAutonomous("conservative-chat")
+	if err != nil {
+		t.Fatalf("BeginAutonomous returned error: %v", err)
+	}
+	quest := engine.quests[state.ActiveQuests[0]]
+	if quest.Metadata["execution_mode"] != string(ModeConservative) {
+		t.Fatalf("expected execution_mode conservative, got %q", quest.Metadata["execution_mode"])
+	}
+	if quest.Metadata["dry_run"] != "true" {
+		t.Fatalf("expected dry_run true, got %q", quest.Metadata["dry_run"])
+	}
+	if quest.Metadata["paper_trading"] != "false" {
+		t.Fatalf("expected paper_trading false, got %q", quest.Metadata["paper_trading"])
+	}
+}
+
+func TestBeginAutonomous_UsesStoredLiveModeMetadata(t *testing.T) {
+	engine := NewQuestEngine(NewInMemoryQuestStore())
+	engine.SetOperationalModeService(&OperationalModeService{
+		config: DefaultOperationalModeConfig(),
+		states: map[string]*OperationalModeState{
+			"live-chat": {ChatID: "live-chat", Mode: OpModeLive},
+		},
+	})
+
+	state, err := engine.BeginAutonomous("live-chat")
+	if err != nil {
+		t.Fatalf("BeginAutonomous returned error: %v", err)
+	}
+	quest := engine.quests[state.ActiveQuests[0]]
+	if quest.Metadata["execution_mode"] != string(OpModeLive) {
+		t.Fatalf("expected execution_mode live, got %q", quest.Metadata["execution_mode"])
+	}
+	if quest.Metadata["dry_run"] != "false" {
+		t.Fatalf("expected dry_run false, got %q", quest.Metadata["dry_run"])
+	}
+	if quest.Metadata["paper_trading"] != "false" {
+		t.Fatalf("expected paper_trading false, got %q", quest.Metadata["paper_trading"])
+	}
+}
+
 func ptrTime(t time.Time) *time.Time {
 	return &t
 }


### PR DESCRIPTION
## Summary
- Wire `QuestEngine` to the operational mode service during route setup.
- Set begin-time scalping quest metadata from the stored operator mode instead of hard-coding `dry_run=false`.
- Default begin-time metadata to dry mode when no mode service is available, and add tests for paper, dry, and live startup metadata.

## Validation
- `rtk env GOTMPDIR=/private/tmp/nt-go-tmp-begin-paper GOCACHE=/private/tmp/nt-go-cache-begin-paper go -C services/backend-api test ./internal/services -run 'TestBeginAutonomous_(UsesStoredPaperModeMetadata|DefaultsToDryWhenModeUnavailable|UsesStoredLiveModeMetadata|ReusesExistingScalpingQuest)' -count=1`
- `rtk env GOTMPDIR=/private/tmp/nt-go-tmp-begin-paper GOCACHE=/private/tmp/nt-go-cache-begin-paper go -C services/backend-api test ./internal/services -count=1`
- `rtk env GOTMPDIR=/private/tmp/nt-go-tmp-begin-paper GOCACHE=/private/tmp/nt-go-cache-begin-paper make build`

Fixes bd `NeuraTrade-tgp`, discovered from `neura-zuju`.

## Summary by Sourcery

Align autonomous quest startup metadata with the operator trading mode and wire the quest engine to the operational mode service.

New Features:
- Determine autonomous quest execution metadata (dry_run, paper_trading, execution_mode) from the current operational mode at startup.

Enhancements:
- Introduce an operational mode service dependency on the quest engine to drive quest startup behavior, with a fallback resolver that defaults to dry mode when mode information is unavailable or non-live.

Tests:
- Add quest engine tests covering paper, dry, and live operational modes for autonomous startup metadata and behavior.