### PR TITLE
[codex] Wire validated scalping candidate paths

### DIFF
--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -80,6 +80,18 @@ const (
 	scalpingRecentBuyMaxRangePct    = 35.0
 	scalpingNoRecentBuyMaxRangePct  = 20.0
 	scalpingRecentSellMinRangePct   = 75.0
+	scalpingReversalBuyMaxSpreadPct = 0.06
+	scalpingReversalBuyMaxRangePct  = 20.0
+	scalpingReversalBuyMaxRecentPct = -0.15
+	scalpingReversalBuyMaxTrendPct  = 0.0
+	scalpingSellWindowMaxSpreadPct  = 0.10
+	scalpingSellWindowMaxImbalance  = -0.30
+	scalpingSellWindowMinRangePct   = 25.0
+	scalpingSellWindowMaxRangePct   = 75.0
+	scalpingSellWindowMinRecentPct  = -0.60
+	scalpingSellWindowMaxRecentPct  = 0.20
+	scalpingSellWindowMinTrendPct   = 0.0
+	scalpingSellWindowMaxTrendPct   = 0.50
 	scalpingRecentMomentumWindow    = 5 * time.Minute
 	scalpingRecentMomentumMinAge    = 30 * time.Second
 
@@ -2077,12 +2089,13 @@ Return JSON only:
 - spread <= %.4f%%: tradable liquidity ceiling; anything wider must be treated as hold
 - recent_price_change_pct is short-window momentum in percentage points; values below %.4f are below the buy momentum confirmation gate
 - Buy safety gates: when recent_price_change_pct is present, buy only if recent_price_change_pct >= %.4f, spread_pct <= %.4f, price_change_24h_pct >= %.4f, and range_pos_24h <= %.1f; if recent_price_change_pct is absent, buy only at deep-low range_pos_24h <= %.1f
-- Sell safety gates: sell only if spread_pct <= %.4f%%, price_change_24h_pct <= %.4f%%, range_pos_24h > 15.0, and ob_imbalance <= -0.20
+- Validated reversal-buy exception: buy may also be selected when spread_pct <= %.4f%%, range_pos_24h <= %.1f, recent_price_change_pct <= %.4f%%, and price_change_24h_pct <= %.4f%%
+- Sell safety gates: sell only if spread_pct <= %.4f%%, price_change_24h_pct <= %.4f%%, range_pos_24h > 15.0, and ob_imbalance <= -0.20; validated sell-window exception also allows sell when spread_pct <= %.4f%%, ob_imbalance <= %.2f, range_pos_24h is between %.1f and %.1f, recent_price_change_pct is between %.4f%% and %.4f%%, and price_change_24h_pct is between %.4f%% and %.4f%%
 - Before returning hold, evaluate every symbol against the sell safety gates; do not apply the %.4f%% buy spread gate to sell decisions, because sells use the %.4f%% liquidity ceiling
 - If one or more symbols clear sell safety gates and confidence can meet the effective threshold, choose the strongest sell instead of hold; hold only when both buy and sell gates fail
 - range_pos_24h > 80: Price near daily high (avoid chasing late entries)
 - range_pos_24h < 20: Price near daily low (avoid aggressive shorting into support)
-		`, s.config.Leverage, skillContent, s.maxBidAskSpreadPct(), buyMomentumGate, buyMomentumGate, scalpingRecentBuyMaxSpreadPct, scalpingRecentBuyMinTrendPct, scalpingRecentBuyMaxRangePct, scalpingNoRecentBuyMaxRangePct, s.maxBidAskSpreadPct(), scalpingSellBroadTrendMaxPct, scalpingRecentBuyMaxSpreadPct, s.maxBidAskSpreadPct())
+		`, s.config.Leverage, skillContent, s.maxBidAskSpreadPct(), buyMomentumGate, buyMomentumGate, scalpingRecentBuyMaxSpreadPct, scalpingRecentBuyMinTrendPct, scalpingRecentBuyMaxRangePct, scalpingNoRecentBuyMaxRangePct, scalpingReversalBuyMaxSpreadPct, scalpingReversalBuyMaxRangePct, scalpingReversalBuyMaxRecentPct, scalpingReversalBuyMaxTrendPct, s.maxBidAskSpreadPct(), scalpingSellBroadTrendMaxPct, scalpingSellWindowMaxSpreadPct, scalpingSellWindowMaxImbalance, scalpingSellWindowMinRangePct, scalpingSellWindowMaxRangePct, scalpingSellWindowMinRecentPct, scalpingSellWindowMaxRecentPct, scalpingSellWindowMinTrendPct, scalpingSellWindowMaxTrendPct, scalpingRecentBuyMaxSpreadPct, s.maxBidAskSpreadPct())
 }
 
 func (s *AIScalpingService) buildUserPrompt(ctx context.Context, signals []aiMarketSignal, portfolio TradingPortfolio) string {
@@ -2606,14 +2619,17 @@ func (s *AIScalpingService) validateDecision(decision *AITradingDecision, signal
 		entry := decimal.NewFromFloat(resolved.Price)
 		decision.EntryPrice = &entry
 	}
-	spreadThreshold := s.maxBidAskSpreadPct()
+	spreadThreshold := s.decisionSpreadThreshold(decision.Action, resolved)
 	if resolved.BidAskSpread > spreadThreshold {
 		return fmt.Errorf("spread %.3f%% too wide for scalping on %s", resolved.BidAskSpread, decision.Symbol)
 	}
 	if resolved.BidAskSpread == 0 && resolved.OrderBookImbalance == 0 {
 		return fmt.Errorf("missing orderbook quality signals for %s", decision.Symbol)
 	}
-	if decision.Action == "sell" && !scalpingSellTrendConfirmed(resolved) && !scalpingBlowoffSellTrendConfirmed(resolved) {
+	if decision.Action == "sell" &&
+		!scalpingSellTrendConfirmed(resolved) &&
+		!scalpingBlowoffSellTrendConfirmed(resolved) &&
+		!scalpingSellWindowCandidate(resolved) {
 		return fmt.Errorf("sell decision rejected without 24h downside confirmation on %s (price_change_24h=%.4f%%, required<=%.4f%%)", resolved.Symbol, resolved.PriceChange24h, scalpingSellBroadTrendMaxPct)
 	}
 	if decision.SizePercent <= 0 {
@@ -2679,7 +2695,25 @@ func (s *AIScalpingService) validateDecision(decision *AITradingDecision, signal
 	return nil
 }
 
+func (s *AIScalpingService) decisionSpreadThreshold(action string, signal aiMarketSignal) float64 {
+	threshold := s.maxBidAskSpreadPct()
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "buy":
+		if scalpingReversalBuyCandidate(signal) {
+			threshold = math.Max(threshold, scalpingReversalBuyMaxSpreadPct)
+		}
+	case "sell":
+		if scalpingSellWindowCandidate(signal) {
+			threshold = math.Max(threshold, scalpingSellWindowMaxSpreadPct)
+		}
+	}
+	return threshold
+}
+
 func (s *AIScalpingService) scalpingBuySignalRejectionReason(signal aiMarketSignal) string {
+	if scalpingReversalBuyCandidate(signal) {
+		return ""
+	}
 	buyMomentumMin := math.Max(s.deterministicFallbackConfig().BuyMinPriceChangePct, 0.05)
 	if !signal.RecentChangeKnown {
 		if signal.RangePosition24h > scalpingNoRecentBuyMaxRangePct {
@@ -3299,13 +3333,15 @@ func (s *AIScalpingService) deterministicFallbackCandidate(
 	if signal.Price <= 0 || signal.Symbol == "" {
 		return nil, 0, false
 	}
-	if signal.BidAskSpread <= 0 || signal.BidAskSpread > effectiveMaxSpread {
+	reversalBuy := scalpingReversalBuyCandidate(signal)
+	sellWindow := scalpingSellWindowCandidate(signal)
+	if signal.BidAskSpread <= 0 || (signal.BidAskSpread > effectiveMaxSpread && !reversalBuy && !sellWindow) {
 		return nil, 0, false
 	}
 
 	imbalance := math.Abs(signal.OrderBookImbalance)
 	blowoffReversal := scalpingBlowoffSellTrendConfirmed(signal)
-	if imbalance < effectiveMinImbalance && !blowoffReversal {
+	if imbalance < effectiveMinImbalance && !blowoffReversal && !reversalBuy && !sellWindow {
 		return nil, 0, false
 	}
 
@@ -3321,6 +3357,22 @@ func (s *AIScalpingService) deterministicFallbackCandidate(
 	momentumAligned := false
 	blowoffReversal = false
 	switch {
+	case reversalBuy:
+		action = "buy"
+		momentumAligned = true
+		rangeAlignment = clampFloat(
+			(scalpingReversalBuyMaxRangePct-signal.RangePosition24h)/math.Max(scalpingReversalBuyMaxRangePct, 1),
+			0,
+			1,
+		)
+	case sellWindow:
+		action = "sell"
+		momentumAligned = true
+		rangeAlignment = clampFloat(
+			(signal.RangePosition24h-scalpingSellWindowMinRangePct)/math.Max(100-scalpingSellWindowMinRangePct, 1),
+			0,
+			1,
+		)
 	case signal.OrderBookImbalance >= effectiveMinImbalance &&
 		signal.RangePosition24h <= buyRangeMax:
 		action = "buy"
@@ -3396,16 +3448,16 @@ func (s *AIScalpingService) deterministicFallbackCandidate(
 	if !momentumAligned {
 		return nil, 0, false
 	}
-	if signal.RecentChangeKnown && action == "buy" && signal.BidAskSpread > scalpingRecentBuyMaxSpreadPct {
+	if signal.RecentChangeKnown && action == "buy" && !reversalBuy && signal.BidAskSpread > scalpingRecentBuyMaxSpreadPct {
 		return nil, 0, false
 	}
-	if signal.RecentChangeKnown && action == "buy" && signal.PriceChange24h < scalpingRecentBuyMinTrendPct {
+	if signal.RecentChangeKnown && action == "buy" && !reversalBuy && signal.PriceChange24h < scalpingRecentBuyMinTrendPct {
 		return nil, 0, false
 	}
-	if signal.RecentChangeKnown && action == "buy" && signal.RangePosition24h > scalpingRecentBuyMaxRangePct {
+	if signal.RecentChangeKnown && action == "buy" && !reversalBuy && signal.RangePosition24h > scalpingRecentBuyMaxRangePct {
 		return nil, 0, false
 	}
-	if signal.RecentChangeKnown && action == "sell" && !blowoffReversal && signal.RangePosition24h < scalpingRecentSellMinRangePct {
+	if signal.RecentChangeKnown && action == "sell" && !blowoffReversal && !sellWindow && signal.RangePosition24h < scalpingRecentSellMinRangePct {
 		return nil, 0, false
 	}
 
@@ -3430,6 +3482,9 @@ func (s *AIScalpingService) deterministicFallbackCandidate(
 	}
 	if minConfidenceFloor <= 0 {
 		minConfidenceFloor = fallbackCfg.ConfidenceFloor
+	}
+	if reversalBuy || sellWindow {
+		minConfidenceFloor = math.Min(minConfidenceFloor, s.config.MinConfidence)
 	}
 	if confidenceFloorOffset > 0 {
 		minConfidenceFloor -= confidenceFloorOffset
@@ -3489,6 +3544,10 @@ func (s *AIScalpingService) deterministicFallbackCandidate(
 	setup := "directional"
 	if blowoffReversal {
 		setup = "blowoff reversal"
+	} else if reversalBuy {
+		setup = "validated reversal buy"
+	} else if sellWindow {
+		setup = "validated sell window"
 	}
 	reason := fmt.Sprintf(
 		"deterministic fallback %s: %s pressure %.3f with spread %.3f%%, momentum %.3f%%, range position %.1f%%, projected net edge %s%%",
@@ -3571,6 +3630,28 @@ func fallbackMomentumPct(signal aiMarketSignal) float64 {
 
 func scalpingSellTrendConfirmed(signal aiMarketSignal) bool {
 	return signal.PriceChange24h <= scalpingSellBroadTrendMaxPct
+}
+
+func scalpingReversalBuyCandidate(signal aiMarketSignal) bool {
+	return signal.RecentChangeKnown &&
+		signal.BidAskSpread > 0 &&
+		signal.BidAskSpread <= scalpingReversalBuyMaxSpreadPct &&
+		signal.RangePosition24h <= scalpingReversalBuyMaxRangePct &&
+		signal.RecentPriceChange <= scalpingReversalBuyMaxRecentPct &&
+		signal.PriceChange24h <= scalpingReversalBuyMaxTrendPct
+}
+
+func scalpingSellWindowCandidate(signal aiMarketSignal) bool {
+	return signal.RecentChangeKnown &&
+		signal.BidAskSpread > 0 &&
+		signal.BidAskSpread <= scalpingSellWindowMaxSpreadPct &&
+		signal.OrderBookImbalance <= scalpingSellWindowMaxImbalance &&
+		signal.RangePosition24h >= scalpingSellWindowMinRangePct &&
+		signal.RangePosition24h <= scalpingSellWindowMaxRangePct &&
+		signal.RecentPriceChange >= scalpingSellWindowMinRecentPct &&
+		signal.RecentPriceChange <= scalpingSellWindowMaxRecentPct &&
+		signal.PriceChange24h >= scalpingSellWindowMinTrendPct &&
+		signal.PriceChange24h <= scalpingSellWindowMaxTrendPct
 }
 
 func scalpingBlowoffSellTrendConfirmed(signal aiMarketSignal) bool {

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -1373,6 +1373,22 @@ func TestAIScalpingService_BuildSystemPrompt_IncludesBackendSellSafetyGates(t *t
 	assert.NotContains(t, prompt, "Blowoff reversal sells")
 }
 
+func TestAIScalpingService_BuildSystemPrompt_UsesValidatedCandidateConstants(t *testing.T) {
+	svc := &AIScalpingService{config: AIScalpingConfig{Leverage: 5, MaxBidAskSpreadPct: 0.04}}
+
+	prompt := svc.buildSystemPrompt()
+
+	assert.Contains(t, prompt, "spread_pct <= 0.0600%")
+	assert.Contains(t, prompt, "range_pos_24h <= 20.0")
+	assert.Contains(t, prompt, "recent_price_change_pct <= -0.1500%")
+	assert.Contains(t, prompt, "price_change_24h_pct <= 0.0000%")
+	assert.Contains(t, prompt, "spread_pct <= 0.1000%")
+	assert.Contains(t, prompt, "ob_imbalance <= -0.30")
+	assert.Contains(t, prompt, "range_pos_24h is between 25.0 and 75.0")
+	assert.Contains(t, prompt, "recent_price_change_pct is between -0.6000% and 0.2000%")
+	assert.Contains(t, prompt, "price_change_24h_pct is between 0.0000% and 0.5000%")
+}
+
 func TestAIScalpingService_EstimateNetExpectancy_PrefersScopedRealizedJournal(t *testing.T) {
 	original := globalScalpingPerformance
 	globalScalpingPerformance = NewScalpingPerformance()
@@ -3566,6 +3582,110 @@ func TestFallbackProjectedNetEdgePct(t *testing.T) {
 	marginalEdge, _ := fallbackProjectedNetEdgePct(0.22, decimal.NewFromFloat(0.0040)).Float64()
 	assert.InDelta(t, 1.66, standardEdge, 0.0001)
 	assert.InDelta(t, 0.06, marginalEdge, 0.0001)
+}
+
+func TestAIScalpingService_ValidateDecisionAllowsValidatedReversalBuy(t *testing.T) {
+	cfg := DefaultAIScalpingConfig()
+	cfg.MaxBidAskSpreadPct = scalpingRecentBuyMaxSpreadPct
+	svc := &AIScalpingService{config: cfg}
+	stopLoss := decimal.NewFromFloat(99)
+	takeProfit := decimal.NewFromFloat(102)
+	decision := &AITradingDecision{
+		Action:      "buy",
+		Symbol:      "REV/USDT",
+		SizePercent: 5,
+		Confidence:  0.70,
+		StopLoss:    &stopLoss,
+		TakeProfit:  &takeProfit,
+	}
+
+	err := svc.validateDecision(decision, []aiMarketSignal{{
+		Symbol:             "REV/USDT",
+		Price:              100,
+		High24h:            115,
+		Low24h:             95,
+		Volume24h:          5_000_000,
+		BidAskSpread:       0.05,
+		OrderBookImbalance: 0.05,
+		RangePosition24h:   18,
+		PriceChange24h:     -0.10,
+		RecentPriceChange:  -0.20,
+		RecentChangeKnown:  true,
+	}})
+
+	require.NoError(t, err)
+}
+
+func TestAIScalpingService_ValidateDecisionAllowsValidatedSellWindow(t *testing.T) {
+	cfg := DefaultAIScalpingConfig()
+	cfg.MaxBidAskSpreadPct = scalpingRecentBuyMaxSpreadPct
+	svc := &AIScalpingService{config: cfg}
+	stopLoss := decimal.NewFromFloat(101)
+	takeProfit := decimal.NewFromFloat(98)
+	decision := &AITradingDecision{
+		Action:      "sell",
+		Symbol:      "SW/USDT",
+		SizePercent: 5,
+		Confidence:  0.70,
+		StopLoss:    &stopLoss,
+		TakeProfit:  &takeProfit,
+	}
+
+	err := svc.validateDecision(decision, []aiMarketSignal{{
+		Symbol:             "SW/USDT",
+		Price:              100,
+		High24h:            115,
+		Low24h:             95,
+		Volume24h:          5_000_000,
+		BidAskSpread:       0.09,
+		OrderBookImbalance: -0.45,
+		RangePosition24h:   55,
+		PriceChange24h:     0.30,
+		RecentPriceChange:  -0.10,
+		RecentChangeKnown:  true,
+	}})
+
+	require.NoError(t, err)
+}
+
+func TestAIScalpingService_DeterministicFallbackCandidate_AllowsValidatedCandidateShapes(t *testing.T) {
+	svc := &AIScalpingService{config: DefaultAIScalpingConfig()}
+
+	buyDecision, _, ok := svc.deterministicFallbackCandidate(context.Background(), aiMarketSignal{
+		Symbol:             "REV/USDT",
+		Price:              100,
+		High24h:            115,
+		Low24h:             95,
+		Volume24h:          5_000_000,
+		BidAskSpread:       0.05,
+		OrderBookImbalance: 0.05,
+		RangePosition24h:   18,
+		PriceChange24h:     -0.10,
+		RecentPriceChange:  -0.20,
+		RecentChangeKnown:  true,
+	}, TradingPortfolio{}, false)
+	require.True(t, ok)
+	require.NotNil(t, buyDecision)
+	require.Equal(t, "buy", buyDecision.Action)
+	require.Contains(t, buyDecision.Reasoning, "validated reversal buy")
+
+	sellDecision, _, ok := svc.deterministicFallbackCandidate(context.Background(), aiMarketSignal{
+		Symbol:             "SW/USDT",
+		Price:              100,
+		High24h:            115,
+		Low24h:             95,
+		Volume24h:          5_000_000,
+		BidAskSpread:       0.09,
+		OrderBookImbalance: -0.45,
+		RangePosition24h:   55,
+		PriceChange24h:     0.30,
+		RecentPriceChange:  -0.10,
+		RecentChangeKnown:  true,
+	}, TradingPortfolio{}, false)
+	require.True(t, ok)
+	require.NotNil(t, sellDecision)
+	require.Equal(t, "sell", sellDecision.Action)
+	require.Contains(t, sellDecision.Reasoning, "validated sell window")
 }
 
 func TestAIScalpingService_DeterministicFallbackCandidate_BlocksNegativeSymbolExpectancyForMicro(t *testing.T) {

--- a/services/backend-api/internal/services/scalping_backtest.go
+++ b/services/backend-api/internal/services/scalping_backtest.go
@@ -662,7 +662,10 @@ func (e *ScalpingBacktestEngine) classifyRegimeVolatility(signal MarketSignal) s
 func (e *ScalpingBacktestEngine) evaluateGates(signal MarketSignal, decision *AITradingDecision) map[string]GateResult {
 	results := map[string]GateResult{}
 
-	spreadAllowed := signal.BidAskSpread >= 0 && signal.BidAskSpread <= e.config.MaxBidAskSpreadPct
+	spreadAllowed := signal.BidAskSpread >= 0 &&
+		(signal.BidAskSpread <= e.config.MaxBidAskSpreadPct ||
+			scalpingReversalBuyCandidate(signal) ||
+			scalpingSellWindowCandidate(signal))
 	results["spread"] = GateResult{Allowed: spreadAllowed, Reason: gateReason(spreadAllowed, "spread_too_wide")}
 
 	imbalanceAllowed := math.Abs(signal.OrderBookImbalance) >= 0.10
@@ -900,14 +903,16 @@ func (e *ScalpingBacktestEngine) buildDecisionFromSignal(ctx context.Context, si
 	}
 
 	imbalance := math.Abs(signal.OrderBookImbalance)
-	if signal.BidAskSpread <= 0 || signal.BidAskSpread > e.config.MaxBidAskSpreadPct {
+	reversalBuy := scalpingReversalBuyCandidate(signal)
+	sellWindow := scalpingSellWindowCandidate(signal)
+	if signal.BidAskSpread <= 0 || (signal.BidAskSpread > e.config.MaxBidAskSpreadPct && !reversalBuy && !sellWindow) {
 		return nil
 	}
 	effectiveMinImbalance := math.Min(fallback.MinImbalance, 0.20)
 	if e.config.RequireRecentMomentum {
 		effectiveMinImbalance = fallback.MinImbalance
 	}
-	if imbalance < effectiveMinImbalance && !scalpingBlowoffSellTrendConfirmed(signal) {
+	if imbalance < effectiveMinImbalance && !scalpingBlowoffSellTrendConfirmed(signal) && !reversalBuy && !sellWindow {
 		return nil
 	}
 
@@ -930,6 +935,14 @@ func (e *ScalpingBacktestEngine) buildDecisionFromSignal(ctx context.Context, si
 	rangeAlignment := 0.0
 	momentumAligned := false
 	switch {
+	case reversalBuy:
+		action = "buy"
+		momentumAligned = true
+		rangeAlignment = clampFloat((scalpingReversalBuyMaxRangePct-signal.RangePosition24h)/math.Max(scalpingReversalBuyMaxRangePct, 1), 0, 1)
+	case sellWindow:
+		action = "sell"
+		momentumAligned = true
+		rangeAlignment = clampFloat((signal.RangePosition24h-scalpingSellWindowMinRangePct)/math.Max(100-scalpingSellWindowMinRangePct, 1), 0, 1)
 	case signal.OrderBookImbalance >= effectiveMinImbalance && signal.RangePosition24h <= fallback.BuyRangeMax:
 		action = "buy"
 		momentumAligned = momentumPct >= buyMomentumMin
@@ -968,17 +981,17 @@ func (e *ScalpingBacktestEngine) buildDecisionFromSignal(ctx context.Context, si
 	if !momentumAligned {
 		return nil
 	}
-	if e.config.RequireRecentMomentum && action == "buy" && signal.BidAskSpread > scalpingRecentBuyMaxSpreadPct {
+	if e.config.RequireRecentMomentum && action == "buy" && !reversalBuy && signal.BidAskSpread > scalpingRecentBuyMaxSpreadPct {
 		return nil
 	}
-	if e.config.RequireRecentMomentum && action == "buy" && signal.PriceChange24h < scalpingRecentBuyMinTrendPct {
+	if e.config.RequireRecentMomentum && action == "buy" && !reversalBuy && signal.PriceChange24h < scalpingRecentBuyMinTrendPct {
 		return nil
 	}
-	if e.config.RequireRecentMomentum && action == "buy" && signal.RangePosition24h > scalpingRecentBuyMaxRangePct {
+	if e.config.RequireRecentMomentum && action == "buy" && !reversalBuy && signal.RangePosition24h > scalpingRecentBuyMaxRangePct {
 		return nil
 	}
 	if e.config.RequireRecentMomentum && action == "sell" && !scalpingBlowoffSellTrendConfirmed(signal) &&
-		signal.RangePosition24h < scalpingRecentSellMinRangePct {
+		!sellWindow && signal.RangePosition24h < scalpingRecentSellMinRangePct {
 		return nil
 	}
 

--- a/services/backend-api/internal/services/scalping_backtest_test.go
+++ b/services/backend-api/internal/services/scalping_backtest_test.go
@@ -647,6 +647,57 @@ func TestScalpingBacktestEngine_BuildDecisionBlocksWeakBlowoffSellPressure(t *te
 	require.Nil(t, decision)
 }
 
+func TestScalpingBacktestEngine_BuildDecisionAllowsValidatedReversalBuy(t *testing.T) {
+	now := time.Date(2026, 5, 21, 2, 25, 0, 0, time.UTC)
+	engine := newRunSignalsTestEngine(now)
+	engine.config.RequireRecentMomentum = true
+	engine.config.MinRecentMomentumPct = 0.05
+
+	decision := engine.buildDecisionFromSignal(context.Background(), MarketSignal{
+		Symbol:             "REV/USDT",
+		Price:              100,
+		High24h:            115,
+		Low24h:             95,
+		Volume24h:          5_000_000,
+		BidAskSpread:       0.05,
+		OrderBookImbalance: 0.05,
+		RangePosition24h:   18,
+		PriceChange24h:     -0.10,
+		RecentPriceChange:  -0.20,
+		RecentChangeKnown:  true,
+	})
+
+	require.NotNil(t, decision)
+	require.Equal(t, "buy", decision.Action)
+	require.Equal(t, "REV/USDT", decision.Symbol)
+}
+
+func TestScalpingBacktestEngine_BuildDecisionAllowsValidatedSellWindow(t *testing.T) {
+	now := time.Date(2026, 5, 21, 2, 25, 30, 0, time.UTC)
+	engine := newRunSignalsTestEngine(now)
+	engine.config.RequireRecentMomentum = true
+	engine.config.MinRecentMomentumPct = 0.05
+	engine.config.MaxBidAskSpreadPct = 0.08
+
+	decision := engine.buildDecisionFromSignal(context.Background(), MarketSignal{
+		Symbol:             "SW/USDT",
+		Price:              100,
+		High24h:            115,
+		Low24h:             95,
+		Volume24h:          5_000_000,
+		BidAskSpread:       0.09,
+		OrderBookImbalance: -0.45,
+		RangePosition24h:   55,
+		PriceChange24h:     0.30,
+		RecentPriceChange:  -0.10,
+		RecentChangeKnown:  true,
+	})
+
+	require.NotNil(t, decision)
+	require.Equal(t, "sell", decision.Action)
+	require.Equal(t, "SW/USDT", decision.Symbol)
+}
+
 func TestScalpingBacktestEngine_RunSignalsAllowsBufferedMidRangeBuy(t *testing.T) {
 	now := time.Date(2026, 5, 12, 2, 48, 0, 0, time.UTC)
 	engine := newRunSignalsTestEngine(now)


### PR DESCRIPTION
## Summary

- add explicit runtime/backtest gates for the only strict offline scalping candidates found so far: reversal buys and a bounded sell window
- keep the runtime validator, deterministic fallback, LLM prompt, and backtest decision builder aligned
- add unit coverage for both candidate shapes in the live service path and backtest path

## Evidence

Offline source: `/private/tmp/neuratrade-paper-rule-search-20260520/expanded-four-exchange-hold60-candidate-portfolio-validation.json`.

A fresh Bitget telemetry soak on May 21, 2026 exercised the new path but did **not** prove live readiness:

- artifact: `/tmp/neuratrade-runtime-candidates-20260521/bitget-60.json`
- 60 cycles / 480 signals
- 3 eligible signals
- 1 closed paper trade
- net PnL `-0.002052478194850864312761`
- live trial readiness `false`
- readiness blockers: closed trades below minimum, no winning trades, non-positive net/average PnL, hold ratio above maximum

## Validation

- `git diff --check`
- `go test ./internal/services`
- `make build`
- `make lint`

## Notes

This PR is stacked on #377 and should remain draft. It wires the best validated candidate shapes into runtime/backtest logic, but it is not sufficient evidence for real-money scalping readiness.

## Summary by Sourcery

Wire validated reversal-buy and sell-window scalping candidate shapes through runtime validation, deterministic fallback, prompts, and backtest evaluation.

New Features:
- Introduce dedicated reversal-buy and bounded sell-window scalping candidate definitions with explicit thresholds for spread, range, momentum, and trend.
- Allow deterministic fallback and backtest engines to select trades based on validated reversal-buy and sell-window candidates even when they exceed default spread and imbalance constraints.

Enhancements:
- Extend system prompt guidance to describe validated reversal-buy and sell-window exceptions for the model’s buy and sell safety gates.
- Adjust runtime decision validation to use action-aware spread thresholds and to recognize validated sell-window candidates as an alternative to standard sell trend confirmation.

Tests:
- Add unit tests ensuring prompts include validated candidate constants and that runtime and backtest paths both accept the validated reversal-buy and sell-window candidate scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validated reversal buy and sell window trade patterns in AI scalping engine.

* **Improvements**
  * Enhanced spread gating logic with action and signal-type dependent thresholds.
  * Refined trade decision validation for new candidate patterns.
  * Improved deterministic fallback selection with range-alignment scoring.

* **Tests**
  * Expanded test coverage for new validated candidate types and decision validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->