### PR TITLE
fix: reset drawdown baseline on manual resume

### DIFF
--- a/services/backend-api/internal/services/max_drawdown_halt.go
+++ b/services/backend-api/internal/services/max_drawdown_halt.go
@@ -386,6 +386,7 @@ func (h *MaxDrawdownHalt) ResumeTrading(ctx context.Context, chatID string) erro
 
 	state.TradingHalted = false
 	state.Status = DrawdownStatusNormal
+	state.resetActiveDrawdownBaseline()
 	now := time.Now().UTC()
 	state.RecoveredAt = &now
 	h.metrics.IncrementRecovery()
@@ -497,6 +498,7 @@ func (h *MaxDrawdownHalt) ForceResumeAll(ctx context.Context) []string {
 		if state.TradingHalted {
 			state.TradingHalted = false
 			state.Status = DrawdownStatusNormal
+			state.resetActiveDrawdownBaseline()
 			state.RecoveredAt = &now
 			h.metrics.IncrementRecovery()
 			resumed = append(resumed, chatID)
@@ -508,6 +510,16 @@ func (h *MaxDrawdownHalt) ForceResumeAll(ctx context.Context) []string {
 	}
 
 	return resumed
+}
+
+func (state *DrawdownState) resetActiveDrawdownBaseline() {
+	if state == nil {
+		return
+	}
+	if state.CurrentValue.GreaterThan(decimal.Zero) {
+		state.PeakValue = state.CurrentValue
+	}
+	state.CurrentDrawdown = decimal.Zero
 }
 
 // ResolveMaxDrawdownConfigFromEnv overrides default config with environment variables.

--- a/services/backend-api/internal/services/max_drawdown_halt_test.go
+++ b/services/backend-api/internal/services/max_drawdown_halt_test.go
@@ -116,15 +116,48 @@ func TestMaxDrawdownHalt_ForceHalt(t *testing.T) {
 func TestMaxDrawdownHalt_ResumeTrading(t *testing.T) {
 	halt := NewMaxDrawdownHalt(nil, DefaultMaxDrawdownConfig())
 
-	_ = halt.ForceHalt(context.Background(), "chat-1", "test")
+	state, err := halt.CheckDrawdown(context.Background(), "chat-1", decimal.NewFromInt(1000))
+	if err != nil {
+		t.Fatalf("unexpected error on initial CheckDrawdown: %v", err)
+	}
+	if state.TradingHalted {
+		t.Error("expected trading to not be halted at initial peak")
+	}
 
-	err := halt.ResumeTrading(context.Background(), "chat-1")
+	state, err = halt.CheckDrawdown(context.Background(), "chat-1", decimal.NewFromInt(800))
+	if err != nil {
+		t.Fatalf("unexpected error on drawdown CheckDrawdown: %v", err)
+	}
+	if !state.TradingHalted {
+		t.Error("expected trading to be halted after drawdown before resume")
+	}
+
+	err = halt.ResumeTrading(context.Background(), "chat-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if halt.IsTradingHalted("chat-1") {
 		t.Error("expected chat-1 to not be halted after resume")
+	}
+
+	state, exists := halt.GetState("chat-1")
+	if !exists {
+		t.Fatal("expected drawdown state after resume")
+	}
+	if !state.PeakValue.Equal(decimal.NewFromInt(800)) {
+		t.Errorf("expected active peak reset to current value 800, got %s", state.PeakValue)
+	}
+	if !state.CurrentDrawdown.IsZero() {
+		t.Errorf("expected active drawdown reset to zero, got %s", state.CurrentDrawdown)
+	}
+	if !state.MaxDrawdownSeen.Equal(decimal.RequireFromString("0.2")) {
+		t.Errorf("expected historical max drawdown to remain 0.2, got %s", state.MaxDrawdownSeen)
+	}
+
+	_, _ = halt.CheckDrawdown(context.Background(), "chat-1", decimal.NewFromInt(800))
+	if halt.IsTradingHalted("chat-1") {
+		t.Error("expected resumed chat not to immediately re-halt at the same current value")
 	}
 }
 
@@ -163,6 +196,90 @@ func TestMaxDrawdownHalt_ResetPeak(t *testing.T) {
 	state, _ := halt.GetState("chat-1")
 	if !state.PeakValue.Equal(decimal.NewFromInt(900)) {
 		t.Errorf("expected peak to be 900, got %s", state.PeakValue)
+	}
+}
+
+func TestMaxDrawdownHalt_ForceResumeAllResetsActiveBaseline(t *testing.T) {
+	halt := NewMaxDrawdownHalt(nil, DefaultMaxDrawdownConfig())
+
+	state, err := halt.CheckDrawdown(context.Background(), "chat-1", decimal.NewFromInt(1000))
+	if err != nil {
+		t.Fatalf("unexpected error on initial CheckDrawdown: %v", err)
+	}
+	if state.TradingHalted {
+		t.Error("expected chat-1 to not be halted at initial peak")
+	}
+	state, err = halt.CheckDrawdown(context.Background(), "chat-1", decimal.NewFromInt(800))
+	if err != nil {
+		t.Fatalf("unexpected error on drawdown CheckDrawdown: %v", err)
+	}
+	if !state.TradingHalted {
+		t.Error("expected chat-1 to be halted before force resume")
+	}
+	state, err = halt.CheckDrawdown(context.Background(), "chat-2", decimal.NewFromInt(500))
+	if err != nil {
+		t.Fatalf("unexpected error on chat-2 CheckDrawdown: %v", err)
+	}
+	if state.TradingHalted {
+		t.Error("expected chat-2 to not be halted")
+	}
+
+	resumed := halt.ForceResumeAll(context.Background())
+	if len(resumed) != 1 || resumed[0] != "chat-1" {
+		t.Fatalf("expected only chat-1 to resume, got %#v", resumed)
+	}
+	if halt.IsTradingHalted("chat-1") {
+		t.Fatal("expected chat-1 to be resumed")
+	}
+
+	state, exists := halt.GetState("chat-1")
+	if !exists {
+		t.Fatal("expected drawdown state for chat-1")
+	}
+	if !state.PeakValue.Equal(decimal.NewFromInt(800)) {
+		t.Errorf("expected active peak reset to current value 800, got %s", state.PeakValue)
+	}
+	if !state.CurrentDrawdown.IsZero() {
+		t.Errorf("expected active drawdown reset to zero, got %s", state.CurrentDrawdown)
+	}
+	if !state.MaxDrawdownSeen.Equal(decimal.RequireFromString("0.2")) {
+		t.Errorf("expected historical max drawdown to remain 0.2, got %s", state.MaxDrawdownSeen)
+	}
+
+	_, _ = halt.CheckDrawdown(context.Background(), "chat-1", decimal.NewFromInt(800))
+	if halt.IsTradingHalted("chat-1") {
+		t.Error("expected force-resumed chat not to immediately re-halt at the same current value")
+	}
+}
+
+func TestMaxDrawdownHalt_ForceHaltFreshAccountResumeInitializesBaseline(t *testing.T) {
+	halt := NewMaxDrawdownHalt(nil, DefaultMaxDrawdownConfig())
+
+	err := halt.ForceHalt(context.Background(), "chat-fresh", "manual")
+	if err != nil {
+		t.Fatalf("unexpected ForceHalt error: %v", err)
+	}
+
+	err = halt.ResumeTrading(context.Background(), "chat-fresh")
+	if err != nil {
+		t.Fatalf("unexpected ResumeTrading error: %v", err)
+	}
+
+	state, err := halt.CheckDrawdown(context.Background(), "chat-fresh", decimal.NewFromInt(1000))
+	if err != nil {
+		t.Fatalf("unexpected CheckDrawdown error after fresh resume: %v", err)
+	}
+	if halt.IsTradingHalted("chat-fresh") {
+		t.Error("expected fresh-resumed account not to re-halt on first check")
+	}
+	if !state.CurrentDrawdown.IsZero() {
+		t.Errorf("expected zero drawdown after fresh resume, got %s", state.CurrentDrawdown)
+	}
+	if !state.PeakValue.Equal(decimal.NewFromInt(1000)) {
+		t.Errorf("expected peak initialized to 1000, got %s", state.PeakValue)
+	}
+	if !state.CurrentValue.Equal(decimal.NewFromInt(1000)) {
+		t.Errorf("expected current value initialized to 1000, got %s", state.CurrentValue)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reset the active drawdown baseline when an operator manually resumes a halted account
- preserve historical max drawdown while preventing an immediate re-halt at the same current equity
- cover both single-account resume and force-resume-all behavior

## Tests
- rtk env GOCACHE=/private/tmp/nt-go-cache-drawdown-resume GOTMPDIR=/private/tmp/nt-go-tmp-drawdown-resume go test ./internal/services -run TestMaxDrawdownHalt -count=1
- rtk env GOCACHE=/private/tmp/nt-go-cache-drawdown-resume GOTMPDIR=/private/tmp/nt-go-tmp-drawdown-resume go test ./internal/services -count=1

Fixes NeuraTrade-gho

## Summary by Sourcery

Adjust max drawdown halt handling so that manual resume operations reset the active drawdown baseline while preserving historical drawdown metrics.

Bug Fixes:
- Ensure resuming a halted account resets the active drawdown baseline to the current value to prevent immediate re-halt at the same equity.
- Ensure force-resume-all resets active drawdown baselines for resumed accounts while keeping historical max drawdown intact.

Tests:
- Extend max drawdown halt tests to cover baseline reset and non-rehalt behavior for both single-account resume and force-resume-all flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trading resume operations to properly reset drawdown baseline tracking, preventing immediate re-halts after resume.
  * Ensured historical maximum drawdown metrics are preserved while resetting active tracking on resume.

* **Tests**
  * Expanded test coverage for trading resume scenarios and baseline reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->