### PR TITLE
fix: alert on degraded AI scalping runtime

### DIFF
--- a/services/backend-api/internal/services/notification_ops_alerts.go
+++ b/services/backend-api/internal/services/notification_ops_alerts.go
@@ -377,6 +377,28 @@ func buildAIReasoningMessageLines(reasoning AIReasoningNotification, category st
 		if recoveryAction, ok := reasoning.RuntimeDetails["recovery_action"]; ok {
 			lines = append(lines, fmt.Sprintf("Recovery Action: %s", recoveryAction))
 		}
+		if total, ok := reasoning.RuntimeDetails["ai_window_total"]; ok {
+			if errors, eok := reasoning.RuntimeDetails["ai_window_errors"]; eok {
+				if rate, rok := reasoning.RuntimeDetails["ai_error_rate"]; rok {
+					lines = append(lines, fmt.Sprintf("AI Runtime Window: %s/%s errors (%s)", errors, total, rate))
+				} else {
+					lines = append(lines, fmt.Sprintf("AI Runtime Window: %s/%s errors", errors, total))
+				}
+			}
+		}
+		if attempts, ok := reasoning.RuntimeDetails["ai_failover_attempts"]; ok {
+			if failures, fok := reasoning.RuntimeDetails["ai_failover_failures"]; fok {
+				lines = append(lines, fmt.Sprintf("AI Failover: %s attempts, %s failures", attempts, failures))
+			} else {
+				lines = append(lines, fmt.Sprintf("AI Failover: %s attempts", attempts))
+			}
+		}
+		if failedProviders, ok := reasoning.RuntimeDetails["ai_failed_providers"]; ok {
+			lines = append(lines, fmt.Sprintf("AI Failed Providers: %s", failedProviders))
+		}
+		if category, ok := reasoning.RuntimeDetails["ai_last_category"]; ok {
+			lines = append(lines, fmt.Sprintf("AI Last Category: %s", category))
+		}
 	}
 	if strings.TrimSpace(reasoning.UnblockCondition) != "" {
 		lines = append(lines, fmt.Sprintf("Unblock Condition: %s", strings.TrimSpace(reasoning.UnblockCondition)))

--- a/services/backend-api/internal/services/notification_test.go
+++ b/services/backend-api/internal/services/notification_test.go
@@ -2473,6 +2473,29 @@ func TestNotificationService_RuntimeStatusRendering(t *testing.T) {
 		assert.Contains(t, message, "Runtime Status:")
 	})
 
+	t.Run("LLM degraded runtime details", func(t *testing.T) {
+		message := ns.formatAIReasoningMessage(AIReasoningNotification{
+			DecisionType:  "scalping_cycle",
+			Summary:       "LLM runtime degraded",
+			RuntimeStatus: runtimeStatusLLMDegraded,
+			RuntimeDetails: map[string]string{
+				"ai_window_total":      "8",
+				"ai_window_errors":     "5",
+				"ai_error_rate":        "63%",
+				"ai_failover_attempts": "4",
+				"ai_failover_failures": "3",
+				"ai_failed_providers":  "zai,minimax",
+				"ai_last_category":     "execution_unavailable",
+			},
+			Reasons: []string{"LLM completion failed"},
+			Action:  "hold",
+		})
+		assert.Contains(t, message, "AI Runtime Window: 5/8 errors (63%)")
+		assert.Contains(t, message, "AI Failover: 4 attempts, 3 failures")
+		assert.Contains(t, message, "AI Failed Providers: zai,minimax")
+		assert.Contains(t, message, "AI Last Category: execution_unavailable")
+	})
+
 	t.Run("infrastructure hold with original confidence gated", func(t *testing.T) {
 		message := ns.formatAIReasoningMessage(AIReasoningNotification{
 			DecisionType:    "scalping_cycle",

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -1505,6 +1505,10 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		} else if errRate := checkpointFloat(quest.Checkpoint["runtime_ai_window_error_rate"]); errRate > 0.5 {
 			cycleRuntimeStatus = runtimeStatusLLMDegraded
 		}
+		runtimeDetails := map[string]string(nil)
+		if cycleRuntimeStatus == runtimeStatusLLMDegraded {
+			runtimeDetails = aiRuntimeDetailsFromCheckpoint(quest.Checkpoint)
+		}
 		h.notifyScalpingDecision(ctx, chatID, AIReasoningNotification{
 			DecisionType:          "scalping_cycle",
 			Summary:               "AI held position this cycle",
@@ -1517,6 +1521,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			Reasons:               reasons,
 			Action:                "hold",
 			RuntimeStatus:         cycleRuntimeStatus,
+			RuntimeDetails:        runtimeDetails,
 		})
 		h.maybeSendHoldDigest(ctx, quest, chatID, decision, portfolio)
 		return nil
@@ -5886,10 +5891,50 @@ func shouldSendScalpingDecisionNotification(notif AIReasoningNotification) bool 
 	if action == "buy" || action == "sell" || action == "record" {
 		return true
 	}
+	if strings.EqualFold(strings.TrimSpace(notif.RuntimeStatus), runtimeStatusLLMDegraded) {
+		return true
+	}
 	switch decisionType {
 	case "pnl_reconciliation", "risk_reduction", "scalping_digest":
 		return true
 	default:
 		return false
+	}
+}
+
+func aiRuntimeDetailsFromCheckpoint(checkpoint map[string]interface{}) map[string]string {
+	if len(checkpoint) == 0 {
+		return nil
+	}
+
+	details := map[string]string{}
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_total", "ai_window_total")
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_errors", "ai_window_errors")
+	if rate := checkpointFloat(checkpoint["runtime_ai_window_error_rate"]); rate > 0 {
+		details["ai_error_rate"] = fmt.Sprintf("%.0f%%", rate*100)
+	}
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_timeouts", "ai_timeouts")
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_parse_fails", "ai_parse_fails")
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_failover_attempts", "ai_failover_attempts")
+	addCheckpointIntDetail(details, checkpoint, "runtime_ai_window_failover_failures", "ai_failover_failures")
+	if provider := checkpointString(checkpoint["runtime_ai_last_provider"]); provider != "" {
+		details["ai_last_provider"] = provider
+	}
+	if category := checkpointString(checkpoint["runtime_ai_last_category"]); category != "" {
+		details["ai_last_category"] = category
+	}
+	if failed := checkpointStringSlice(checkpoint["runtime_ai_failed_providers"]); len(failed) > 0 {
+		details["ai_failed_providers"] = strings.Join(failed, ",")
+	}
+
+	if len(details) == 0 {
+		return nil
+	}
+	return details
+}
+
+func addCheckpointIntDetail(details map[string]string, checkpoint map[string]interface{}, checkpointKey string, detailKey string) {
+	if value := checkpointInt(checkpoint[checkpointKey]); value > 0 {
+		details[detailKey] = strconv.Itoa(value)
 	}
 }

--- a/services/backend-api/internal/services/quest_handlers_integrated_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_test.go
@@ -587,6 +587,11 @@ func TestShouldSendScalpingDecisionNotification_DefaultActionableOnly(t *testing
 		DecisionType: "scalping_cycle",
 		Action:       "hold",
 	}))
