### PR TITLE
Fix paper-mode restore for autonomous scalping

### DIFF
--- a/services/backend-api/internal/ai/client.go
+++ b/services/backend-api/internal/ai/client.go
@@ -397,7 +397,7 @@ func (c *Client) buildToolsJSON() ([]json.RawMessage, error) {
 
 // chatOpenAI makes a request to OpenAI API.
 // chatOpenAI is deprecated - use provider_unified.go instead
-// nolint:unused,deadcode
+// nolint:unused
 func (c *Client) chatOpenAI(ctx context.Context, provider *ProviderInfo, req *ChatRequest) (*ChatResponse, error) {
 	apiKey := c.getAPIKey(provider.ID)
 	if apiKey == "" {
@@ -481,7 +481,7 @@ func (c *Client) chatOpenAI(ctx context.Context, provider *ProviderInfo, req *Ch
 
 // chatAnthropic makes a request to Anthropic API.
 // chatAnthropic is deprecated - use provider_unified.go instead
-// nolint:unused,deadcode
+// nolint:unused
 func (c *Client) chatAnthropic(ctx context.Context, provider *ProviderInfo, req *ChatRequest) (*ChatResponse, error) {
 	apiKey := c.getAPIKey(provider.ID)
 	if apiKey == "" {

--- a/services/backend-api/internal/app/risk/policy_engine.go
+++ b/services/backend-api/internal/app/risk/policy_engine.go
@@ -487,7 +487,7 @@ func (e *Engine) AddRule(rule ports.PolicyRule) error {
 	}
 	ruleValue := reflect.ValueOf(rule)
 	switch ruleValue.Kind() {
-	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Interface, reflect.Func:
+	case reflect.Pointer, reflect.Map, reflect.Slice, reflect.Interface, reflect.Func:
 		if ruleValue.IsNil() {
 			return fmt.Errorf("nil rule")
 		}

--- a/services/backend-api/internal/services/interfaces.go
+++ b/services/backend-api/internal/services/interfaces.go
@@ -22,7 +22,7 @@ func isNilDBPool(db DBPool) bool {
 	}
 
 	v := reflect.ValueOf(db)
-	if v.Kind() == reflect.Ptr && v.IsNil() {
+	if v.Kind() == reflect.Pointer && v.IsNil() {
 		return true
 	}
 

--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -1678,6 +1678,9 @@ func (e *QuestEngine) BeginAutonomous(chatID string) (*AutonomousState, error) {
 }
 
 func (e *QuestEngine) resolveBeginAutonomousMode(chatID string, quest *Quest) OperationalMode {
+	if mode, ok := runtimeModeOverrideFromEnv(); ok {
+		return mode
+	}
 	if e != nil && e.opModeService != nil {
 		switch mode := e.opModeService.GetMode(chatID); mode {
 		case OpModeLive:

--- a/services/backend-api/internal/services/quest_engine_test.go
+++ b/services/backend-api/internal/services/quest_engine_test.go
@@ -1479,6 +1479,9 @@ func TestBeginAutonomous_UsesStoredPaperModeMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BeginAutonomous returned error: %v", err)
 	}
+	if len(state.ActiveQuests) == 0 {
+		t.Fatal("expected at least one active quest")
+	}
 	quest := engine.quests[state.ActiveQuests[0]]
 	if quest.Metadata["execution_mode"] != string(ModePaper) {
 		t.Fatalf("expected execution_mode paper, got %q", quest.Metadata["execution_mode"])
@@ -1506,6 +1509,9 @@ func TestBeginAutonomous_RuntimePaperEnvOverridesStoredLiveMode(t *testing.T) {
 	state, err := engine.BeginAutonomous("paper-env-chat")
 	if err != nil {
 		t.Fatalf("BeginAutonomous returned error: %v", err)
+	}
+	if len(state.ActiveQuests) == 0 {
+		t.Fatal("expected at least one active quest")
 	}
 	quest := engine.quests[state.ActiveQuests[0]]
 	if quest.Metadata["execution_mode"] != string(ModePaper) {

--- a/services/backend-api/internal/services/quest_engine_test.go
+++ b/services/backend-api/internal/services/quest_engine_test.go
@@ -1491,6 +1491,34 @@ func TestBeginAutonomous_UsesStoredPaperModeMetadata(t *testing.T) {
 	}
 }
 
+func TestBeginAutonomous_RuntimePaperEnvOverridesStoredLiveMode(t *testing.T) {
+	t.Setenv("FEATURE_PAPER_TRADING", "true")
+	t.Setenv("FEATURE_REAL_TRADING", "false")
+
+	engine := NewQuestEngine(NewInMemoryQuestStore())
+	engine.SetOperationalModeService(&OperationalModeService{
+		config: DefaultOperationalModeConfig(),
+		states: map[string]*OperationalModeState{
+			"paper-env-chat": {ChatID: "paper-env-chat", Mode: OpModeLive},
+		},
+	})
+
+	state, err := engine.BeginAutonomous("paper-env-chat")
+	if err != nil {
+		t.Fatalf("BeginAutonomous returned error: %v", err)
+	}
+	quest := engine.quests[state.ActiveQuests[0]]
+	if quest.Metadata["execution_mode"] != string(ModePaper) {
+		t.Fatalf("expected execution_mode paper, got %q", quest.Metadata["execution_mode"])
+	}
+	if quest.Metadata["dry_run"] != "true" {
+		t.Fatalf("expected dry_run true, got %q", quest.Metadata["dry_run"])
+	}
+	if quest.Metadata["paper_trading"] != "true" {
+		t.Fatalf("expected paper_trading true, got %q", quest.Metadata["paper_trading"])
+	}
+}
+
 func TestBeginAutonomous_DefaultsToDryWhenModeUnavailable(t *testing.T) {
 	engine := NewQuestEngine(NewInMemoryQuestStore())
 

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -378,6 +378,9 @@ func (h *IntegratedQuestHandlers) clearScalpingAutonomyCoordinator() {
 }
 
 func (h *IntegratedQuestHandlers) resolveOperationalMode(chatID string, quest *Quest) OperationalMode {
+	if mode, ok := runtimeModeOverrideFromEnv(); ok {
+		return mode
+	}
 	if h != nil && h.opModeService != nil {
 		switch mode := h.opModeService.GetMode(chatID); mode {
 		case OpModeLive:

--- a/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
@@ -125,6 +125,20 @@ func TestIntegratedQuestHandlersResolveOperationalModePrefersStoredState(t *test
 	}
 }
 
+func TestIntegratedQuestHandlersResolveOperationalModeRuntimePaperEnvOverridesStoredLive(t *testing.T) {
+	t.Setenv("FEATURE_PAPER_TRADING", "true")
+	t.Setenv("FEATURE_REAL_TRADING", "false")
+
+	handlers := &IntegratedQuestHandlers{opModeService: &OperationalModeService{
+		config: DefaultOperationalModeConfig(),
+		states: map[string]*OperationalModeState{
+			"paper-env-chat": {ChatID: "paper-env-chat", Mode: OpModeLive},
+		},
+	}}
+
+	assert.Equal(t, ModePaper, handlers.resolveOperationalMode("paper-env-chat", &Quest{}))
+}
+
 func TestIntegratedQuestHandlersSyncScalpingStrategyModeFollowsOperatorMode(t *testing.T) {
 	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "rollout-sync.db"))
 	require.NoError(t, err)

--- a/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_mode_test.go
@@ -22,6 +22,7 @@ func TestIntegratedQuestHandlersResolveOperationalModePrefersStoredState(t *test
 		opModeService *OperationalModeService
 		quest         *Quest
 		chatID        string
+		env           map[string]string
 		expected      OperationalMode
 	}{
 		{
@@ -62,6 +63,25 @@ func TestIntegratedQuestHandlersResolveOperationalModePrefersStoredState(t *test
 			},
 			quest:    &Quest{Metadata: map[string]string{"dry_run": "false"}},
 			chatID:   "chat-paper",
+			expected: ModePaper,
+		},
+		{
+			name: "runtime_paper_env_overrides_stored_live_mode",
+			opModeService: &OperationalModeService{
+				config: DefaultOperationalModeConfig(),
+				states: map[string]*OperationalModeState{
+					"paper-env-chat": {
+						ChatID: "paper-env-chat",
+						Mode:   OpModeLive,
+					},
+				},
+			},
+			quest:  &Quest{},
+			chatID: "paper-env-chat",
+			env: map[string]string{
+				envFeaturePaperTrading: "true",
+				envFeatureRealTrading:  "false",
+			},
 			expected: ModePaper,
 		},
 		{
@@ -119,24 +139,14 @@ func TestIntegratedQuestHandlersResolveOperationalModePrefersStoredState(t *test
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			unsetRuntimeModeEnv(t)
+			for key, value := range tc.env {
+				t.Setenv(key, value)
+			}
 			handlers := &IntegratedQuestHandlers{opModeService: tc.opModeService}
 			assert.Equal(t, tc.expected, handlers.resolveOperationalMode(tc.chatID, tc.quest))
 		})
 	}
-}
-
-func TestIntegratedQuestHandlersResolveOperationalModeRuntimePaperEnvOverridesStoredLive(t *testing.T) {
-	t.Setenv("FEATURE_PAPER_TRADING", "true")
-	t.Setenv("FEATURE_REAL_TRADING", "false")
-
-	handlers := &IntegratedQuestHandlers{opModeService: &OperationalModeService{
-		config: DefaultOperationalModeConfig(),
-		states: map[string]*OperationalModeState{
-			"paper-env-chat": {ChatID: "paper-env-chat", Mode: OpModeLive},
-		},
-	}}
-
-	assert.Equal(t, ModePaper, handlers.resolveOperationalMode("paper-env-chat", &Quest{}))
 }
 
 func TestIntegratedQuestHandlersSyncScalpingStrategyModeFollowsOperatorMode(t *testing.T) {

--- a/services/backend-api/internal/services/trading_mode.go
+++ b/services/backend-api/internal/services/trading_mode.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,6 +50,34 @@ func DefaultOperationalModeConfig() OperationalModeConfig {
 		RequireConfirmation: true,
 		ConfirmationCount:   2, // Require 2 confirmations to switch to live mode
 	}
+}
+
+func runtimeModeOverrideFromEnv() (OperationalMode, bool) {
+	paperEnabled, paperSet := boolEnvAny("FEATURES_PAPER_TRADING", "FEATURE_PAPER_TRADING")
+	realEnabled, realSet := boolEnvAny("FEATURES_REAL_TRADING", "FEATURE_REAL_TRADING")
+	if paperSet && paperEnabled && (!realSet || !realEnabled) {
+		return ModePaper, true
+	}
+	if realSet && !realEnabled {
+		return OpModeDry, true
+	}
+	return "", false
+}
+
+func boolEnvAny(names ...string) (bool, bool) {
+	for _, name := range names {
+		raw, ok := os.LookupEnv(name)
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(raw)) {
+		case "1", "true", "yes", "on":
+			return true, true
+		case "0", "false", "no", "off":
+			return false, true
+		}
+	}
+	return false, false
 }
 
 // OperationalModeService manages the operational mode state

--- a/services/backend-api/internal/services/trading_mode.go
+++ b/services/backend-api/internal/services/trading_mode.go
@@ -60,8 +60,8 @@ func DefaultOperationalModeConfig() OperationalModeConfig {
 }
 
 func runtimeModeOverrideFromEnv() (OperationalMode, bool) {
-	paperEnabled, paperSet := boolEnvAny(envFeaturesPaperTrading, envFeaturePaperTrading)
-	realEnabled, realSet := boolEnvAny(envFeaturesRealTrading, envFeatureRealTrading)
+	paperEnabled, paperSet := boolEnvAny(true, envFeaturesPaperTrading, envFeaturePaperTrading)
+	realEnabled, realSet := boolEnvAny(false, envFeaturesRealTrading, envFeatureRealTrading)
 	if paperSet && paperEnabled && (!realSet || !realEnabled) {
 		return ModePaper, true
 	}
@@ -72,8 +72,11 @@ func runtimeModeOverrideFromEnv() (OperationalMode, bool) {
 }
 
 // boolEnvAny treats unrecognized present values as explicit false so typoed
-// safety gates cannot silently preserve a persisted live mode.
-func boolEnvAny(names ...string) (bool, bool) {
+// safety gates cannot silently preserve a persisted live mode. When aliases
+// conflict, preferSafeTrue selects the value that keeps execution non-live.
+func boolEnvAny(preferSafeTrue bool, names ...string) (bool, bool) {
+	seenTrue := false
+	seenFalse := false
 	for _, name := range names {
 		raw, ok := os.LookupEnv(name)
 		if !ok {
@@ -81,10 +84,20 @@ func boolEnvAny(names ...string) (bool, bool) {
 		}
 		switch strings.ToLower(strings.TrimSpace(raw)) {
 		case "1", "true", "yes", "on":
-			return true, true
+			seenTrue = true
 		case "0", "false", "no", "off":
-			return false, true
+			seenFalse = true
+		default:
+			seenFalse = true
 		}
+	}
+	if seenTrue && seenFalse {
+		return preferSafeTrue, true
+	}
+	if seenTrue {
+		return true, true
+	}
+	if seenFalse {
 		return false, true
 	}
 	return false, false

--- a/services/backend-api/internal/services/trading_mode.go
+++ b/services/backend-api/internal/services/trading_mode.go
@@ -26,6 +26,13 @@ const (
 	ModePaper        OperationalMode = "paper"
 )
 
+const (
+	envFeaturesPaperTrading = "FEATURES_PAPER_TRADING"
+	envFeaturePaperTrading  = "FEATURE_PAPER_TRADING"
+	envFeaturesRealTrading  = "FEATURES_REAL_TRADING"
+	envFeatureRealTrading   = "FEATURE_REAL_TRADING"
+)
+
 // OperationalModeState represents the current operational mode state
 type OperationalModeState struct {
 	Mode          OperationalMode `json:"mode"`
@@ -53,8 +60,8 @@ func DefaultOperationalModeConfig() OperationalModeConfig {
 }
 
 func runtimeModeOverrideFromEnv() (OperationalMode, bool) {
-	paperEnabled, paperSet := boolEnvAny("FEATURES_PAPER_TRADING", "FEATURE_PAPER_TRADING")
-	realEnabled, realSet := boolEnvAny("FEATURES_REAL_TRADING", "FEATURE_REAL_TRADING")
+	paperEnabled, paperSet := boolEnvAny(envFeaturesPaperTrading, envFeaturePaperTrading)
+	realEnabled, realSet := boolEnvAny(envFeaturesRealTrading, envFeatureRealTrading)
 	if paperSet && paperEnabled && (!realSet || !realEnabled) {
 		return ModePaper, true
 	}
@@ -64,6 +71,8 @@ func runtimeModeOverrideFromEnv() (OperationalMode, bool) {
 	return "", false
 }
 
+// boolEnvAny treats unrecognized present values as explicit false so typoed
+// safety gates cannot silently preserve a persisted live mode.
 func boolEnvAny(names ...string) (bool, bool) {
 	for _, name := range names {
 		raw, ok := os.LookupEnv(name)
@@ -76,6 +85,7 @@ func boolEnvAny(names ...string) (bool, bool) {
 		case "0", "false", "no", "off":
 			return false, true
 		}
+		return false, true
 	}
 	return false, false
 }

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -112,6 +112,14 @@ func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T)
 			ok:       true,
 		},
 		{
+			name: "paper and real both enabled does not override persisted state",
+			env: map[string]string{
+				envFeaturePaperTrading: "true",
+				envFeatureRealTrading:  "true",
+			},
+			ok: false,
+		},
+		{
 			name: "unset env does not override persisted state",
 			env:  map[string]string{},
 			ok:   false,

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -79,8 +80,8 @@ func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T)
 		{
 			name: "singular paper enabled and real disabled",
 			env: map[string]string{
-				"FEATURE_PAPER_TRADING": "true",
-				"FEATURE_REAL_TRADING":  "false",
+				envFeaturePaperTrading: "true",
+				envFeatureRealTrading:  "false",
 			},
 			expected: ModePaper,
 			ok:       true,
@@ -88,8 +89,8 @@ func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T)
 		{
 			name: "plural paper enabled and real disabled",
 			env: map[string]string{
-				"FEATURES_PAPER_TRADING": "true",
-				"FEATURES_REAL_TRADING":  "false",
+				envFeaturesPaperTrading: "true",
+				envFeaturesRealTrading:  "false",
 			},
 			expected: ModePaper,
 			ok:       true,
@@ -97,7 +98,15 @@ func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T)
 		{
 			name: "real disabled without paper falls back to dry",
 			env: map[string]string{
-				"FEATURE_REAL_TRADING": "false",
+				envFeatureRealTrading: "false",
+			},
+			expected: OpModeDry,
+			ok:       true,
+		},
+		{
+			name: "invalid real trading value is treated as disabled",
+			env: map[string]string{
+				envFeatureRealTrading: "flase",
 			},
 			expected: OpModeDry,
 			ok:       true,
@@ -111,9 +120,7 @@ func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			for _, key := range []string{"FEATURE_PAPER_TRADING", "FEATURES_PAPER_TRADING", "FEATURE_REAL_TRADING", "FEATURES_REAL_TRADING"} {
-				t.Setenv(key, "")
-			}
+			unsetRuntimeModeEnv(t)
 			for key, value := range tc.env {
 				t.Setenv(key, value)
 			}
@@ -121,6 +128,21 @@ func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T)
 			mode, ok := runtimeModeOverrideFromEnv()
 			assert.Equal(t, tc.ok, ok)
 			assert.Equal(t, tc.expected, mode)
+		})
+	}
+}
+
+func unsetRuntimeModeEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{envFeaturePaperTrading, envFeaturesPaperTrading, envFeatureRealTrading, envFeaturesRealTrading} {
+		previous, ok := os.LookupEnv(key)
+		require.NoError(t, os.Unsetenv(key))
+		t.Cleanup(func() {
+			if ok {
+				require.NoError(t, os.Setenv(key, previous))
+				return
+			}
+			require.NoError(t, os.Unsetenv(key))
 		})
 	}
 }

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -68,3 +68,59 @@ func TestOperationalModeService_GetModeInfo_UsesDistinctDryAndPaperLabels(t *tes
 	assert.Contains(t, paperInfo, "PAPER MODE (Simulated Orders)")
 	assert.Contains(t, paperInfo, "Orders are simulated through the autonomy paper stage")
 }
+
+func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T) {
+	testCases := []struct {
+		name     string
+		env      map[string]string
+		expected OperationalMode
+		ok       bool
+	}{
+		{
+			name: "singular paper enabled and real disabled",
+			env: map[string]string{
+				"FEATURE_PAPER_TRADING": "true",
+				"FEATURE_REAL_TRADING":  "false",
+			},
+			expected: ModePaper,
+			ok:       true,
+		},
+		{
+			name: "plural paper enabled and real disabled",
+			env: map[string]string{
+				"FEATURES_PAPER_TRADING": "true",
+				"FEATURES_REAL_TRADING":  "false",
+			},
+			expected: ModePaper,
+			ok:       true,
+		},
+		{
+			name: "real disabled without paper falls back to dry",
+			env: map[string]string{
+				"FEATURE_REAL_TRADING": "false",
+			},
+			expected: OpModeDry,
+			ok:       true,
+		},
+		{
+			name: "unset env does not override persisted state",
+			env:  map[string]string{},
+			ok:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, key := range []string{"FEATURE_PAPER_TRADING", "FEATURES_PAPER_TRADING", "FEATURE_REAL_TRADING", "FEATURES_REAL_TRADING"} {
+				t.Setenv(key, "")
+			}
+			for key, value := range tc.env {
+				t.Setenv(key, value)
+			}
+
+			mode, ok := runtimeModeOverrideFromEnv()
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.expected, mode)
+		})
+	}
+}

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -112,6 +112,24 @@ func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T)
 			ok:       true,
 		},
 		{
+			name: "paper aliases prefer non-live when conflicting",
+			env: map[string]string{
+				envFeaturesPaperTrading: "false",
+				envFeaturePaperTrading:  "true",
+			},
+			expected: ModePaper,
+			ok:       true,
+		},
+		{
+			name: "real aliases prefer disabled when conflicting",
+			env: map[string]string{
+				envFeaturesRealTrading: "true",
+				envFeatureRealTrading:  "false",
+			},
+			expected: OpModeDry,
+			ok:       true,
+		},
+		{
 			name: "paper and real both enabled does not override persisted state",
 			env: map[string]string{
 				envFeaturePaperTrading: "true",

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -146,6 +146,14 @@ func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T)
 			ok: false,
 		},
 		{
+			name: "mixed paper and real aliases enabled does not override persisted state",
+			env: map[string]string{
+				envFeaturesPaperTrading: "true",
+				envFeatureRealTrading:   "true",
+			},
+			ok: false,
+		},
+		{
 			name: "unset env does not override persisted state",
 			env:  map[string]string{},
 			ok:   false,

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -138,6 +138,14 @@ func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T)
 			ok: false,
 		},
 		{
+			name: "plural paper and real both enabled does not override persisted state",
+			env: map[string]string{
+				envFeaturesPaperTrading: "true",
+				envFeaturesRealTrading:  "true",
+			},
+			ok: false,
+		},
+		{
 			name: "unset env does not override persisted state",
 			env:  map[string]string{},
 			ok:   false,


### PR DESCRIPTION
## Summary\n- honor installed FEATURE_PAPER_TRADING/FEATURE_REAL_TRADING env gates before persisted chat mode when restoring/autostarting autonomous scalping\n- make singular/plural runtime env aliases fail closed so conflicting aliases prefer non-live safety\n- add regression coverage for restored live state being forced back to paper/dry by runtime env aliases, both-enabled no-override semantics, conflicting alias semantics, and active quest guards\n- clear current lint/security gate drift: reflect.Pointer modernization, stale deadcode nolints, and telegram protobufjs audit override to 8.2.0\n\n## Validation\n- go test ./internal/services -run 'TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases|TestBeginAutonomous_RuntimePaperEnvOverridesStoredLiveMode|TestBeginAutonomous_UsesStoredPaperModeMetadata|TestIntegratedQuestHandlersResolveOperationalModePrefersStoredState' -count=1\n- go test ./internal/services -count=1\n- make fmt-check\n- make lint\n- make test\n- make build\n- services/telegram-service: bun audit, bun test, bun run build\n- ./install.sh --disable-autostart\n- installed smoke: neuratrade-server --help, backend on :18081 returned /health 200 and /live 200, restored quest logged execution_mode=paper dry_run=true paper_trading=true\n- gitleaks detect --source . --redact --no-banner --log-opts origin/development..HEAD\n\nFixes NeuraTrade-jq0.\n\nDo not merge yet; PR is ready for human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a startup bug where paper-mode environment settings could be bypassed during autonomous quest restoration.

* **New Features**
  * Added environment variable overrides for trading mode (paper/real feature flags), enabling runtime configuration of paper vs. live trading.
  * Exposed concurrency limits in diagnostic endpoints and Telegram status reports.
  * Separated strategy confidence reporting from runtime degradation indicators in notifications.

* **Chores**
  * Updated protobufjs dependency to version 8.2.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/370)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->