### PR TITLE
fix(strategy): dedupe scalping signal publishes

### DIFF
--- a/services/backend-api/internal/app/strategy/strategy_actor.go
+++ b/services/backend-api/internal/app/strategy/strategy_actor.go
@@ -80,6 +80,7 @@ type StrategyActor struct {
 	windows          map[string][]signals.Tick
 	candleBuffer     map[string][]scalping.OHLCVCandle
 	obMetricsCache   map[string]scalping.OrderBookMetrics
+	lastScalpingIDs  map[string]string
 	logger           *slog.Logger
 	scalpingComposer ScalpingSignalComposer
 }
@@ -103,15 +104,16 @@ func NewStrategyActor(cfg Config, bus *eventbus.Bus, logger *slog.Logger) *Strat
 	}
 
 	return &StrategyActor{
-		id:             cfg.ActorID,
-		strategyID:     cfg.StrategyID,
-		windowSize:     cfg.WindowSize,
-		engine:         signals.NewEngine(cfg.Signal),
-		eventBus:       bus,
-		windows:        make(map[string][]signals.Tick),
-		candleBuffer:   make(map[string][]scalping.OHLCVCandle),
-		obMetricsCache: make(map[string]scalping.OrderBookMetrics),
-		logger:         logger,
+		id:              cfg.ActorID,
+		strategyID:      cfg.StrategyID,
+		windowSize:      cfg.WindowSize,
+		engine:          signals.NewEngine(cfg.Signal),
+		eventBus:        bus,
+		windows:         make(map[string][]signals.Tick),
+		candleBuffer:    make(map[string][]scalping.OHLCVCandle),
+		obMetricsCache:  make(map[string]scalping.OrderBookMetrics),
+		lastScalpingIDs: make(map[string]string),
+		logger:          logger,
 	}
 }
 
@@ -200,6 +202,10 @@ func (s *StrategyActor) handleTick(ctx context.Context, env actor.Envelope, tick
 }
 
 func (s *StrategyActor) tryComposeScalpingSignal(ctx context.Context, traceID string, tick marketdata.MarketTickEvent) {
+	if s.eventBus == nil {
+		return
+	}
+
 	key := tick.Exchange + ":" + tick.Symbol
 	candles := s.candleBuffer[key]
 	if len(candles) == 0 {
@@ -224,6 +230,13 @@ func (s *StrategyActor) tryComposeScalpingSignal(ctx context.Context, traceID st
 		return
 	}
 	if result == nil {
+		return
+	}
+	if result.ID != "" && s.lastScalpingIDs[key] == result.ID {
+		s.logger.Debug("skipping duplicate scalping signal",
+			"signal_id", result.ID,
+			"exchange", tick.Exchange,
+			"symbol", tick.Symbol)
 		return
 	}
 
@@ -266,6 +279,10 @@ func (s *StrategyActor) tryComposeScalpingSignal(ctx context.Context, traceID st
 
 	if err := s.eventBus.PublishSync(ctx, event); err != nil {
 		s.logger.Warn("failed to publish scalping signal", "error", err)
+		return
+	}
+	if result.ID != "" {
+		s.lastScalpingIDs[key] = result.ID
 	}
 }
 

--- a/services/backend-api/internal/app/strategy/strategy_actor.go
+++ b/services/backend-api/internal/app/strategy/strategy_actor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/irfndi/neuratrade/internal/domain/marketdata"
@@ -80,7 +81,7 @@ type StrategyActor struct {
 	windows          map[string][]signals.Tick
 	candleBuffer     map[string][]scalping.OHLCVCandle
 	obMetricsCache   map[string]scalping.OrderBookMetrics
-	lastScalpingIDs  map[string]string
+	lastScalpingKeys map[string]string
 	logger           *slog.Logger
 	scalpingComposer ScalpingSignalComposer
 }
@@ -104,16 +105,16 @@ func NewStrategyActor(cfg Config, bus *eventbus.Bus, logger *slog.Logger) *Strat
 	}
 
 	return &StrategyActor{
-		id:              cfg.ActorID,
-		strategyID:      cfg.StrategyID,
-		windowSize:      cfg.WindowSize,
-		engine:          signals.NewEngine(cfg.Signal),
-		eventBus:        bus,
-		windows:         make(map[string][]signals.Tick),
-		candleBuffer:    make(map[string][]scalping.OHLCVCandle),
-		obMetricsCache:  make(map[string]scalping.OrderBookMetrics),
-		lastScalpingIDs: make(map[string]string),
-		logger:          logger,
+		id:               cfg.ActorID,
+		strategyID:       cfg.StrategyID,
+		windowSize:       cfg.WindowSize,
+		engine:           signals.NewEngine(cfg.Signal),
+		eventBus:         bus,
+		windows:          make(map[string][]signals.Tick),
+		candleBuffer:     make(map[string][]scalping.OHLCVCandle),
+		obMetricsCache:   make(map[string]scalping.OrderBookMetrics),
+		lastScalpingKeys: make(map[string]string),
+		logger:           logger,
 	}
 }
 