+	assert.True(t, shouldSendScalpingDecisionNotification(AIReasoningNotification{
+		DecisionType:  "scalping_cycle",
+		Action:        "hold",
+		RuntimeStatus: runtimeStatusLLMDegraded,
+	}), "LLM-degraded hold cycles must alert even when actionable-only filtering is enabled")
 
 	assert.True(t, shouldSendScalpingDecisionNotification(AIReasoningNotification{
 		DecisionType: "scalping",
@@ -622,6 +627,29 @@ func TestShouldSendScalpingDecisionNotification_EnvOverrides(t *testing.T) {
 		DecisionType: "scalping_cycle",
 		Action:       "hold",
 	}))
+}
+
+func TestAIRuntimeDetailsFromCheckpoint(t *testing.T) {
+	details := aiRuntimeDetailsFromCheckpoint(map[string]interface{}{
+		"runtime_ai_window_total":             8,
+		"runtime_ai_window_errors":            5,
+		"runtime_ai_window_error_rate":        0.63,
+		"runtime_ai_window_failover_attempts": 4,
+		"runtime_ai_window_failover_failures": 3,
+		"runtime_ai_last_provider":            "zai",
+		"runtime_ai_last_category":            aiReasonExecutionUnavailable,
+		"runtime_ai_failed_providers":         []string{"zai", "minimax"},
+	})
+
+	require.NotNil(t, details)
+	assert.Equal(t, "8", details["ai_window_total"])
+	assert.Equal(t, "5", details["ai_window_errors"])
+	assert.Equal(t, "63%", details["ai_error_rate"])
+	assert.Equal(t, "4", details["ai_failover_attempts"])
+	assert.Equal(t, "3", details["ai_failover_failures"])
+	assert.Equal(t, "zai", details["ai_last_provider"])
+	assert.Equal(t, aiReasonExecutionUnavailable, details["ai_last_category"])
+	assert.Equal(t, "zai,minimax", details["ai_failed_providers"])
 }
 
 func TestIntegratedQuestHandlers_EvaluateRecoveryGateState_HybridModes(t *testing.T) {


### PR DESCRIPTION
## Summary
- allow LLM-degraded scalping hold cycles through the default actionable-only Telegram filter
- include AI runtime window, failover, failed-provider, and reason-category details in degraded runtime notifications
- add focused regression tests for the notification gate and runtime detail rendering

## Verification
- env GOCACHE=/private/tmp/nt-go-cache go test ./internal/services -run TestShouldSendScalpingDecisionNotification
- env GOCACHE=/private/tmp/nt-go-cache go test ./internal/services -run TestAIRuntimeDetailsFromCheckpoint
- env GOCACHE=/private/tmp/nt-go-cache go test ./internal/services -run TestNotificationService_RuntimeStatusRendering
- env GOCACHE=/private/tmp/nt-go-cache go test ./internal/services
- env GOCACHE=/private/tmp/nt-go-cache make build

Stacked on #345 because it consumes the scalping runtime telemetry added there. Does not merge either PR.

## Summary by Sourcery

Alert on LLM-degraded AI scalping runtime and surface detailed runtime diagnostics in notifications.

New Features:
- Include AI runtime window, failover, provider, and category details in AI reasoning notifications for degraded runtimes.

Bug Fixes:
- Ensure LLM-degraded scalping hold cycles bypass actionable-only filtering and always send notifications.

Tests:
- Add unit tests for scalping decision notification gating when runtime is LLM-degraded.
- Add unit tests for extracting AI runtime details from checkpoints.
- Extend notification formatting tests to cover AI runtime window and failover detail rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced AI system notifications now include detailed runtime diagnostics (error rates, failover statistics, and provider information) when the AI system is degraded, providing better visibility into performance issues.
  * Notifications are guaranteed when the AI system experiences degradation, ensuring critical status updates are always received.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/365)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->