### PR TITLE
fix: record scalping risk gate telemetry

### DIFF
--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -942,6 +942,15 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			Confidence: 0,
 			Reasoning:  "risk lock active",
 		}
+		h.recordScalpingGateCycle(
+			gateCtx,
+			chatID,
+			userExchange,
+			time.Now().UTC(),
+			"risk_lock",
+			checkpointString(quest.Checkpoint["runtime_entry_gate_reason"]),
+			portfolio,
+		)
 		h.notifyScalpingDecision(gateCtx, chatID, AIReasoningNotification{
 			DecisionType:     "risk_reduction",
 			Summary:          "Risk lock active: entry scans paused, risk controls still running",
@@ -1016,6 +1025,15 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			}
 			runtimeDetails["force_repair_eligible"] = fmt.Sprintf("%t", dcBool)
 		}
+		h.recordScalpingGateCycle(
+			gateCtx,
+			chatID,
+			userExchange,
+			time.Now().UTC(),
+			"state_drift_gate",
+			checkpointString(quest.Checkpoint["runtime_entry_gate_reason"]),
+			portfolio,
+		)
 		h.notifyScalpingDecision(gateCtx, chatID, AIReasoningNotification{
 			DecisionType:     "scalping_cycle",
 			Summary:          "State drift gate active: reconciling lifecycle with exchange before new entries",
@@ -2566,6 +2584,61 @@ func (h *IntegratedQuestHandlers) recordScalpingPortfolioSnapshot(
 	})
 	if err != nil {
 		log.Printf("[SCALPING] Portfolio snapshot persist failed for chat %s exchange %s: %v", chatID, exchange, err)
+	}
+}
+
+func (h *IntegratedQuestHandlers) recordScalpingGateCycle(
+	ctx context.Context,
+	chatID, exchange string,
+	cycleAt time.Time,
+	gateBlockCode, gateBlockReason string,
+	portfolio TradingPortfolio,
+) {
+	if h == nil || h.telemetryStore == nil {
+		return
+	}
+	chatID = strings.TrimSpace(chatID)
+	exchange = strings.TrimSpace(exchange)
+	gateBlockCode = strings.TrimSpace(gateBlockCode)
+	gateBlockReason = strings.TrimSpace(gateBlockReason)
+	if gateBlockCode == "" {
+		return
+	}
+	if cycleAt.IsZero() {
+		cycleAt = time.Now().UTC()
+	} else {
+		cycleAt = cycleAt.UTC()
+	}
+	rejectionJSON := "{}"
+	policyJSON, marshalErr := json.Marshal([]string{gateBlockCode})
+	if marshalErr != nil {
+		log.Printf("[TELEMETRY] Failed to marshal gate policy adjustments: %v", marshalErr)
+		policyJSON = []byte("[]")
+	}
+	cycleRec := CycleRecord{
+		ID:                     fmt.Sprintf("scalp-%s-%d", chatID, cycleAt.UnixNano()),
+		ChatID:                 chatID,
+		Exchange:               exchange,
+		CycleAt:                cycleAt,
+		Action:                 "hold",
+		Confidence:             0,
+		RejectionCountsJSON:    rejectionJSON,
+		Regime:                 portfolio.StrategyPhase,
+		GateBlockCode:          gateBlockCode,
+		GateBlockReason:        gateBlockReason,
+		AccountTier:            portfolio.AccountTier,
+		EffectiveMinConfidence: portfolio.PhaseMinConfidence,
+		EffectiveMaxCapitalPct: portfolio.PhaseMaxCapitalPct,
+		PolicyAdjustmentsJSON:  string(policyJSON),
+	}
+	baseCtx := context.Background()
+	if ctx != nil {
+		baseCtx = ctx
+	}
+	writeCtx, writeCancel := withBoundedTimeoutContext(baseCtx, 2*time.Second)
+	defer writeCancel()
+	if _, err := h.telemetryStore.InsertCycleRecord(writeCtx, cycleRec); err != nil {
+		log.Printf("[TELEMETRY] Failed to insert gated scalping cycle: %v", err)
 	}
 }
 

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -2669,6 +2669,15 @@ func (h *IntegratedQuestHandlers) executeFallbackScalping(ctx context.Context, q
 	quest.CurrentCount++
 	quest.Checkpoint["last_scalp_check"] = time.Now().UTC().Format(time.RFC3339)
 	quest.Checkpoint["chat_id"] = chatID
+	h.recordScalpingGateCycle(
+		ctx,
+		chatID,
+		h.getUserExchange(chatID),
+		time.Now().UTC(),
+		"ai_unavailable",
+		"AI scalping service is not initialized",
+		TradingPortfolio{},
+	)
 	h.notifyScalpingDecision(ctx, chatID, AIReasoningNotification{
 		DecisionType: "scalping_cycle",
 		Summary:      "Scalping engine unavailable; observe-only cycle",

--- a/services/backend-api/internal/services/quest_handlers_integrated_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_test.go
@@ -535,6 +535,50 @@ func TestIntegratedQuestHandlers_RecordsTelemetryWhenStateDriftGatesScalping(t *
 	assert.Equal(t, "bitget", exchange)
 }
 
+func TestIntegratedQuestHandlers_RecordsTelemetryWhenAIScalpingUnavailable(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "quest-ai-unavailable-telemetry.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+	telemetryStore := NewScalpingTelemetryStore(sqliteDB, nil)
+	require.NoError(t, telemetryStore.EnsureSchema(ctx))
+
+	handlers := &IntegratedQuestHandlers{
+		telemetryStore: telemetryStore,
+	}
+	quest := &Quest{
+		ID: "ai-unavailable-scalping",
+		Metadata: map[string]string{
+			"chat_id":       "dry-chat",
+			"definition_id": "scalping_execution",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err = handlers.executeFallbackScalping(ctx, quest, "dry-chat")
+	require.NoError(t, err)
+	assert.Equal(t, "ai_unavailable_hold", quest.Checkpoint["status"])
+
+	var count int
+	var action, gateBlockCode, gateBlockReason, exchange string
+	err = sqliteDB.QueryRow(ctx, `
+		SELECT COUNT(1),
+		       COALESCE(MAX(action), ''),
+		       COALESCE(MAX(gate_block_code), ''),
+		       COALESCE(MAX(gate_block_reason), ''),
+		       COALESCE(MAX(exchange), '')
+		  FROM scalping_cycle_telemetry
+	`).Scan(&count, &action, &gateBlockCode, &gateBlockReason, &exchange)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "hold", action)
+	assert.Equal(t, "ai_unavailable", gateBlockCode)
+	assert.Contains(t, gateBlockReason, "AI scalping service is not initialized")
+	assert.Equal(t, "bitget", exchange)
+}
+
 func TestShouldSendScalpingDecisionNotification_DefaultActionableOnly(t *testing.T) {
 	t.Setenv("NEURATRADE_TELEGRAM_NOTIFY_AI_DECISIONS", "")
 	t.Setenv("NEURATRADE_TELEGRAM_ACTIONABLE_ONLY", "")

--- a/services/backend-api/internal/services/quest_handlers_integrated_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_test.go
@@ -20,6 +20,14 @@ import (
 
 var testLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
 
+type scalpingGateBalanceOnlyCCXT struct {
+	balance *ccxt.BalanceResponse
+}
+
+func (m *scalpingGateBalanceOnlyCCXT) FetchBalance(ctx context.Context, exchange string) (*ccxt.BalanceResponse, error) {
+	return m.balance, nil
+}
+
 // TestIntegratedQuestHandlers_MarketScanWithTA tests market scanning with TA
 func TestIntegratedQuestHandlers_MarketScanWithTA(t *testing.T) {
 	mockNotif := &NotificationService{}
@@ -376,6 +384,155 @@ func TestIntegratedQuestHandlers_GetUserExchange_SQLiteLookup(t *testing.T) {
 
 	assert.Equal(t, "bitget", handlers.getUserExchange("chat-1"))
 	assert.Equal(t, "bitget", handlers.getUserExchange("chat-missing"))
+}
+
+func TestIntegratedQuestHandlers_RecordsTelemetryWhenRiskLockGatesScalping(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "quest-risk-lock-telemetry.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+	telemetryStore := NewScalpingTelemetryStore(sqliteDB, nil)
+	require.NoError(t, telemetryStore.EnsureSchema(ctx))
+
+	mockCCXT := &mockAIScalpingCCXT{
+		mockCCXTForPortfolioSafety: mockCCXTForPortfolioSafety{
+			balanceResponse: &ccxt.BalanceResponse{
+				Exchange: "bitget",
+				Free: map[string]float64{
+					"USDT_FUTURES_USDT": 48,
+				},
+				Total: map[string]float64{
+					"USDT_FUTURES_USDT": 48,
+				},
+			},
+		},
+	}
+	aiSvc := NewAIScalpingService(AIScalpingConfig{}, nil, nil, mockCCXT, nil, nil)
+	handlers := &IntegratedQuestHandlers{
+		ccxtService:       mockCCXT,
+		aiScalpingService: aiSvc,
+		telemetryStore:    telemetryStore,
+		opModeService: &OperationalModeService{
+			config: DefaultOperationalModeConfig(),
+			states: map[string]*OperationalModeState{
+				"live-chat": {
+					ChatID: "live-chat",
+					Mode:   OpModeLive,
+				},
+			},
+		},
+	}
+	quest := &Quest{
+		ID: "risk-lock-scalping",
+		Metadata: map[string]string{
+			"chat_id":       "live-chat",
+			"definition_id": "scalping_execution",
+		},
+		Checkpoint: map[string]interface{}{
+			"runtime_entry_blocked_by_risk_lock": true,
+			"runtime_entry_blocked_at":           time.Now().UTC().Add(-time.Minute).Format(time.RFC3339),
+		},
+	}
+
+	err = handlers.executeAIScalping(ctx, quest, "live-chat", aiSvc)
+	require.NoError(t, err)
+	assert.Equal(t, "risk_lock", quest.Checkpoint["status"])
+
+	var count int
+	var action, gateBlockCode, gateBlockReason, exchange string
+	err = sqliteDB.QueryRow(ctx, `
+		SELECT COUNT(1),
+		       COALESCE(MAX(action), ''),
+		       COALESCE(MAX(gate_block_code), ''),
+		       COALESCE(MAX(gate_block_reason), ''),
+		       COALESCE(MAX(exchange), '')
+		  FROM scalping_cycle_telemetry
+	`).Scan(&count, &action, &gateBlockCode, &gateBlockReason, &exchange)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "hold", action)
+	assert.Equal(t, "risk_lock", gateBlockCode)
+	assert.Contains(t, gateBlockReason, "risk lock active")
+	assert.Equal(t, "bitget", exchange)
+}
+
+func TestIntegratedQuestHandlers_RecordsTelemetryWhenStateDriftGatesScalping(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "quest-state-drift-telemetry.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+	telemetryStore := NewScalpingTelemetryStore(sqliteDB, nil)
+	require.NoError(t, telemetryStore.EnsureSchema(ctx))
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	balanceOnlyCCXT := &scalpingGateBalanceOnlyCCXT{
+		balance: &ccxt.BalanceResponse{
+			Exchange: "bitget",
+			Free: map[string]float64{
+				"USDT_FUTURES_USDT": 48,
+			},
+			Total: map[string]float64{
+				"USDT_FUTURES_USDT": 48,
+			},
+		},
+	}
+	aiSvc := &AIScalpingService{}
+	handlers := &IntegratedQuestHandlers{
+		ccxtService:       balanceOnlyCCXT,
+		aiScalpingService: aiSvc,
+		lifecycleStore:    lifecycleStore,
+		telemetryStore:    telemetryStore,
+		opModeService: &OperationalModeService{
+			config: DefaultOperationalModeConfig(),
+			states: map[string]*OperationalModeState{
+				"live-chat": {
+					ChatID: "live-chat",
+					Mode:   OpModeLive,
+				},
+			},
+		},
+	}
+	quest := &Quest{
+		ID: "state-drift-scalping",
+		Metadata: map[string]string{
+			"chat_id":       "live-chat",
+			"definition_id": "scalping_execution",
+		},
+		Checkpoint: map[string]interface{}{
+			"runtime_entry_blocked_by_state_drift": true,
+			"runtime_entry_blocked_at":             time.Now().UTC().Add(-time.Minute).Format(time.RFC3339),
+			"runtime_entry_gate_reason":            "state drift detected: reconcile/repair pending",
+			"state_drift_active":                   true,
+			"state_drift_positions":                2,
+			"state_drift_clean_passes":             0,
+		},
+	}
+
+	err = handlers.executeAIScalping(ctx, quest, "live-chat", aiSvc)
+	require.NoError(t, err)
+	assert.Equal(t, "state_drift_gate", quest.Checkpoint["status"])
+
+	var count int
+	var action, gateBlockCode, gateBlockReason, exchange string
+	err = sqliteDB.QueryRow(ctx, `
+		SELECT COUNT(1),
+		       COALESCE(MAX(action), ''),
+		       COALESCE(MAX(gate_block_code), ''),
+		       COALESCE(MAX(gate_block_reason), ''),
+		       COALESCE(MAX(exchange), '')
+		  FROM scalping_cycle_telemetry
+	`).Scan(&count, &action, &gateBlockCode, &gateBlockReason, &exchange)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "hold", action)
+	assert.Equal(t, "state_drift_gate", gateBlockCode)
+	assert.Contains(t, gateBlockReason, "state drift")
+	assert.Equal(t, "bitget", exchange)
 }
 
 func TestShouldSendScalpingDecisionNotification_DefaultActionableOnly(t *testing.T) {


### PR DESCRIPTION
## Summary
- persist scalping_cycle_telemetry rows when risk-lock or state-drift gates pause live entries before AI execution
- mark those cycles as hold with gate_block_code/gate_block_reason so live dashboards no longer show stale pre-gate metrics
- add SQLite regression coverage for the live risk-lock gate path

## Validation
- GOCACHE=/private/tmp/nt-go-cache-risk-lock GOTMPDIR=/private/tmp/nt-go-tmp-risk-lock go -C services/backend-api test ./internal/services -run TestIntegratedQuestHandlers_RecordsTelemetryWhenRiskLockGatesScalping -count=1
- GOCACHE=/private/tmp/nt-go-cache-risk-lock GOTMPDIR=/private/tmp/nt-go-tmp-risk-lock go -C services/backend-api test ./internal/services -count=1

Fixes NeuraTrade-6sz

## Summary by Sourcery

Record telemetry cycles when scalping is blocked by risk-related gates and add regression coverage for this behavior.

Bug Fixes:
- Persist scalping telemetry cycles as held when risk-lock or state-drift gates block live entries so dashboards no longer show stale pre-gate metrics.

Tests:
- Add SQLite-backed integration test ensuring scalping telemetry is recorded when the risk-lock gate prevents execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced telemetry and monitoring to provide better visibility when risk management gates pause scalping operations, including detailed tracking of pause reasons and current portfolio context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->