### PR TITLE
fix: preserve AI provider balance diagnostics

### DIFF
--- a/services/backend-api/internal/ai/llm/anthropic.go
+++ b/services/backend-api/internal/ai/llm/anthropic.go
@@ -503,6 +503,15 @@ func (c *AnthropicClient) handleErrorResponse(statusCode int, headers http.Heade
 		if retryAfter <= 0 {
 			retryAfter = 30 * time.Second
 		}
+		if isProviderBalanceExhausted(apiErr.Error.Message, apiErr.Error.Type, "") {
+			return ProviderAPIError{
+				Provider:   provider,
+				StatusCode: statusCode,
+				Message:    apiErr.Error.Message,
+				Type:       apiErr.Error.Type,
+				RetryAfter: retryAfter,
+			}
+		}
 		return RateLimitedError{Provider: provider, RetryAfter: retryAfter}
 	case http.StatusBadRequest:
 		if apiErr.Error.Type == "invalid_request_error" {

--- a/services/backend-api/internal/ai/llm/client.go
+++ b/services/backend-api/internal/ai/llm/client.go
@@ -308,3 +308,19 @@ func (e ProviderAPIError) Error() string {
 func (e ProviderAPIError) Retryable() bool {
 	return e.StatusCode == 408 || e.StatusCode == 429 || (e.StatusCode >= 500 && e.StatusCode <= 599)
 }
+
+func isProviderBalanceExhausted(message string, errorType string, code string) bool {
+	text := strings.ToLower(strings.Join([]string{message, errorType, code}, " "))
+	return strings.Contains(text, "insufficient balance") ||
+		strings.Contains(text, "insufficient_balance") ||
+		strings.Contains(text, "insufficient quota") ||
+		strings.Contains(text, "insufficient_quota") ||
+		strings.Contains(text, "quota exceeded") ||
+		strings.Contains(text, "resource package") ||
+		strings.Contains(text, "credit exhausted") ||
+		strings.Contains(text, "credit balance") ||
+		strings.Contains(text, "billing_issue") ||
+		strings.Contains(text, "billing_limit") ||
+		strings.Contains(text, "billing exceeded") ||
+		strings.Contains(text, "1113")
+}

--- a/services/backend-api/internal/ai/llm/client_test.go
+++ b/services/backend-api/internal/ai/llm/client_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -234,12 +235,146 @@ func TestOpenAIClientComplete_UsesConfiguredProviderInErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
+	var apiErr ProviderAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected ProviderAPIError, got %T (%v)", err, err)
+	}
+	if apiErr.Provider != Provider("zhipu") {
+		t.Fatalf("expected provider zhipu, got %s", apiErr.Provider)
+	}
+	if apiErr.Type != "insufficient_balance" {
+		t.Fatalf("expected insufficient_balance type, got %q", apiErr.Type)
+	}
+	if apiErr.Code != "1113" {
+		t.Fatalf("expected code 1113, got %q", apiErr.Code)
+	}
+	if !apiErr.Retryable() {
+		t.Fatal("expected exhausted-balance 429 to remain retryable for provider failover")
+	}
+}
+
+func TestOpenAIClientComplete_RateLimitWithoutBalanceExhaustionUsesRateLimitedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"too many requests","type":"rate_limit_error","code":"rate_limit"}}`))
+	}))
+	defer server.Close()
+
+	client := NewOpenAIClient(ClientConfig{
+		Provider: Provider("zhipu"),
+		APIKey:   "test-key",
+		BaseURL:  server.URL,
+	})
+
+	_, err := client.Complete(context.Background(), &CompletionRequest{
+		Model: "glm-5-turbo",
+		Messages: []Message{
+			{Role: RoleUser, Content: "ping"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
 	rateErr, ok := err.(RateLimitedError)
 	if !ok {
 		t.Fatalf("expected RateLimitedError, got %T (%v)", err, err)
 	}
 	if rateErr.Provider != Provider("zhipu") {
 		t.Fatalf("expected provider zhipu, got %s", rateErr.Provider)
+	}
+	if rateErr.RetryAfter != 7*time.Second {
+		t.Fatalf("expected retry-after 7s, got %s", rateErr.RetryAfter)
+	}
+}
+
+func TestIsProviderBalanceExhausted(t *testing.T) {
+	tests := []struct {
+		name      string
+		message   string
+		errorType string
+		code      string
+		want      bool
+	}{
+		{
+			name:    "insufficient balance message",
+			message: "Insufficient balance",
+			want:    true,
+		},
+		{
+			name:      "insufficient balance type",
+			errorType: "insufficient_balance",
+			want:      true,
+		},
+		{
+			name:    "insufficient quota message",
+			message: "Insufficient quota",
+			want:    true,
+		},
+		{
+			name:      "insufficient quota type",
+			errorType: "insufficient_quota",
+			want:      true,
+		},
+		{
+			name: "bare 1113 code",
+			code: "1113",
+			want: true,
+		},
+		{
+			name:    "quota exceeded",
+			message: "Quota exceeded for this model",
+			want:    true,
+		},
+		{
+			name:    "credit exhausted",
+			message: "Account credit exhausted",
+			want:    true,
+		},
+		{
+			name:    "credit balance",
+			message: "Low credit balance",
+			want:    true,
+		},
+		{
+			name:    "resource package exhausted",
+			message: "resource package exhausted",
+			want:    true,
+		},
+		{
+			name:    "billing limit",
+			message: "billing_limit reached",
+			want:    true,
+		},
+		{
+			name:    "billing exceeded",
+			message: "Billing exceeded for account",
+			want:    true,
+		},
+		{
+			name:      "plain provider rate limit",
+			message:   "too many requests",
+			errorType: "rate_limit_error",
+			code:      "rate_limit",
+			want:      false,
+		},
+		{
+			name:    "credentials notice is not balance exhaustion",
+			message: "credentials validation failed",
+			want:    false,
+		},
+		{
+			name:    "billing address notice is not balance exhaustion",
+			message: "billing address update required",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isProviderBalanceExhausted(tt.message, tt.errorType, tt.code))
+		})
 	}
 }
 
@@ -313,6 +448,47 @@ func TestAnthropicClientComplete(t *testing.T) {
 
 	if resp.Usage.InputTokens != 15 {
 		t.Errorf("Expected 15 input tokens, got %d", resp.Usage.InputTokens)
+	}
+}
+
+func TestAnthropicClientComplete_PreservesBalanceExhaustion429(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"insufficient_balance","message":"resource package exhausted"}}`))
+	}))
+	defer server.Close()
+
+	client := NewAnthropicClient(ClientConfig{
+		Provider: Provider("minimax"),
+		APIKey:   "test-key",
+		BaseURL:  server.URL,
+	})
+
+	_, err := client.Complete(context.Background(), &CompletionRequest{
+		Model: "abab6.5",
+		Messages: []Message{
+			{Role: RoleUser, Content: "ping"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var apiErr ProviderAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected ProviderAPIError, got %T (%v)", err, err)
+	}
+	if apiErr.Provider != Provider("minimax") {
+		t.Fatalf("expected provider minimax, got %s", apiErr.Provider)
+	}
+	if apiErr.Type != "insufficient_balance" {
+		t.Fatalf("expected insufficient_balance type, got %q", apiErr.Type)
+	}
+	if apiErr.Message != "resource package exhausted" {
+		t.Fatalf("expected resource package message, got %q", apiErr.Message)
+	}
+	if !apiErr.Retryable() {
+		t.Fatal("expected exhausted-balance 429 to remain retryable for provider failover")
 	}
 }
 

--- a/services/backend-api/internal/ai/llm/openai.go
+++ b/services/backend-api/internal/ai/llm/openai.go
@@ -508,6 +508,16 @@ func (c *OpenAIClient) handleErrorResponse(statusCode int, headers http.Header, 
 		if retryAfter <= 0 {
 			retryAfter = 30 * time.Second
 		}
+		if isProviderBalanceExhausted(apiErr.Error.Message, apiErr.Error.Type, apiErr.Error.Code) {
+			return ProviderAPIError{
+				Provider:   provider,
+				StatusCode: statusCode,
+				Message:    apiErr.Error.Message,
+				Type:       apiErr.Error.Type,
+				Code:       apiErr.Error.Code,
+				RetryAfter: retryAfter,
+			}
+		}
 		return RateLimitedError{Provider: provider, RetryAfter: retryAfter}
 	case http.StatusBadRequest:
 		if apiErr.Error.Code == "context_length_exceeded" {

--- a/services/backend-api/internal/services/notification_ops_alerts.go
+++ b/services/backend-api/internal/services/notification_ops_alerts.go
@@ -377,6 +377,28 @@ func buildAIReasoningMessageLines(reasoning AIReasoningNotification, category st
 		if recoveryAction, ok := reasoning.RuntimeDetails["recovery_action"]; ok {
 			lines = append(lines, fmt.Sprintf("Recovery Action: %s", recoveryAction))
 		}
+		if total, ok := reasoning.RuntimeDetails["ai_window_total"]; ok {
+			if errors, eok := reasoning.RuntimeDetails["ai_window_errors"]; eok {
+				if rate, rok := reasoning.RuntimeDetails["ai_error_rate"]; rok {
+					lines = append(lines, fmt.Sprintf("AI Runtime Window: %s/%s errors (%s)", errors, total, rate))
+				} else {
+					lines = append(lines, fmt.Sprintf("AI Runtime Window: %s/%s errors", errors, total))
+				}
+			}
+		}
+		if attempts, ok := reasoning.RuntimeDetails["ai_failover_attempts"]; ok {
+			if failures, fok := reasoning.RuntimeDetails["ai_failover_failures"]; fok {
+				lines = append(lines, fmt.Sprintf("AI Failover: %s attempts, %s failures", attempts, failures))
+			} else {
+				lines = append(lines, fmt.Sprintf("AI Failover: %s attempts", attempts))
+			}
+		}
+		if failedProviders, ok := reasoning.RuntimeDetails["ai_failed_providers"]; ok {
+			lines = append(lines, fmt.Sprintf("AI Failed Providers: %s", failedProviders))
+		}
+		if category, ok := reasoning.RuntimeDetails["ai_last_category"]; ok {
+			lines = append(lines, fmt.Sprintf("AI Last Category: %s", category))
+		}
 	}
 	if strings.TrimSpace(reasoning.UnblockCondition) != "" {
 		lines = append(lines, fmt.Sprintf("Unblock Condition: %s", strings.TrimSpace(reasoning.UnblockCondition)))

--- a/services/backend-api/internal/services/notification_ops_alerts.go
+++ b/services/backend-api/internal/services/notification_ops_alerts.go
@@ -399,6 +399,9 @@ func buildAIReasoningMessageLines(reasoning AIReasoningNotification, category st
 		if category, ok := reasoning.RuntimeDetails["ai_last_category"]; ok {
 			lines = append(lines, fmt.Sprintf("AI Last Category: %s", category))
 		}
+		if lastError, ok := reasoning.RuntimeDetails["ai_last_error"]; ok {
+			lines = append(lines, fmt.Sprintf("AI Last Error: %s", lastError))
+		}
 	}
 	if strings.TrimSpace(reasoning.UnblockCondition) != "" {
 		lines = append(lines, fmt.Sprintf("Unblock Condition: %s", strings.TrimSpace(reasoning.UnblockCondition)))

--- a/services/backend-api/internal/services/notification_test.go
+++ b/services/backend-api/internal/services/notification_test.go
@@ -2486,6 +2486,7 @@ func TestNotificationService_RuntimeStatusRendering(t *testing.T) {
 				"ai_failover_failures": "3",
 				"ai_failed_providers":  "zai,minimax",
 				"ai_last_category":     "execution_unavailable",
+				"ai_last_error":        "zai-coding-plan API error (status 429): resource package exhausted, type: insufficient_balance, code: 1113",
 			},
 			Reasons: []string{"LLM completion failed"},
 			Action:  "hold",
@@ -2494,6 +2495,7 @@ func TestNotificationService_RuntimeStatusRendering(t *testing.T) {
 		assert.Contains(t, message, "AI Failover: 4 attempts, 3 failures")
 		assert.Contains(t, message, "AI Failed Providers: zai,minimax")
 		assert.Contains(t, message, "AI Last Category: execution_unavailable")
+		assert.Contains(t, message, "AI Last Error: zai-coding-plan API error (status 429): resource package exhausted")
 	})
 
 	t.Run("infrastructure hold with original confidence gated", func(t *testing.T) {

--- a/services/backend-api/internal/services/notification_test.go
+++ b/services/backend-api/internal/services/notification_test.go
@@ -2473,6 +2473,29 @@ func TestNotificationService_RuntimeStatusRendering(t *testing.T) {
 		assert.Contains(t, message, "Runtime Status:")
 	})
 
+	t.Run("LLM degraded runtime details", func(t *testing.T) {
+		message := ns.formatAIReasoningMessage(AIReasoningNotification{
+			DecisionType:  "scalping_cycle",
+			Summary:       "LLM runtime degraded",
+			RuntimeStatus: runtimeStatusLLMDegraded,
+			RuntimeDetails: map[string]string{
+				"ai_window_total":      "8",
+				"ai_window_errors":     "5",
+				"ai_error_rate":        "63%",
+				"ai_failover_attempts": "4",
+				"ai_failover_failures": "3",
+				"ai_failed_providers":  "zai,minimax",
+				"ai_last_category":     "execution_unavailable",
+			},
+			Reasons: []string{"LLM completion failed"},
+			Action:  "hold",
+		})
+		assert.Contains(t, message, "AI Runtime Window: 5/8 errors (63%)")
+		assert.Contains(t, message, "AI Failover: 4 attempts, 3 failures")
+		assert.Contains(t, message, "AI Failed Providers: zai,minimax")
+		assert.Contains(t, message, "AI Last Category: execution_unavailable")
+	})
+
 	t.Run("infrastructure hold with original confidence gated", func(t *testing.T) {
 		message := ns.formatAIReasoningMessage(AIReasoningNotification{
 			DecisionType:    "scalping_cycle",

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -5829,6 +5829,9 @@ func aiRuntimeDetailsFromCheckpoint(checkpoint map[string]interface{}) map[strin
 	if category := checkpointString(checkpoint["runtime_ai_last_category"]); category != "" {
 		details["ai_last_category"] = category
 	}
+	if lastError := truncateAIRuntimeDetail(checkpointString(checkpoint["runtime_ai_last_error"])); lastError != "" {
+		details["ai_last_error"] = lastError
+	}
 	if failed := checkpointStringSlice(checkpoint["runtime_ai_failed_providers"]); len(failed) > 0 {
 		details["ai_failed_providers"] = strings.Join(failed, ",")
 	}
@@ -5843,4 +5846,13 @@ func addCheckpointIntDetail(details map[string]string, checkpoint map[string]int
 	if value := checkpointInt(checkpoint[checkpointKey]); value > 0 {
 		details[detailKey] = strconv.Itoa(value)
 	}
+}
+
+func truncateAIRuntimeDetail(value string) string {
+	value = strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+	runes := []rune(value)
+	if len(runes) <= 180 {
+		return value
+	}
+	return string(runes[:177]) + "..."
 }

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -1477,6 +1477,10 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		} else if errRate := checkpointFloat(quest.Checkpoint["runtime_ai_window_error_rate"]); errRate > 0.5 {
 			cycleRuntimeStatus = runtimeStatusLLMDegraded
 		}
+		runtimeDetails := map[string]string(nil)
+		if cycleRuntimeStatus == runtimeStatusLLMDegraded {
+			runtimeDetails = aiRuntimeDetailsFromCheckpoint(quest.Checkpoint)
+		}
 		h.notifyScalpingDecision(ctx, chatID, AIReasoningNotification{
 			DecisionType:          "scalping_cycle",
 			Summary:               "AI held position this cycle",
@@ -1489,6 +1493,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			Reasons:               reasons,
 			Action:                "hold",
 			RuntimeStatus:         cycleRuntimeStatus,
+			RuntimeDetails:        runtimeDetails,
 		})
 		h.maybeSendHoldDigest(ctx, quest, chatID, decision, portfolio)
 		return nil
@@ -5792,10 +5797,50 @@ func shouldSendScalpingDecisionNotification(notif AIReasoningNotification) bool 
 	if action == "buy" || action == "sell" || action == "record" {
 		return true
 	}
+	if strings.EqualFold(strings.TrimSpace(notif.RuntimeStatus), runtimeStatusLLMDegraded) {
+		return true
+	}
 	switch decisionType {
 	case "pnl_reconciliation", "risk_reduction", "scalping_digest":
 		return true
 	default:
 		return false
+	}
+}
+
+func aiRuntimeDetailsFromCheckpoint(checkpoint map[string]interface{}) map[string]string {
+	if len(checkpoint) == 0 {
+		return nil
+	}
+
+	details := map[string]string{}
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_total", "ai_window_total")
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_errors", "ai_window_errors")
+	if rate := checkpointFloat(checkpoint["runtime_ai_window_error_rate"]); rate > 0 {
+		details["ai_error_rate"] = fmt.Sprintf("%.0f%%", rate*100)
+	}
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_timeouts", "ai_timeouts")
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_parse_fails", "ai_parse_fails")
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_failover_attempts", "ai_failover_attempts")
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_failover_failures", "ai_failover_failures")
+	if provider := checkpointString(checkpoint["runtime_ai_last_provider"]); provider != "" {
+		details["ai_last_provider"] = provider
+	}
+	if category := checkpointString(checkpoint["runtime_ai_last_category"]); category != "" {
+		details["ai_last_category"] = category
+	}
+	if failed := checkpointStringSlice(checkpoint["runtime_ai_failed_providers"]); len(failed) > 0 {
+		details["ai_failed_providers"] = strings.Join(failed, ",")
+	}
+
+	if len(details) == 0 {
+		return nil
+	}
+	return details
+}
+
+func addCheckpointIntDetail(details map[string]string, checkpoint map[string]interface{}, checkpointKey string, detailKey string) {
+	if value := checkpointInt(checkpoint[checkpointKey]); value > 0 {
+		details[detailKey] = strconv.Itoa(value)
 	}
 }

--- a/services/backend-api/internal/services/quest_handlers_integrated_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_test.go
@@ -587,6 +587,11 @@ func TestShouldSendScalpingDecisionNotification_DefaultActionableOnly(t *testing
 		DecisionType: "scalping_cycle",
 		Action:       "hold",
 	}))
+	assert.True(t, shouldSendScalpingDecisionNotification(AIReasoningNotification{
+		DecisionType:  "scalping_cycle",
+		Action:        "hold",
+		RuntimeStatus: runtimeStatusLLMDegraded,
+	}), "LLM-degraded hold cycles must alert even when actionable-only filtering is enabled")
 
 	assert.True(t, shouldSendScalpingDecisionNotification(AIReasoningNotification{
 		DecisionType: "scalping",
@@ -622,6 +627,29 @@ func TestShouldSendScalpingDecisionNotification_EnvOverrides(t *testing.T) {
 		DecisionType: "scalping_cycle",
 		Action:       "hold",
 	}))
+}
+
+func TestAIRuntimeDetailsFromCheckpoint(t *testing.T) {
+	details := aiRuntimeDetailsFromCheckpoint(map[string]interface{}{
+		"runtime_ai_window_total":             8,
+		"runtime_ai_window_errors":            5,
+		"runtime_ai_window_error_rate":        0.63,
+		"runtime_ai_window_failover_attempts": 4,
+		"runtime_ai_window_failover_failures": 3,
+		"runtime_ai_last_provider":            "zai",
+		"runtime_ai_last_category":            aiReasonExecutionUnavailable,
+		"runtime_ai_failed_providers":         []string{"zai", "minimax"},
+	})
+
+	require.NotNil(t, details)
+	assert.Equal(t, "8", details["ai_window_total"])
+	assert.Equal(t, "5", details["ai_window_errors"])
+	assert.Equal(t, "63%", details["ai_error_rate"])
+	assert.Equal(t, "4", details["ai_failover_attempts"])
+	assert.Equal(t, "3", details["ai_failover_failures"])
+	assert.Equal(t, "zai", details["ai_last_provider"])
+	assert.Equal(t, aiReasonExecutionUnavailable, details["ai_last_category"])
+	assert.Equal(t, "zai,minimax", details["ai_failed_providers"])
 }
 
 func TestIntegratedQuestHandlers_EvaluateRecoveryGateState_HybridModes(t *testing.T) {

--- a/services/backend-api/internal/services/quest_handlers_integrated_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_test.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	appautonomy "github.com/irfndi/neuratrade/internal/app/autonomy"
 	"github.com/irfndi/neuratrade/internal/ccxt"
@@ -638,6 +640,7 @@ func TestAIRuntimeDetailsFromCheckpoint(t *testing.T) {
 		"runtime_ai_window_failover_failures": 3,
 		"runtime_ai_last_provider":            "zai",
 		"runtime_ai_last_category":            aiReasonExecutionUnavailable,
+		"runtime_ai_last_error":               "zai-coding-plan API error (status 429): resource package exhausted, type: insufficient_balance, code: 1113",
 		"runtime_ai_failed_providers":         []string{"zai", "minimax"},
 	})
 
@@ -649,7 +652,48 @@ func TestAIRuntimeDetailsFromCheckpoint(t *testing.T) {
 	assert.Equal(t, "3", details["ai_failover_failures"])
 	assert.Equal(t, "zai", details["ai_last_provider"])
 	assert.Equal(t, aiReasonExecutionUnavailable, details["ai_last_category"])
+	assert.Contains(t, details["ai_last_error"], "resource package exhausted")
 	assert.Equal(t, "zai,minimax", details["ai_failed_providers"])
+}
+
+func TestTruncateAIRuntimeDetail_PreservesUTF8(t *testing.T) {
+	input := strings.Repeat("資", 181)
+
+	got := truncateAIRuntimeDetail(input)
+
+	require.True(t, utf8.ValidString(got))
+	assert.True(t, strings.HasSuffix(got, "..."))
+	assert.Equal(t, 180, utf8.RuneCountInString(got))
+}
+
+func TestTruncateAIRuntimeDetail_Boundaries(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "trims and collapses whitespace",
+			input: "  provider\tbalance\n\nexhausted  ",
+			want:  "provider balance exhausted",
+		},
+		{
+			name:  "preserves exactly 180 runes",
+			input: strings.Repeat("a", 180),
+			want:  strings.Repeat("a", 180),
+		},
+		{
+			name:  "truncates over 180 runes",
+			input: strings.Repeat("b", 181),
+			want:  strings.Repeat("b", 177) + "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, truncateAIRuntimeDetail(tt.input))
+		})
+	}
 }
 
 func TestIntegratedQuestHandlers_EvaluateRecoveryGateState_HybridModes(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve OpenAI-compatible and Anthropic-compatible 429 provider-account failures as ProviderAPIError when the body indicates insufficient balance/quota/resource package exhaustion
- keep those 429 errors retryable so failover can still try the next provider
- include the last AI runtime error in degraded-runtime Telegram details, truncated for operator readability

## Verification
- env GOCACHE=/private/tmp/nt-go-cache go test ./internal/ai/llm -run 'TestOpenAIClientComplete_UsesConfiguredProviderInErrors|TestOpenAIClientComplete_RateLimitWithoutBalanceExhaustionUsesRateLimitedError|TestAnthropicClientComplete_PreservesBalanceExhaustion429'
- env GOCACHE=/private/tmp/nt-go-cache go test ./internal/services -run 'TestAIRuntimeDetailsFromCheckpoint|TestNotificationService_RuntimeStatusRendering'
- env GOCACHE=/private/tmp/nt-go-cache go test ./internal/ai/llm ./internal/services
- env GOCACHE=/private/tmp/nt-go-cache make build

Stacked on #349. This improves diagnostics for NeuraTrade-8sd but does not itself fund or reconfigure a provider.

## Summary by Sourcery

Improve AI provider error handling and runtime diagnostics for balance-related failures and operational alerts.

Bug Fixes:
- Preserve provider-specific 429 insufficient balance/quota errors as ProviderAPIError while keeping them retryable for failover across OpenAI-compatible and Anthropic-compatible clients.

Enhancements:
- Detect provider balance exhaustion heuristically from error payloads and map such 429 responses to richer ProviderAPIError metadata including message, type, code, and retry-after.
- Expose and truncate the last AI runtime error from checkpoints into runtime details and operator notifications for clearer degraded-runtime diagnostics.
- Extend AI notification messages with the last AI error context and ensure retry-after headers are surfaced correctly for rate limit handling.

Tests:
- Add and update unit tests for OpenAI and Anthropic clients, runtime detail extraction, and notification rendering to cover new balance exhaustion handling and AI error diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for AI provider rate-limit responses to properly distinguish between rate-limiting and account/balance issues.
  * Added tracking of the last encountered AI error in runtime diagnostics.

* **Tests**
  * Expanded test coverage for AI provider error scenarios and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->