@@ -232,7 +233,8 @@ func (s *StrategyActor) tryComposeScalpingSignal(ctx context.Context, traceID st
 	if result == nil {
 		return
 	}
-	if result.ID != "" && s.lastScalpingIDs[key] == result.ID {
+	fingerprint := scalpingSignalFingerprint(result)
+	if fingerprint != "" && s.lastScalpingKeys[key] == fingerprint {
 		s.logger.Debug("skipping duplicate scalping signal",
 			"signal_id", result.ID,
 			"exchange", tick.Exchange,
@@ -281,9 +283,58 @@ func (s *StrategyActor) tryComposeScalpingSignal(ctx context.Context, traceID st
 		s.logger.Warn("failed to publish scalping signal", "error", err)
 		return
 	}
-	if result.ID != "" {
-		s.lastScalpingIDs[key] = result.ID
+	if fingerprint != "" {
+		s.lastScalpingKeys[key] = fingerprint
 	}
+}
+
+func scalpingSignalFingerprint(signal *scalping.ScalpingSignal) string {
+	if signal == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(signal.Exchange)
+	b.WriteByte('|')
+	b.WriteString(signal.Symbol)
+	b.WriteByte('|')
+	b.WriteString(string(signal.Direction))
+	b.WriteByte('|')
+	b.WriteString(signal.Confidence.String())
+	b.WriteByte('|')
+	b.WriteString(signal.StopLoss.String())
+	b.WriteByte('|')
+	b.WriteString(signal.TakeProfit.String())
+
+	if signal.Quality != nil {
+		b.WriteString("|q=")
+		b.WriteString(signal.Quality.OverallScore.String())
+		b.WriteByte('/')
+		b.WriteString(signal.Quality.DataFreshness.String())
+		b.WriteByte('/')
+		b.WriteString(signal.Quality.LiquidityScore.String())
+		b.WriteByte('/')
+		if signal.Quality.VolatilityOK {
+			b.WriteByte('1')
+		} else {
+			b.WriteByte('0')
+		}
+	}
+
+	for _, component := range signal.Components {
+		b.WriteString("|c=")
+		b.WriteString(component.Name)
+		b.WriteByte('/')
+		b.WriteString(component.Value.String())
+		b.WriteByte('/')
+		b.WriteString(string(component.Signal))
+		b.WriteByte('/')
+		b.WriteString(string(component.Strength))
+		b.WriteByte('/')
+		b.WriteString(component.Weight.String())
+	}
+
+	return b.String()
 }
 
 func (s *StrategyActor) handleCandle(candle marketdata.MarketCandleEvent) {

--- a/services/backend-api/internal/app/strategy/strategy_actor.go
+++ b/services/backend-api/internal/app/strategy/strategy_actor.go
@@ -204,6 +204,10 @@ func (s *StrategyActor) handleTick(ctx context.Context, env actor.Envelope, tick
 
 func (s *StrategyActor) tryComposeScalpingSignal(ctx context.Context, traceID string, tick marketdata.MarketTickEvent) {
 	if s.eventBus == nil {
+		s.logger.Warn("skipping scalping signal composition because event bus is unavailable",
+			"exchange", tick.Exchange,
+			"symbol", tick.Symbol,
+		)
 		return
 	}
 

--- a/services/backend-api/internal/app/strategy/strategy_actor_test.go
+++ b/services/backend-api/internal/app/strategy/strategy_actor_test.go
@@ -233,7 +233,7 @@ func TestStrategyActor_DeterministicReplay(t *testing.T) {
 func TestStrategyActor_ScalpingSignalNilEventBusDoesNotPanic(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Signal.Lookback = 3
-	actor := NewStrategyActor(cfg, nil, nil)
+	strategyActor := NewStrategyActor(cfg, nil, nil)
 	composer := &stubScalpingComposer{
 		signal: &scalping.ScalpingSignal{
 			ID:         "scalp-1",
@@ -243,12 +243,14 @@ func TestStrategyActor_ScalpingSignalNilEventBusDoesNotPanic(t *testing.T) {
 			Confidence: decimal.RequireFromString("0.75"),
 		},
 	}
-	actor.SetScalpingComposer(composer)
+	strategyActor.SetScalpingComposer(composer)
 
-	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestCandleMessage{Candle: scalpingTestCandle()})))
+	require.NoError(t, strategyActor.Receive(context.Background(), actorEnvelope(&IngestCandleMessage{Candle: scalpingTestCandle()})))
+	var receiveErr error
 	require.NotPanics(t, func() {
-		require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
+		receiveErr = strategyActor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()}))
 	})
+	require.NoError(t, receiveErr)
 	require.Equal(t, 0, composer.calls, "nil event bus should avoid composing an unpublishable scalping signal")
 }
 
@@ -256,8 +258,8 @@ func TestStrategyActor_ScalpingSignalDeduplicatesEquivalentSignalsPerSymbol(t *t
 	bus := eventbus.New(eventbus.DefaultConfig())
 	cfg := DefaultConfig()
 	cfg.Signal.Lookback = 3
-	actor := NewStrategyActor(cfg, bus, nil)
-	actor.SetScalpingComposer(&stubScalpingComposer{
+	strategyActor := NewStrategyActor(cfg, bus, nil)
+	strategyActor.SetScalpingComposer(&stubScalpingComposer{
 		signals: []*scalping.ScalpingSignal{
 			{
 				ID:         "scalp-signal-1",
@@ -321,10 +323,10 @@ func TestStrategyActor_ScalpingSignalDeduplicatesEquivalentSignalsPerSymbol(t *t
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
-	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestCandleMessage{Candle: scalpingTestCandle()})))
-	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
-	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
-	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
+	require.NoError(t, strategyActor.Receive(context.Background(), actorEnvelope(&IngestCandleMessage{Candle: scalpingTestCandle()})))
+	require.NoError(t, strategyActor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
+	require.NoError(t, strategyActor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
+	require.NoError(t, strategyActor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
 
 	select {
 	case event := <-published:

--- a/services/backend-api/internal/app/strategy/strategy_actor_test.go
+++ b/services/backend-api/internal/app/strategy/strategy_actor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/irfndi/neuratrade/internal/platform/actor"
 	"github.com/irfndi/neuratrade/internal/platform/eventbus"
 	"github.com/irfndi/neuratrade/internal/ports"
+	scalping "github.com/irfndi/neuratrade/internal/services/scalping"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 )
@@ -229,6 +230,75 @@ func TestStrategyActor_DeterministicReplay(t *testing.T) {
 	}
 }
 
+func TestStrategyActor_ScalpingSignalNilEventBusDoesNotPanic(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Signal.Lookback = 3
+	actor := NewStrategyActor(cfg, nil, nil)
+	composer := &stubScalpingComposer{
+		signal: &scalping.ScalpingSignal{
+			ID:         "scalp-1",
+			Exchange:   "bitget",
+			Symbol:     "BTC/USDT",
+			Direction:  scalping.DirectionBuy,
+			Confidence: decimal.RequireFromString("0.75"),
+		},
+	}
+	actor.SetScalpingComposer(composer)
+
+	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestCandleMessage{Candle: scalpingTestCandle()})))
+	require.NotPanics(t, func() {
+		require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
+	})
+	require.Equal(t, 0, composer.calls, "nil event bus should avoid composing an unpublishable scalping signal")
+}
+
+func TestStrategyActor_ScalpingSignalDeduplicatesPerSymbol(t *testing.T) {
+	bus := eventbus.New(eventbus.DefaultConfig())
+	cfg := DefaultConfig()
+	cfg.Signal.Lookback = 3
+	actor := NewStrategyActor(cfg, bus, nil)
+	actor.SetScalpingComposer(&stubScalpingComposer{
+		signal: &scalping.ScalpingSignal{
+			ID:         "same-scalp-signal",
+			Exchange:   "bitget",
+			Symbol:     "BTC/USDT",
+			Direction:  scalping.DirectionBuy,
+			Confidence: decimal.RequireFromString("0.75"),
+			Components: []scalping.SignalComponent{
+				{Name: "spread", Signal: scalping.DirectionBuy},
+			},
+		},
+	})
+
+	published := make(chan signals.ScalpingSignalProposedEvent, 2)
+	sub, err := bus.Subscribe(context.Background(), ports.EventTypeScalpingSignalProposed, func(ctx context.Context, event eventbus.Event) error {
+		payload, ok := event.Payload.(signals.ScalpingSignalProposedEvent)
+		if ok {
+			published <- payload
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestCandleMessage{Candle: scalpingTestCandle()})))
+	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
+	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
+
+	select {
+	case event := <-published:
+		require.Equal(t, "same-scalp-signal", event.SignalID)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for scalping signal")
+	}
+
+	select {
+	case duplicate := <-published:
+		t.Fatalf("unexpected duplicate scalping signal: %s", duplicate.SignalID)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func replayWithActor(ticks []marketdata.MarketTickEvent) ([]signals.SignalProposedEvent, error) {
 	bus := eventbus.New(eventbus.DefaultConfig())
 	cfg := DefaultConfig()
@@ -260,6 +330,50 @@ func replayWithActor(ticks []marketdata.MarketTickEvent) ([]signals.SignalPropos
 		}
 	}
 	return out, nil
+}
+
+type stubScalpingComposer struct {
+	signal *scalping.ScalpingSignal
+	err    error
+	calls  int
+}
+
+func (s *stubScalpingComposer) ComposeSignal(
+	ctx context.Context,
+	ohlcv scalping.OHLCVData,
+	obMetrics scalping.OrderBookMetrics,
+) (*scalping.ScalpingSignal, error) {
+	s.calls++
+	return s.signal, s.err
+}
+
+func actorEnvelope(message actor.Message) actor.Envelope {
+	return actor.Envelope{Message: message, TraceID: "test-trace"}
+}
+
+func scalpingTestCandle() marketdata.MarketCandleEvent {
+	return marketdata.MarketCandleEvent{
+		Exchange:  "bitget",
+		Symbol:    "BTC/USDT",
+		Timestamp: time.Unix(1700003000, 0),
+		Open:      decimal.RequireFromString("100"),
+		High:      decimal.RequireFromString("101"),
+		Low:       decimal.RequireFromString("99"),
+		Close:     decimal.RequireFromString("100.5"),
+		Volume:    decimal.RequireFromString("10"),
+	}
+}
+
+func scalpingTestTick() marketdata.MarketTickEvent {
+	return marketdata.MarketTickEvent{
+		Exchange:  "bitget",
+		Symbol:    "BTC/USDT",
+		Last:      decimal.RequireFromString("100.5"),
+		Bid:       decimal.RequireFromString("100.4"),
+		Ask:       decimal.RequireFromString("100.6"),
+		Volume:    decimal.RequireFromString("10"),
+		Timestamp: time.Unix(1700003001, 0),
+	}
 }
 
 func startActor(t *testing.T, ref *actor.Ref) (context.CancelFunc, chan error) {

--- a/services/backend-api/internal/app/strategy/strategy_actor_test.go
+++ b/services/backend-api/internal/app/strategy/strategy_actor_test.go
@@ -252,20 +252,60 @@ func TestStrategyActor_ScalpingSignalNilEventBusDoesNotPanic(t *testing.T) {
 	require.Equal(t, 0, composer.calls, "nil event bus should avoid composing an unpublishable scalping signal")
 }
 
-func TestStrategyActor_ScalpingSignalDeduplicatesPerSymbol(t *testing.T) {
+func TestStrategyActor_ScalpingSignalDeduplicatesEquivalentSignalsPerSymbol(t *testing.T) {
 	bus := eventbus.New(eventbus.DefaultConfig())
 	cfg := DefaultConfig()
 	cfg.Signal.Lookback = 3
 	actor := NewStrategyActor(cfg, bus, nil)
 	actor.SetScalpingComposer(&stubScalpingComposer{
-		signal: &scalping.ScalpingSignal{
-			ID:         "same-scalp-signal",
-			Exchange:   "bitget",
-			Symbol:     "BTC/USDT",
-			Direction:  scalping.DirectionBuy,
-			Confidence: decimal.RequireFromString("0.75"),
-			Components: []scalping.SignalComponent{
-				{Name: "spread", Signal: scalping.DirectionBuy},
+		signals: []*scalping.ScalpingSignal{
+			{
+				ID:         "scalp-signal-1",
+				Exchange:   "bitget",
+				Symbol:     "BTC/USDT",
+				Direction:  scalping.DirectionBuy,
+				Confidence: decimal.RequireFromString("0.75"),
+				Components: []scalping.SignalComponent{
+					{
+						Name:     "spread",
+						Value:    decimal.RequireFromString("0.04"),
+						Signal:   scalping.DirectionBuy,
+						Strength: scalping.StrengthMedium,
+						Weight:   decimal.RequireFromString("0.10"),
+					},
+				},
+			},
+			{
+				ID:         "scalp-signal-2",
+				Exchange:   "bitget",
+				Symbol:     "BTC/USDT",
+				Direction:  scalping.DirectionBuy,
+				Confidence: decimal.RequireFromString("0.75"),
+				Components: []scalping.SignalComponent{
+					{
+						Name:     "spread",
+						Value:    decimal.RequireFromString("0.04"),
+						Signal:   scalping.DirectionBuy,
+						Strength: scalping.StrengthMedium,
+						Weight:   decimal.RequireFromString("0.10"),
+					},
+				},
+			},
+			{
+				ID:         "scalp-signal-3",
+				Exchange:   "bitget",
+				Symbol:     "BTC/USDT",
+				Direction:  scalping.DirectionSell,
+				Confidence: decimal.RequireFromString("0.75"),
+				Components: []scalping.SignalComponent{
+					{
+						Name:     "spread",
+						Value:    decimal.RequireFromString("0.21"),
+						Signal:   scalping.DirectionSell,
+						Strength: scalping.StrengthWeak,
+						Weight:   decimal.RequireFromString("0.10"),
+					},
+				},
 			},
 		},
 	})
@@ -284,17 +324,25 @@ func TestStrategyActor_ScalpingSignalDeduplicatesPerSymbol(t *testing.T) {
 	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestCandleMessage{Candle: scalpingTestCandle()})))
 	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
 	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
+	require.NoError(t, actor.Receive(context.Background(), actorEnvelope(&IngestMarketTickMessage{Tick: scalpingTestTick()})))
 
 	select {
 	case event := <-published:
-		require.Equal(t, "same-scalp-signal", event.SignalID)
+		require.Equal(t, "scalp-signal-1", event.SignalID)
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for scalping signal")
 	}
 
 	select {
-	case duplicate := <-published:
-		t.Fatalf("unexpected duplicate scalping signal: %s", duplicate.SignalID)
+	case event := <-published:
+		require.Equal(t, "scalp-signal-3", event.SignalID)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for changed scalping signal")
+	}
+
+	select {
+	case event := <-published:
+		t.Fatalf("unexpected extra scalping signal: %s", event.SignalID)
 	case <-time.After(50 * time.Millisecond):
 	}
 }
@@ -333,9 +381,10 @@ func replayWithActor(ticks []marketdata.MarketTickEvent) ([]signals.SignalPropos
 }
 
 type stubScalpingComposer struct {
-	signal *scalping.ScalpingSignal
-	err    error
-	calls  int
+	signal  *scalping.ScalpingSignal
+	signals []*scalping.ScalpingSignal
+	err     error
+	calls   int
 }
 
 func (s *stubScalpingComposer) ComposeSignal(
@@ -344,6 +393,13 @@ func (s *stubScalpingComposer) ComposeSignal(
 	obMetrics scalping.OrderBookMetrics,
 ) (*scalping.ScalpingSignal, error) {
 	s.calls++
+	if len(s.signals) > 0 {
+		index := s.calls - 1
+		if index >= len(s.signals) {
+			index = len(s.signals) - 1
+		}
+		return s.signals[index], s.err
+	}
 	return s.signal, s.err
 }
 


### PR DESCRIPTION
## Summary
- add a nil-event-bus guard before scalping signal composition/publish in StrategyActor
- suppress repeated scalping signal publishes per exchange/symbol when the composer returns the same signal ID
- add regression tests for nil bus handling and duplicate scalping signal suppression

## Root cause
The normal strategy signal path returned ErrNilEventBus before publishing, but the scalping path called PublishSync unconditionally. It also re-published the same scalping signal ID on repeated ticks for the same symbol.

## Validation
- go test ./internal/app/strategy -count=1
- make build

Fixes NeuraTrade-2ht.

## Summary by Sourcery

Prevent StrategyActor from composing or publishing invalid or duplicate scalping signals.

Bug Fixes:
- Avoid composing and publishing scalping signals when no event bus is configured to prevent nil-bus panics.
- Suppress repeated scalping signal publications per exchange/symbol when the composer returns the same signal ID.

Tests:
- Add regression tests covering nil event bus handling for scalping signals and deduplication of repeated scalping signal publishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate scalping trading signals per symbol during market-data processing, reducing alert fatigue and improving signal relevance.
  * Improved resilience when market-ingest pipelines lack an event bus, avoiding panics and ensuring stable processing under edge conditions.

* **Tests**
  * Added tests covering nil-event-bus behavior and per-symbol scalping-signal deduplication to validate expected runtime behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/360)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->