### PR TITLE
fix: expand sqlite futures arbitrage schema

### DIFF
--- a/services/backend-api/database/sqlite_migrations/081_expand_futures_arbitrage_opportunities.sql
+++ b/services/backend-api/database/sqlite_migrations/081_expand_futures_arbitrage_opportunities.sql
@@ -1,0 +1,98 @@
+-- Rebuild SQLite futures arbitrage opportunities to match runtime inserts.
+-- The original SQLite table had compact funding columns with NOT NULL
+-- constraints that conflict with the current service/API insert contract.
+
+DROP INDEX IF EXISTS idx_futures_arbitrage_is_active;
+DROP INDEX IF EXISTS idx_futures_arbitrage_detected;
+DROP INDEX IF EXISTS idx_futures_arbitrage_symbol;
+DROP INDEX IF EXISTS idx_futures_arbitrage_expires;
+DROP INDEX IF EXISTS idx_futures_arbitrage_unique;
+DROP INDEX IF EXISTS idx_futures_arbitrage_opportunities_apy;
+DROP INDEX IF EXISTS idx_futures_arbitrage_opportunities_active;
+
+CREATE TABLE futures_arbitrage_opportunities_new (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    symbol TEXT NOT NULL,
+    base_currency TEXT NOT NULL DEFAULT '',
+    quote_currency TEXT NOT NULL DEFAULT '',
+    long_exchange TEXT NOT NULL DEFAULT '',
+    short_exchange TEXT NOT NULL DEFAULT '',
+    -- Legacy numeric exchange IDs are preserved for migrated rows only; runtime
+    -- inserts write exchange slugs and intentionally leave these nullable.
+    long_exchange_id INTEGER,
+    short_exchange_id INTEGER,
+    long_funding_rate NUMERIC NOT NULL DEFAULT 0,
+    short_funding_rate NUMERIC NOT NULL DEFAULT 0,
+    net_funding_rate NUMERIC NOT NULL DEFAULT 0,
+    funding_interval INTEGER NOT NULL DEFAULT 8,
+    long_mark_price NUMERIC NOT NULL DEFAULT 0,
+    short_mark_price NUMERIC NOT NULL DEFAULT 0,
+    price_difference NUMERIC NOT NULL DEFAULT 0,
+    price_difference_percentage NUMERIC NOT NULL DEFAULT 0,
+    hourly_rate NUMERIC NOT NULL DEFAULT 0,
+    daily_rate NUMERIC NOT NULL DEFAULT 0,
+    apy NUMERIC NOT NULL DEFAULT 0,
+    estimated_profit_8h NUMERIC NOT NULL DEFAULT 0,
+    estimated_profit_daily NUMERIC NOT NULL DEFAULT 0,
+    estimated_profit_weekly NUMERIC NOT NULL DEFAULT 0,
+    estimated_profit_monthly NUMERIC NOT NULL DEFAULT 0,
+    risk_score NUMERIC NOT NULL DEFAULT 0,
+    volatility_score NUMERIC NOT NULL DEFAULT 0,
+    liquidity_score NUMERIC NOT NULL DEFAULT 0,
+    recommended_position_size NUMERIC,
+    max_leverage NUMERIC NOT NULL DEFAULT 1,
+    recommended_leverage NUMERIC DEFAULT 1,
+    stop_loss_percentage NUMERIC,
+    min_position_size NUMERIC,
+    max_position_size NUMERIC,
+    optimal_position_size NUMERIC,
+    detected_at TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at TEXT NOT NULL DEFAULT (datetime('now', '+1 hour')),
+    next_funding_time TEXT,
+    time_to_next_funding INTEGER,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    market_trend TEXT,
+    volume_24h NUMERIC,
+    open_interest NUMERIC
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_futures_arbitrage_unique
+ON futures_arbitrage_opportunities_new(symbol, long_exchange, short_exchange);
+
+INSERT OR REPLACE INTO futures_arbitrage_opportunities_new (
+    id, symbol, long_exchange, short_exchange, long_exchange_id, short_exchange_id,
+    long_funding_rate, short_funding_rate, net_funding_rate,
+    apy, risk_score, volume_24h, is_active, expires_at, detected_at
+)
+SELECT
+    COALESCE(id, lower(hex(randomblob(16)))),
+    symbol,
+    COALESCE(CAST(buy_exchange_id AS TEXT), ''),
+    COALESCE(CAST(sell_exchange_id AS TEXT), ''),
+    buy_exchange_id,
+    sell_exchange_id,
+    funding_rate_buy,
+    funding_rate_sell,
+    rate_difference,
+    apy,
+    risk_score,
+    volume_24h,
+    COALESCE(is_active, 1),
+    expires_at,
+    detected_at
+FROM futures_arbitrage_opportunities;
+
+DROP TABLE futures_arbitrage_opportunities;
+ALTER TABLE futures_arbitrage_opportunities_new RENAME TO futures_arbitrage_opportunities;
+
+CREATE INDEX IF NOT EXISTS idx_futures_arbitrage_opportunities_symbol
+ON futures_arbitrage_opportunities(symbol);
+
+CREATE INDEX IF NOT EXISTS idx_futures_arbitrage_opportunities_apy
+ON futures_arbitrage_opportunities(apy DESC);
+
+CREATE INDEX IF NOT EXISTS idx_futures_arbitrage_opportunities_active
+ON futures_arbitrage_opportunities(is_active, expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_futures_arbitrage_opportunities_detected_at
+ON futures_arbitrage_opportunities(detected_at DESC);

--- a/services/backend-api/internal/services/futures_arbitrage_service_test.go
+++ b/services/backend-api/internal/services/futures_arbitrage_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockErrorRecoveryManager is a mock implementation of ErrorRecoveryManager
@@ -300,6 +302,139 @@ func TestFuturesArbitrageService_storeOpportunity(t *testing.T) {
 	err := service.storeOpportunity(ctx, opportunity)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "database pool is not available")
+}
+
+func TestFuturesArbitrageService_storeOpportunity_SQLiteMigrationSchema(t *testing.T) {
+	_ = telemetry.Logger()
+
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "futures-arb.db"))
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+	defer func() {
+		_ = sqliteDB.Close()
+	}()
+
+	applySQLiteMigrationBySuffix(t, sqliteDB, "add_arbitrage_tables.sql")
+	_, err = sqliteDB.Exec(context.Background(), `
+		INSERT INTO futures_arbitrage_opportunities (
+			id, symbol, buy_exchange_id, sell_exchange_id,
+			funding_rate_buy, funding_rate_sell, rate_difference,
+			apy, risk_score, detected_at, expires_at
+		) VALUES
+			('legacy-1', 'ETH/USDT', 1, 2, 0.0001, -0.0002, 0.0003, 0.3, 1.0, datetime('now'), datetime('now', '+1 hour')),
+			('legacy-2', 'ETH/USDT', 1, 2, 0.0002, -0.0003, 0.0005, 0.5, 1.2, datetime('now'), datetime('now', '+1 hour'))
+	`)
+	require.NoError(t, err, "failed to seed legacy rows")
+
+	applySQLiteMigrationBySuffix(t, sqliteDB, "expand_futures_arbitrage_opportunities.sql")
+
+	service := NewFuturesArbitrageService(
+		sqliteDB,
+		nil,
+		&config.Config{Database: config.DatabaseConfig{Driver: "sqlite"}},
+		nil,
+		nil,
+		nil,
+		logging.NewStandardLogger("info", "test"),
+	)
+
+	now := time.Now().UTC()
+	opportunity := &models.FuturesArbitrageOpportunity{
+		Symbol:                    "BTC/USDT",
+		BaseCurrency:              "BTC",
+		QuoteCurrency:             "USDT",
+		LongExchange:              "binance",
+		ShortExchange:             "bybit",
+		LongFundingRate:           decimal.NewFromFloat(0.0001),
+		ShortFundingRate:          decimal.NewFromFloat(-0.0002),
+		NetFundingRate:            decimal.NewFromFloat(0.0003),
+		FundingInterval:           8,
+		LongMarkPrice:             decimal.NewFromFloat(50000),
+		ShortMarkPrice:            decimal.NewFromFloat(50100),
+		PriceDifference:           decimal.NewFromFloat(100),
+		PriceDifferencePercentage: decimal.NewFromFloat(0.2),
+		HourlyRate:                decimal.NewFromFloat(0.0000375),
+		DailyRate:                 decimal.NewFromFloat(0.0009),
+		APY:                       decimal.NewFromFloat(0.3285),
+		EstimatedProfit8h:         decimal.NewFromFloat(0.024),
+		EstimatedProfitDaily:      decimal.NewFromFloat(0.072),
+		EstimatedProfitWeekly:     decimal.NewFromFloat(0.504),
+		EstimatedProfitMonthly:    decimal.NewFromFloat(2.16),
+		RiskScore:                 decimal.NewFromFloat(1.5),
+		VolatilityScore:           decimal.NewFromFloat(0.8),
+		LiquidityScore:            decimal.NewFromFloat(0.9),
+		RecommendedPositionSize:   decimal.NewFromFloat(10000),
+		MaxLeverage:               decimal.NewFromFloat(20),
+		RecommendedLeverage:       decimal.NewFromFloat(5),
+		StopLossPercentage:        decimal.NewFromFloat(3),
+		MinPositionSize:           decimal.NewFromFloat(100),
+		MaxPositionSize:           decimal.NewFromFloat(25000),
+		OptimalPositionSize:       decimal.NewFromFloat(5000),
+		DetectedAt:                now,
+		ExpiresAt:                 now.Add(time.Hour),
+		NextFundingTime:           now.Add(30 * time.Minute),
+		TimeToNextFunding:         30,
+		IsActive:                  true,
+	}
+
+	err = service.storeOpportunity(context.Background(), opportunity)
+	require.NoError(t, err, "first storeOpportunity failed")
+
+	var count int
+	err = sqliteDB.QueryRow(
+		context.Background(),
+		`SELECT COUNT(*) FROM futures_arbitrage_opportunities
+		 WHERE symbol = $1 AND base_currency = $2 AND quote_currency = $3
+		   AND long_exchange = $4 AND short_exchange = $5`,
+		"BTC/USDT",
+		"BTC",
+		"USDT",
+		"binance",
+		"bybit",
+	).Scan(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	err = sqliteDB.QueryRow(
+		context.Background(),
+		`SELECT COUNT(*) FROM futures_arbitrage_opportunities
+		 WHERE symbol = $1 AND long_exchange = $2 AND short_exchange = $3`,
+		"ETH/USDT",
+		"1",
+		"2",
+	).Scan(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count, "migration should dedupe legacy rows before enforcing unique upserts")
+
+	opportunity.APY = decimal.NewFromFloat(0.42)
+	err = service.storeOpportunity(context.Background(), opportunity)
+	require.NoError(t, err, "second storeOpportunity failed")
+
+	err = sqliteDB.QueryRow(
+		context.Background(),
+		`SELECT COUNT(*) FROM futures_arbitrage_opportunities
+		 WHERE symbol = $1 AND long_exchange = $2 AND short_exchange = $3`,
+		"BTC/USDT",
+		"binance",
+		"bybit",
+	).Scan(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count, "unique upsert should update the existing opportunity")
+
+	var updatedAPYStr string
+	err = sqliteDB.QueryRow(
+		context.Background(),
+		`SELECT CAST(apy AS TEXT) FROM futures_arbitrage_opportunities
+		 WHERE symbol = $1 AND long_exchange = $2 AND short_exchange = $3`,
+		"BTC/USDT",
+		"binance",
+		"bybit",
+	).Scan(&updatedAPYStr)
+	assert.NoError(t, err)
+	updatedAPY, err := decimal.NewFromString(updatedAPYStr)
+	assert.NoError(t, err)
+	assert.True(t, updatedAPY.Equal(decimal.RequireFromString("0.42")), "apy mismatch: got %s", updatedAPYStr)
 }
 
 func TestFuturesArbitrageService_cleanupExpiredOpportunities(t *testing.T) {

--- a/services/backend-api/internal/services/sqlite_migration_test_helpers_test.go
+++ b/services/backend-api/internal/services/sqlite_migration_test_helpers_test.go
@@ -1,0 +1,56 @@
+package services
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/irfndi/neuratrade/internal/database"
+)
+
+func applySQLiteMigrationBySuffix(t *testing.T, db *database.SQLiteDB, filenameSuffix string) {
+	t.Helper()
+
+	migrationPath := findSQLiteMigrationBySuffix(t, filenameSuffix)
+	sqlBytes, err := os.ReadFile(migrationPath)
+	if err != nil {
+		t.Fatalf("failed to read migration %s: %v", filepath.Base(migrationPath), err)
+	}
+	if _, err := db.Exec(context.Background(), string(sqlBytes)); err != nil {
+		t.Fatalf("failed to apply migration %s: %v", filepath.Base(migrationPath), err)
+	}
+}
+
+func findSQLiteMigrationBySuffix(t *testing.T, filenameSuffix string) string {
+	t.Helper()
+
+	dir := sqliteMigrationDir(t)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to list sqlite migrations: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), filenameSuffix) {
+			return filepath.Join(dir, entry.Name())
+		}
+	}
+	t.Fatalf("sqlite migration with suffix %q not found", filenameSuffix)
+	return ""
+}
+
+func sqliteMigrationDir(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to resolve sqlite migration helper path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "database", "sqlite_migrations"))
+}


