### PR TITLE
fix(signals): allow technical fallback without volume history

### DIFF
--- a/services/backend-api/internal/services/signal_aggregator.go
+++ b/services/backend-api/internal/services/signal_aggregator.go
@@ -37,6 +37,8 @@ const (
 	SignalStrengthStrong SignalStrength = "strong"
 )
 
+const technicalAnalysisMinHistory = 50
+
 // AggregatedSignal represents a consolidated trading signal derived from multiple sources or indicators.
 type AggregatedSignal struct {
 	ID              string                 `json:"id" gorm:"primaryKey"`
@@ -325,24 +327,25 @@ func (sa *SignalAggregator) AggregateTechnicalSignals(ctx context.Context, input
 
 	sa.logger.WithFields(map[string]interface{}{"symbol": input.Symbol}).Info("Aggregating technical signals")
 
-	if len(input.Prices) < 50 {
+	if len(input.Prices) < technicalAnalysisMinHistory {
 		sa.logger.WithFields(zaplogrus.Fields{
-			"required_points": 50,
+			"required_points": technicalAnalysisMinHistory,
 			"actual_points":   len(input.Prices),
 		}).Error("Insufficient price data for technical analysis")
-		err := fmt.Errorf("insufficient price data for technical analysis: need at least 50 points, got %d", len(input.Prices))
+		err := fmt.Errorf("insufficient price data for technical analysis: need at least %d points, got %d", technicalAnalysisMinHistory, len(input.Prices))
 		observability.AddBreadcrumb(spanCtx, "signal_aggregator", "Insufficient data for analysis", sentry.LevelWarning)
 		return nil, err
 	}
 
-	if len(input.Volumes) < 50 {
+	if len(input.Volumes) < technicalAnalysisMinHistory {
 		sa.logger.WithFields(zaplogrus.Fields{
-			"required_volume_points": 50,
-			"actual_volume_points":   len(input.Volumes),
-		}).Error("Insufficient volume data for technical analysis")
-		err := fmt.Errorf("insufficient volume data for technical analysis: need at least 50 points, got %d", len(input.Volumes))
-		observability.AddBreadcrumb(spanCtx, "signal_aggregator", "Insufficient volume data for analysis", sentry.LevelWarning)
-		return nil, err
+			"symbol":          input.Symbol,
+			"exchange":        input.Exchange,
+			"required_points": technicalAnalysisMinHistory,
+			"actual_points":   len(input.Volumes),
+			"prices_count":    len(input.Prices),
+		}).Info("Volume history below technical threshold; continuing with fallback-capable aggregation")
+		observability.AddBreadcrumb(spanCtx, "signal_aggregator", "Volume history below technical threshold; using fallback-capable aggregation", sentry.LevelInfo)
 	}
 
 	signals := make([]*AggregatedSignal, 0)
@@ -394,6 +397,7 @@ func (sa *SignalAggregator) AggregateTechnicalSignals(ctx context.Context, input
 
 		// Calculate average volume for quality assessment
 		avgVolume := decimal.NewFromFloat(0)
+		volumeUnavailable := len(input.Volumes) < technicalAnalysisMinHistory
 		if len(input.Volumes) > 0 {
 			totalVolume := decimal.NewFromFloat(0)
 			for _, vol := range input.Volumes {
@@ -408,16 +412,17 @@ func (sa *SignalAggregator) AggregateTechnicalSignals(ctx context.Context, input
 		}
 
 		qualityInput := SignalQualityInput{
-			SignalType:       string(signal.SignalType),
-			Symbol:           signal.Symbol,
-			Exchanges:        signal.Exchanges,
-			Volume:           avgVolume,
-			ProfitPotential:  signal.ProfitPotential,
-			Confidence:       signal.Confidence,
-			Timestamp:        signal.CreatedAt,
-			Indicators:       signal.Metadata,
-			SignalCount:      signalCount,
-			SignalComponents: signalComponents,
+			SignalType:        string(signal.SignalType),
+			Symbol:            signal.Symbol,
+			Exchanges:         signal.Exchanges,
+			Volume:            avgVolume,
+			VolumeUnavailable: volumeUnavailable,
+			ProfitPotential:   signal.ProfitPotential,
+			Confidence:        signal.Confidence,
+			Timestamp:         signal.CreatedAt,
+			Indicators:        signal.Metadata,
+			SignalCount:       signalCount,
+			SignalComponents:  signalComponents,
 			MarketData: &MarketDataSnapshot{
 				Price:         lastPrice,
 				LastTradeTime: signal.CreatedAt,
@@ -717,7 +722,7 @@ func (sa *SignalAggregator) removeDuplicateStrings(slice []string) []string {
 func (sa *SignalAggregator) calculateTechnicalIndicators(prices []decimal.Decimal) map[string][]float64 {
 	indicators := make(map[string][]float64)
 
-	if len(prices) < 50 || sa.indicatorProvider == nil {
+	if len(prices) < technicalAnalysisMinHistory || sa.indicatorProvider == nil {
 		return indicators
 	}
 

--- a/services/backend-api/internal/services/signal_aggregator_test.go
+++ b/services/backend-api/internal/services/signal_aggregator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/irfndi/neuratrade/internal/models"
 )
@@ -45,6 +46,112 @@ func TestSignalAggregator_NewSignalAggregator(t *testing.T) {
 	assert.NotNil(t, sa.cache)
 	assert.Equal(t, decimal.NewFromFloat(0.6), sa.sigConfig.MinConfidence)
 	assert.Equal(t, decimal.NewFromFloat(0.5), sa.sigConfig.MinProfitThreshold)
+}
+
+func TestSignalAggregator_AggregateTechnicalSignals_AllowsMissingVolumeFallback(t *testing.T) {
+	logger := zaplogrus.New()
+	sa := NewSignalAggregator(nil, nil, logger)
+
+	mockScorer := &MockSignalQualityScorer{}
+	sa.qualityScorer = mockScorer
+
+	qualityMetrics := &SignalQualityMetrics{
+		OverallScore:         decimal.NewFromFloat(0.8),
+		ExchangeScore:        decimal.NewFromFloat(0.8),
+		VolumeScore:          decimal.NewFromFloat(0.5),
+		LiquidityScore:       decimal.NewFromFloat(0.8),
+		VolatilityScore:      decimal.NewFromFloat(0.7),
+		TimingScore:          decimal.NewFromFloat(0.9),
+		ConfidenceScore:      decimal.NewFromFloat(0.8),
+		RiskScore:            decimal.NewFromFloat(0.2),
+		DataFreshnessScore:   decimal.NewFromFloat(0.9),
+		MarketConditionScore: decimal.NewFromFloat(0.8),
+	}
+	thresholds := &QualityThresholds{
+		MinOverallScore:   decimal.NewFromFloat(0.6),
+		MinExchangeScore:  decimal.NewFromFloat(0.7),
+		MinVolumeScore:    decimal.NewFromFloat(0.5),
+		MinLiquidityScore: decimal.NewFromFloat(0.6),
+		MaxRiskScore:      decimal.NewFromFloat(0.4),
+		MinDataFreshness:  5 * time.Minute,
+	}
+	mockScorer.On("AssessSignalQuality", mock.Anything, mock.MatchedBy(func(input *SignalQualityInput) bool {
+		return input != nil && input.VolumeUnavailable && input.Volume.IsZero()
+	})).Return(qualityMetrics, nil).Once()
+	mockScorer.On("GetDefaultQualityThresholds").Return(thresholds).Once()
+	mockScorer.On("IsSignalQualityAcceptable", qualityMetrics, thresholds).Return(true).Once()
+
+	prices := make([]decimal.Decimal, 60)
+	for i := range prices {
+		prices[i] = decimal.NewFromInt(int64(100 + i))
+	}
+
+	signals, err := sa.AggregateTechnicalSignals(context.Background(), TechnicalSignalInput{
+		Symbol:   "BTC/USDT",
+		Exchange: "bitget",
+		Prices:   prices,
+		Volumes:  nil,
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, signals)
+	assert.Equal(t, "BTC/USDT", signals[0].Symbol)
+	assert.Equal(t, SignalTypeTechnical, signals[0].SignalType)
+	mockScorer.AssertExpectations(t)
+}
+
+func TestSignalAggregator_AggregateTechnicalSignals_TreatsSparseVolumeAsUnavailableForQuality(t *testing.T) {
+	logger := zaplogrus.New()
+	sa := NewSignalAggregator(nil, nil, logger)
+
+	mockScorer := &MockSignalQualityScorer{}
+	sa.qualityScorer = mockScorer
+
+	qualityMetrics := &SignalQualityMetrics{
+		OverallScore:         decimal.NewFromFloat(0.8),
+		ExchangeScore:        decimal.NewFromFloat(0.8),
+		VolumeScore:          decimal.NewFromFloat(missingVolumeNeutralScore),
+		LiquidityScore:       decimal.NewFromFloat(0.8),
+		VolatilityScore:      decimal.NewFromFloat(0.7),
+		TimingScore:          decimal.NewFromFloat(0.9),
+		ConfidenceScore:      decimal.NewFromFloat(0.8),
+		RiskScore:            decimal.NewFromFloat(0.2),
+		DataFreshnessScore:   decimal.NewFromFloat(0.9),
+		MarketConditionScore: decimal.NewFromFloat(0.8),
+	}
+	thresholds := &QualityThresholds{
+		MinOverallScore:   decimal.NewFromFloat(0.6),
+		MinExchangeScore:  decimal.NewFromFloat(0.7),
+		MinVolumeScore:    decimal.NewFromFloat(0.5),
+		MinLiquidityScore: decimal.NewFromFloat(0.6),
+		MaxRiskScore:      decimal.NewFromFloat(0.4),
+		MinDataFreshness:  5 * time.Minute,
+	}
+	mockScorer.On("AssessSignalQuality", mock.Anything, mock.MatchedBy(func(input *SignalQualityInput) bool {
+		return input != nil && input.VolumeUnavailable && input.Volume.Equal(decimal.NewFromInt(100))
+	})).Return(qualityMetrics, nil).Once()
+	mockScorer.On("GetDefaultQualityThresholds").Return(thresholds).Once()
+	mockScorer.On("IsSignalQualityAcceptable", qualityMetrics, thresholds).Return(true).Once()
+
+	prices := make([]decimal.Decimal, 60)
+	for i := range prices {
+		prices[i] = decimal.NewFromInt(int64(100 + i))
+	}
+	volumes := make([]decimal.Decimal, 10)
+	for i := range volumes {
+		volumes[i] = decimal.NewFromInt(100)
+	}
+
+	signals, err := sa.AggregateTechnicalSignals(context.Background(), TechnicalSignalInput{
+		Symbol:   "BTC/USDT",
+		Exchange: "bitget",
+		Prices:   prices,
+		Volumes:  volumes,
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, signals)
+	mockScorer.AssertExpectations(t)
 }
 
 // TestSignalAggregator_AggregateArbitrageSignals_Basic tests basic signal aggregation

--- a/services/backend-api/internal/services/signal_quality_scorer.go
+++ b/services/backend-api/internal/services/signal_quality_scorer.go
@@ -25,6 +25,8 @@ type SignalQualityScorer struct {
 	exchangeStatsProvider    ExchangeStatsProvider
 }
 
+const missingVolumeNeutralScore = 0.5
+
 // ExchangeStatsProvider decouples SignalQualityScorer from direct database access for exchange statistics.
 type ExchangeStatsProvider interface {
 	GetExchangeMetrics(ctx context.Context, exchange string) (*ExchangeMetrics, error)
@@ -78,17 +80,18 @@ type SignalQualityMetrics struct {
 
 // SignalQualityInput contains all necessary input data for performing a quality assessment on a signal.
 type SignalQualityInput struct {
-	SignalType       string                 `json:"signal_type"` // "arbitrage" or "technical"
-	Symbol           string                 `json:"symbol"`
-	Exchanges        []string               `json:"exchanges"`
-	Volume           decimal.Decimal        `json:"volume"`
-	ProfitPotential  decimal.Decimal        `json:"profit_potential"`
-	Confidence       decimal.Decimal        `json:"confidence"`
-	Timestamp        time.Time              `json:"timestamp"`
-	Indicators       map[string]interface{} `json:"indicators,omitempty"`
-	MarketData       *MarketDataSnapshot    `json:"market_data,omitempty"`
-	SignalComponents []string               `json:"signal_components,omitempty"` // List of individual signal indicators for aggregated signals
-	SignalCount      int                    `json:"signal_count,omitempty"`      // Number of confirming signals
+	SignalType        string                 `json:"signal_type"` // "arbitrage" or "technical"
+	Symbol            string                 `json:"symbol"`
+	Exchanges         []string               `json:"exchanges"`
+	Volume            decimal.Decimal        `json:"volume"`
+	VolumeUnavailable bool                   `json:"volume_unavailable,omitempty"`
+	ProfitPotential   decimal.Decimal        `json:"profit_potential"`
+	Confidence        decimal.Decimal        `json:"confidence"`
+	Timestamp         time.Time              `json:"timestamp"`
+	Indicators        map[string]interface{} `json:"indicators,omitempty"`
+	MarketData        *MarketDataSnapshot    `json:"market_data,omitempty"`
+	SignalComponents  []string               `json:"signal_components,omitempty"` // List of individual signal indicators for aggregated signals
+	SignalCount       int                    `json:"signal_count,omitempty"`      // Number of confirming signals
 }
 
 // MarketDataSnapshot represents a snapshot of market conditions at the time of signal generation.
@@ -276,6 +279,9 @@ func (sqs *SignalQualityScorer) calculateExchangeScore(exchanges []string) decim
 
 // calculateVolumeScore evaluates if the trading volume is sufficient for the signal.
 func (sqs *SignalQualityScorer) calculateVolumeScore(input *SignalQualityInput) decimal.Decimal {
+	if input.VolumeUnavailable {
+		return decimal.NewFromFloat(missingVolumeNeutralScore)
+	}
 	if input.Volume.IsZero() {
 		return decimal.Zero
 	}

--- a/services/backend-api/internal/services/signal_quality_scorer_test.go
+++ b/services/backend-api/internal/services/signal_quality_scorer_test.go
@@ -335,6 +335,15 @@ func TestCalculateVolumeScore(t *testing.T) {
 	}
 }
 
+func TestCalculateVolumeScore_MissingVolumeUsesNeutralScore(t *testing.T) {
+	scorer := createTestScorer()
+
+	input := &SignalQualityInput{VolumeUnavailable: true}
+	result := scorer.calculateVolumeScore(input)
+
+	assert.True(t, result.Equal(decimal.NewFromFloat(missingVolumeNeutralScore)))
+}
+
 func TestCalculateLiquidityScore(t *testing.T) {
 	scorer := createTestScorer()
 


### PR DESCRIPTION
## Summary
- allow technical signal aggregation to use the price-only fallback when volume history is missing
- mark missing volume explicitly so quality scoring uses a neutral volume score instead of treating unavailable data as zero-volume liquidity
- add regression coverage for the missing-volume fallback path and quality-score behavior

## Tests
- go test ./internal/services -run 'TestSignalAggregator_AggregateTechnicalSignals_AllowsMissingVolumeFallback|TestCalculateVolumeScore' -count=1
- go test ./internal/services -count=1
- make build

Fixes NeuraTrade-2dc

## Summary by Sourcery

Allow technical signal aggregation and quality scoring to handle missing volume history without failing or mis-scoring signals.

Bug Fixes:
- Allow technical signal aggregation to proceed using price-only data when volume history is absent instead of erroring on insufficient volume points.
- Ensure quality scoring treats unavailable volume as a neutral volume score rather than zero-volume liquidity.

Tests:
- Add regression tests covering technical aggregation with missing volume data and the neutral volume-score path when volume is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Signal aggregation now tolerates missing or sparse volume data: aggregation continues with a neutral volume influence instead of failing.
* **Tests**
  * Added unit tests ensuring missing/sparse volume triggers neutral-volume scoring and that aggregation still produces signals.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/362)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->