### PR DESCRIPTION
## Summary
- Add SQLite migration `081_expand_futures_arbitrage_opportunities.sql` to bring `futures_arbitrage_opportunities` up to the runtime insert contract.
- Add the unique `(symbol, long_exchange, short_exchange)` index required by the service upsert.
- Add a SQLite regression test that applies the old arbitrage table migration plus the new expansion migration, stores an opportunity, and verifies the upsert does not duplicate rows.

## Validation
- `rtk env TMPDIR=/private/tmp/nt-go-tmp-begin-paper GOTMPDIR=/private/tmp/nt-go-tmp-begin-paper GOCACHE=/private/tmp/nt-go-cache-begin-paper go -C services/backend-api test ./internal/services -run 'TestFuturesArbitrageService_storeOpportunity_SQLiteMigrationSchema' -count=1`
- `rtk env TMPDIR=/private/tmp/nt-go-tmp-begin-paper GOTMPDIR=/private/tmp/nt-go-tmp-begin-paper GOCACHE=/private/tmp/nt-go-cache-begin-paper go -C services/backend-api test ./internal/services -count=1`
- `rtk env TMPDIR=/private/tmp/nt-go-tmp-begin-paper GOTMPDIR=/private/tmp/nt-go-tmp-begin-paper GOCACHE=/private/tmp/nt-go-cache-begin-paper make build`

Fixes bd `NeuraTrade-e15`, discovered from `neura-zuju`.

## Summary by Sourcery

Align SQLite futures arbitrage opportunities schema with the service’s runtime insert contract and ensure upserts remain unique per opportunity.

Bug Fixes:
- Prevent duplicate SQLite futures arbitrage opportunity rows when upserting the same symbol and exchange pair.

Enhancements:
- Expand the SQLite futures_arbitrage_opportunities table with additional fields and indexes to match the richer Postgres-oriented model shape.

Tests:
- Add a regression test that applies legacy and new SQLite migrations and verifies futures arbitrage upserts do not create duplicate records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database infrastructure for futures arbitrage opportunities with expanded metrics including pricing, funding, risk, liquidity, and leverage data.
  * Strengthened test coverage for arbitrage opportunity data handling and schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->