### PR TITLE
[codex] Block live mode without strategy readiness proof

### DIFF
--- a/.omo/run-continuation/ses_18ec3fea7ffeHpAioi0S5KX96k.json
+++ b/.omo/run-continuation/ses_18ec3fea7ffeHpAioi0S5KX96k.json
@@ -1,0 +1,10 @@
+{
+  "sessionID": "ses_18ec3fea7ffeHpAioi0S5KX96k",
+  "updatedAt": "2026-05-29T04:27:02.731Z",
+  "sources": {
+    "background-task": {
+      "state": "idle",
+      "updatedAt": "2026-05-29T04:27:02.731Z"
+    }
+  }
+}

--- a/.omo/run-continuation/ses_204d43fa2ffeNW2ndYx5Bz7dNS.json
+++ b/.omo/run-continuation/ses_204d43fa2ffeNW2ndYx5Bz7dNS.json
@@ -1,0 +1,10 @@
+{
+  "sessionID": "ses_204d43fa2ffeNW2ndYx5Bz7dNS",
+  "updatedAt": "2026-05-06T03:56:07.573Z",
+  "sources": {
+    "background-task": {
+      "state": "idle",
+      "updatedAt": "2026-05-06T03:56:07.573Z"
+    }
+  }
+}

--- a/.omo/run-continuation/ses_206d9cbd0ffeQ3IKNRpqrsn75V.json
+++ b/.omo/run-continuation/ses_206d9cbd0ffeQ3IKNRpqrsn75V.json
@@ -1,0 +1,10 @@
+{
+  "sessionID": "ses_206d9cbd0ffeQ3IKNRpqrsn75V",
+  "updatedAt": "2026-05-05T17:49:19.209Z",
+  "sources": {
+    "background-task": {
+      "state": "idle",
+      "updatedAt": "2026-05-05T17:49:19.209Z"
+    }
+  }
+}

--- a/services/backend-api/docs/DAILY_TRADING_READINESS.md
+++ b/services/backend-api/docs/DAILY_TRADING_READINESS.md
@@ -1,0 +1,18 @@
+# Daily Trading Readiness
+
+Daily trading is not real-money ready.
+
+The backend registers a `daily_report` quest, but this is a reporting quest, not an executable daily trading strategy. It now writes explicit checkpoint fields so operators and tests can distinguish daily performance reporting from live-money trading readiness:
+
+- `daily_trading_live_ready=false`
+- `daily_trading_readiness_status=blocked`
+- `daily_trading_readiness_blockers`
+
+Current hard blockers:
+
+- No dedicated `daily_trading` strategy implementation exists.
+- No daily paper order lifecycle has been proven with representative closed wins and losses.
+- No positive daily net/average PnL evidence exists after fees.
+- No readiness evidence should mark daily trading ready until the above proof exists.
+
+The `daily_report` quest may summarize the last 24 hours of realized lifecycle performance when a lifecycle store is configured. That report is observability only and must not be used as live-money authorization.

--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -5,7 +5,8 @@ manifest from `NEURATRADE_LIVE_READINESS_MANIFEST`.
 
 The manifest is intentionally a final gate, not proof by itself. Each entry must
 point to evidence produced by the relevant paper/live-market verifier for that
-strategy.
+strategy. Trading strategies also require structured `evidence_metrics`; a
+non-empty evidence path alone is not enough to permit live mode.
 
 ```json
 {
@@ -19,6 +20,15 @@ strategy.
     "scalping": {
       "ready": true,
       "evidence": "/path/to/scalping-live-trial-ready.json",
+      "evidence_metrics": {
+        "closed_trades": 20,
+        "winning_trades": 9,
+        "losing_trades": 11,
+        "open_positions": 0,
+        "net_pnl": "1.25",
+        "avg_net_pnl": "0.0625",
+        "max_drawdown_pct": "0.42"
+      },
       "verified_at": "2026-05-21T00:00:00Z"
     },
     "daily_trading": {
@@ -33,6 +43,28 @@ strategy.
       "ready": false,
       "reason": "paper/live-market proof missing"
     }
+  }
+}
+```
+
+Required trading-strategy metrics:
+
+- `closed_trades`: at least 20 for `scalping`; at least 2 for `daily_trading`, `swing_trading`, and `arbitrage` unless arbitrage uses documented no-trade safety.
+- `winning_trades` and `losing_trades`: both must be positive.
+- `open_positions`: must be 0.
+- `net_pnl`, `avg_net_pnl`, and `max_drawdown_pct`: decimal strings greater than 0.
+
+Arbitrage may use no-trade safety evidence instead of closed-trade metrics only
+when an observed window proves no executable spreads/opportunities after costs:
+
+```json
+{
+  "ready": true,
+  "evidence": "/path/to/arbitrage-no-trade-safety.json",
+  "evidence_metrics": {
+    "no_trade_safety": true,
+    "no_trade_reason": "no executable spreads after fees across observed window",
+    "open_positions": 0
   }
 }
 ```

--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -1,0 +1,50 @@
+# Live Readiness Manifest
+
+`/mode live` is blocked by default unless the backend can read a live-readiness
+manifest from `NEURATRADE_LIVE_READINESS_MANIFEST`.
+
+The manifest is intentionally a final gate, not proof by itself. Each entry must
+point to evidence produced by the relevant paper/live-market verifier for that
+strategy.
+
+```json
+{
+  "updated_at": "2026-05-21T00:00:00Z",
+  "strategies": {
+    "paper_trading": {
+      "ready": true,
+      "evidence": "/path/to/paper-trading-verification.json",
+      "verified_at": "2026-05-21T00:00:00Z"
+    },
+    "scalping": {
+      "ready": true,
+      "evidence": "/path/to/scalping-live-trial-ready.json",
+      "verified_at": "2026-05-21T00:00:00Z"
+    },
+    "daily_trading": {
+      "ready": false,
+      "reason": "paper/live-market proof missing"
+    },
+    "swing_trading": {
+      "ready": false,
+      "reason": "paper/live-market proof missing"
+    },
+    "arbitrage": {
+      "ready": false,
+      "reason": "paper/live-market proof missing"
+    }
+  }
+}
+```
+
+Default required strategies:
+
+- `paper_trading`
+- `scalping`
+- `daily_trading`
+- `swing_trading`
+- `arbitrage`
+
+Override the checked list with `NEURATRADE_LIVE_READINESS_STRATEGIES`, using a
+comma-separated list. Disable the guard only for local diagnostics with
+`NEURATRADE_REQUIRE_LIVE_READINESS_PROOF=false`.

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -82,6 +82,36 @@ func getEnvOrDefault(key, defaultValue string) string {
 	return defaultValue
 }
 
+func configureLiveReadinessGuard(opModeService *services.OperationalModeService) {
+	if opModeService == nil {
+		return
+	}
+	if liveReadinessGuardDisabled(os.Getenv("NEURATRADE_REQUIRE_LIVE_READINESS_PROOF")) {
+		log.Printf("WARNING: real-money live readiness proof guard disabled by NEURATRADE_REQUIRE_LIVE_READINESS_PROOF")
+		opModeService.SetLiveModeGuard(nil)
+		return
+	}
+
+	requiredStrategies := services.DefaultLiveReadinessStrategies()
+	if raw := strings.TrimSpace(os.Getenv("NEURATRADE_LIVE_READINESS_STRATEGIES")); raw != "" {
+		requiredStrategies = strings.Split(raw, ",")
+	}
+	manifestPath := strings.TrimSpace(os.Getenv(services.LiveReadinessManifestEnv))
+	opModeService.SetLiveModeGuard(services.ManifestLiveModeGuard(manifestPath, requiredStrategies))
+	if manifestPath == "" {
+		log.Printf("Real-money live readiness proof guard enabled; live mode requires %s with strategy evidence", services.LiveReadinessManifestEnv)
+	}
+}
+
+func liveReadinessGuardDisabled(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "0", "false", "no", "off", "disabled":
+		return true
+	default:
+		return false
+	}
+}
+
 type llmProviderNodeConfig struct {
 	Provider      string
 	APIKey        string
@@ -375,6 +405,8 @@ func riskLockSourcePriority(source string) int {
 //
 //nolint:staticcheck // SA1019: SignalAggregator and TechnicalAnalysisService are deprecated but required for backward compatibility until scalping composer migration completes.
 func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, ccxtService ccxt.CCXTService, collectorService *services.CollectorService, cleanupService *services.CleanupService, cacheAnalyticsService *services.CacheAnalyticsService, signalAggregator *services.SignalAggregator, analyticsService *services.AnalyticsService, telegramConfig *config.TelegramConfig, aiConfig *config.AIConfig, featuresConfig *config.FeaturesConfig, authMiddleware *middleware.AuthMiddleware, walletValidator *services.WalletValidator, opModeService *services.OperationalModeService, technicalAnalysisService *services.TechnicalAnalysisService) func() {
+	configureLiveReadinessGuard(opModeService)
+
 	// Initialize admin middleware
 	adminMiddleware := middleware.NewAdminMiddleware()
 

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -94,11 +94,25 @@ func configureLiveReadinessGuard(opModeService *services.OperationalModeService)
 
 	requiredStrategies := services.DefaultLiveReadinessStrategies()
 	if raw := strings.TrimSpace(os.Getenv("NEURATRADE_LIVE_READINESS_STRATEGIES")); raw != "" {
-		requiredStrategies = strings.Split(raw, ",")
+		parsed := strings.Split(raw, ",")
+		filtered := make([]string, 0, len(parsed))
+		for _, s := range parsed {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				filtered = append(filtered, s)
+			}
+		}
+		if len(filtered) > 0 {
+			requiredStrategies = filtered
+		} else {
+			log.Printf("WARNING: NEURATRADE_LIVE_READINESS_STRATEGIES contained only empty/whitespace entries; using defaults")
+		}
 	}
 	manifestPath := strings.TrimSpace(os.Getenv(services.LiveReadinessManifestEnv))
 	opModeService.SetLiveModeGuard(services.ManifestLiveModeGuard(manifestPath, requiredStrategies))
-	if manifestPath == "" {
+	if manifestPath != "" {
+		log.Printf("Real-money live readiness proof guard enabled with manifest %s; live mode requires strategy evidence", manifestPath)
+	} else {
 		log.Printf("Real-money live readiness proof guard enabled; live mode requires %s with strategy evidence", services.LiveReadinessManifestEnv)
 	}
 }

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -1,0 +1,122 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+const (
+	// LiveReadinessManifestEnv is the path to the manifest that records which
+	// strategies have verified evidence before global live mode can be enabled.
+	LiveReadinessManifestEnv = "NEURATRADE_LIVE_READINESS_MANIFEST"
+)
+
+// LiveModeGuard blocks or permits a transition into real-money live mode.
+type LiveModeGuard func(ctx context.Context, chatID string, changedBy string) error
+
+// StrategyLiveReadiness records one strategy's live-readiness evidence.
+type StrategyLiveReadiness struct {
+	Ready      bool   `json:"ready"`
+	Evidence   string `json:"evidence,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+	VerifiedAt string `json:"verified_at,omitempty"`
+}
+
+// LiveReadinessManifest is the file format consumed by ManifestLiveModeGuard.
+type LiveReadinessManifest struct {
+	UpdatedAt  string                           `json:"updated_at,omitempty"`
+	Strategies map[string]StrategyLiveReadiness `json:"strategies"`
+}
+
+// DefaultLiveReadinessStrategies returns every strategy/operator surface that
+// must have proof before the global live mode can be used for real money.
+func DefaultLiveReadinessStrategies() []string {
+	return []string{"paper_trading", "scalping", "daily_trading", "swing_trading", "arbitrage"}
+}
+
+// ManifestLiveModeGuard requires a JSON manifest with ready=true and non-empty
+// evidence for each required strategy.
+func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) LiveModeGuard {
+	required := normalizeReadinessStrategies(requiredStrategies)
+	return func(_ context.Context, _ string, _ string) error {
+		if len(required) == 0 {
+			return nil
+		}
+		path := strings.TrimSpace(manifestPath)
+		if path == "" {
+			return fmt.Errorf(
+				"live mode blocked: %s is required with verified evidence for %s",
+				LiveReadinessManifestEnv,
+				strings.Join(required, ", "),
+			)
+		}
+
+		// #nosec G304 -- path is operator-configured via NEURATRADE_LIVE_READINESS_MANIFEST.
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("live mode blocked: read readiness manifest %q: %w", path, err)
+		}
+
+		var manifest LiveReadinessManifest
+		if err := json.Unmarshal(raw, &manifest); err != nil {
+			return fmt.Errorf("live mode blocked: parse readiness manifest %q: %w", path, err)
+		}
+
+		strategies := normalizeReadinessManifestStrategies(manifest.Strategies)
+		var blockers []string
+		for _, strategy := range required {
+			status, ok := strategies[strategy]
+			switch {
+			case !ok:
+				blockers = append(blockers, fmt.Sprintf("%s=missing", strategy))
+			case !status.Ready:
+				reason := strings.TrimSpace(status.Reason)
+				if reason == "" {
+					reason = "not_ready"
+				}
+				blockers = append(blockers, fmt.Sprintf("%s=%s", strategy, reason))
+			case strings.TrimSpace(status.Evidence) == "":
+				blockers = append(blockers, fmt.Sprintf("%s=missing_evidence", strategy))
+			}
+		}
+		if len(blockers) > 0 {
+			return fmt.Errorf("live mode blocked: readiness proof incomplete (%s)", strings.Join(blockers, "; "))
+		}
+
+		return nil
+	}
+}
+
+func normalizeReadinessStrategies(strategies []string) []string {
+	seen := make(map[string]struct{}, len(strategies))
+	normalized := make([]string, 0, len(strategies))
+	for _, strategy := range strategies {
+		strategy = strings.ToLower(strings.TrimSpace(strategy))
+		if strategy == "" {
+			continue
+		}
+		if _, ok := seen[strategy]; ok {
+			continue
+		}
+		seen[strategy] = struct{}{}
+		normalized = append(normalized, strategy)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func normalizeReadinessManifestStrategies(strategies map[string]StrategyLiveReadiness) map[string]StrategyLiveReadiness {
+	normalized := make(map[string]StrategyLiveReadiness, len(strategies))
+	for strategy, status := range strategies {
+		key := strings.ToLower(strings.TrimSpace(strategy))
+		if key == "" {
+			continue
+		}
+		normalized[key] = status
+	}
+	return normalized
+}

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/shopspring/decimal"
 )
@@ -26,7 +28,7 @@ type StrategyLiveReadiness struct {
 	Evidence        string                     `json:"evidence,omitempty"`
 	EvidenceMetrics *StrategyReadinessEvidence `json:"evidence_metrics,omitempty"`
 	Reason          string                     `json:"reason,omitempty"`
-	VerifiedAt      string                     `json:"verified_at,omitempty"`
+	VerifiedAt      time.Time                  `json:"verified_at,omitempty"`
 }
 
 // StrategyReadinessEvidence records the minimum proof needed before a trading
@@ -45,7 +47,7 @@ type StrategyReadinessEvidence struct {
 
 // LiveReadinessManifest is the file format consumed by ManifestLiveModeGuard.
 type LiveReadinessManifest struct {
-	UpdatedAt  string                           `json:"updated_at,omitempty"`
+	UpdatedAt  time.Time                        `json:"updated_at,omitempty"`
 	Strategies map[string]StrategyLiveReadiness `json:"strategies"`
 }
 
@@ -55,10 +57,21 @@ func DefaultLiveReadinessStrategies() []string {
 	return []string{"paper_trading", "scalping", "daily_trading", "swing_trading", "arbitrage"}
 }
 
+type cachedManifest struct {
+	manifest  LiveReadinessManifest
+	err       error
+	loadedAt  time.Time
+}
+
 // ManifestLiveModeGuard requires a JSON manifest with ready=true and non-empty
-// evidence for each required strategy.
+// evidence for each required strategy. The manifest is cached in memory for 30
+// seconds to avoid re-reading from disk on every live-mode check.
 func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) LiveModeGuard {
 	required := normalizeReadinessStrategies(requiredStrategies)
+	var mu sync.RWMutex
+	var cache *cachedManifest
+	const cacheTTL = 30 * time.Second
+
 	return func(_ context.Context, _ string, _ string) error {
 		if len(required) == 0 {
 			return nil
@@ -72,42 +85,68 @@ func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) Liv
 			)
 		}
 
+		mu.RLock()
+		if cache != nil && time.Since(cache.loadedAt) < cacheTTL {
+			mu.RUnlock()
+			if cache.err != nil {
+				return cache.err
+			}
+			return evaluateReadinessBlockers(required, cache.manifest)
+		}
+		mu.RUnlock()
+
+		mu.Lock()
+		defer mu.Unlock()
+		// Double-check after acquiring write lock
+		if cache != nil && time.Since(cache.loadedAt) < cacheTTL {
+			if cache.err != nil {
+				return cache.err
+			}
+			return evaluateReadinessBlockers(required, cache.manifest)
+		}
+
 		// #nosec G304 -- path is operator-configured via NEURATRADE_LIVE_READINESS_MANIFEST.
 		raw, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("live mode blocked: read readiness manifest %q: %w", path, err)
+			cache = &cachedManifest{err: fmt.Errorf("live mode blocked: read readiness manifest %q: %w", path, err), loadedAt: time.Now()}
+			return cache.err
 		}
 
 		var manifest LiveReadinessManifest
 		if err := json.Unmarshal(raw, &manifest); err != nil {
-			return fmt.Errorf("live mode blocked: parse readiness manifest %q: %w", path, err)
+			cache = &cachedManifest{err: fmt.Errorf("live mode blocked: parse readiness manifest %q: %w", path, err), loadedAt: time.Now()}
+			return cache.err
 		}
 
-		strategies := normalizeReadinessManifestStrategies(manifest.Strategies)
-		var blockers []string
-		for _, strategy := range required {
-			status, ok := strategies[strategy]
-			switch {
-			case !ok:
-				blockers = append(blockers, fmt.Sprintf("%s=missing", strategy))
-			case !status.Ready:
-				reason := strings.TrimSpace(status.Reason)
-				if reason == "" {
-					reason = "not_ready"
-				}
-				blockers = append(blockers, fmt.Sprintf("%s=%s", strategy, reason))
-			case strings.TrimSpace(status.Evidence) == "":
-				blockers = append(blockers, fmt.Sprintf("%s=missing_evidence", strategy))
-			default:
-				blockers = append(blockers, strategyReadinessEvidenceBlockers(strategy, status)...)
-			}
-		}
-		if len(blockers) > 0 {
-			return fmt.Errorf("live mode blocked: readiness proof incomplete (%s)", strings.Join(blockers, "; "))
-		}
-
-		return nil
+		cache = &cachedManifest{manifest: manifest, loadedAt: time.Now()}
+		return evaluateReadinessBlockers(required, manifest)
 	}
+}
+
+func evaluateReadinessBlockers(required []string, manifest LiveReadinessManifest) error {
+	strategies := normalizeReadinessManifestStrategies(manifest.Strategies)
+	var blockers []string
+	for _, strategy := range required {
+		status, ok := strategies[strategy]
+		switch {
+		case !ok:
+			blockers = append(blockers, fmt.Sprintf("%s=missing", strategy))
+		case !status.Ready:
+			reason := strings.TrimSpace(status.Reason)
+			if reason == "" {
+				reason = "not_ready"
+			}
+			blockers = append(blockers, fmt.Sprintf("%s=%s", strategy, reason))
+		case strings.TrimSpace(status.Evidence) == "":
+			blockers = append(blockers, fmt.Sprintf("%s=missing_evidence", strategy))
+		default:
+			blockers = append(blockers, strategyReadinessEvidenceBlockers(strategy, status)...)
+		}
+	}
+	if len(blockers) > 0 {
+		return fmt.Errorf("live mode blocked: readiness proof incomplete (%s)", strings.Join(blockers, "; "))
+	}
+	return nil
 }
 
 func normalizeReadinessStrategies(strategies []string) []string {

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/shopspring/decimal"
 )
 
 const (
@@ -20,10 +22,25 @@ type LiveModeGuard func(ctx context.Context, chatID string, changedBy string) er
 
 // StrategyLiveReadiness records one strategy's live-readiness evidence.
 type StrategyLiveReadiness struct {
-	Ready      bool   `json:"ready"`
-	Evidence   string `json:"evidence,omitempty"`
-	Reason     string `json:"reason,omitempty"`
-	VerifiedAt string `json:"verified_at,omitempty"`
+	Ready           bool                       `json:"ready"`
+	Evidence        string                     `json:"evidence,omitempty"`
+	EvidenceMetrics *StrategyReadinessEvidence `json:"evidence_metrics,omitempty"`
+	Reason          string                     `json:"reason,omitempty"`
+	VerifiedAt      string                     `json:"verified_at,omitempty"`
+}
+
+// StrategyReadinessEvidence records the minimum proof needed before a trading
+// strategy may be represented as live-ready in the operator manifest.
+type StrategyReadinessEvidence struct {
+	ClosedTrades   int    `json:"closed_trades,omitempty"`
+	WinningTrades  int    `json:"winning_trades,omitempty"`
+	LosingTrades   int    `json:"losing_trades,omitempty"`
+	OpenPositions  int    `json:"open_positions,omitempty"`
+	NetPnL         string `json:"net_pnl,omitempty"`
+	AvgNetPnL      string `json:"avg_net_pnl,omitempty"`
+	MaxDrawdownPct string `json:"max_drawdown_pct,omitempty"`
+	NoTradeSafety  bool   `json:"no_trade_safety,omitempty"`
+	NoTradeReason  string `json:"no_trade_reason,omitempty"`
 }
 
 // LiveReadinessManifest is the file format consumed by ManifestLiveModeGuard.
@@ -81,6 +98,8 @@ func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) Liv
 				blockers = append(blockers, fmt.Sprintf("%s=%s", strategy, reason))
 			case strings.TrimSpace(status.Evidence) == "":
 				blockers = append(blockers, fmt.Sprintf("%s=missing_evidence", strategy))
+			default:
+				blockers = append(blockers, strategyReadinessEvidenceBlockers(strategy, status)...)
 			}
 		}
 		if len(blockers) > 0 {
@@ -107,6 +126,69 @@ func normalizeReadinessStrategies(strategies []string) []string {
 	}
 	sort.Strings(normalized)
 	return normalized
+}
+
+func strategyReadinessEvidenceBlockers(strategy string, status StrategyLiveReadiness) []string {
+	if strategy == "paper_trading" {
+		return nil
+	}
+	metrics := status.EvidenceMetrics
+	if metrics == nil {
+		return []string{fmt.Sprintf("%s=missing_evidence_metrics", strategy)}
+	}
+	if strategy == "arbitrage" && metrics.NoTradeSafety {
+		if strings.TrimSpace(metrics.NoTradeReason) == "" {
+			return []string{"arbitrage=missing_no_trade_reason"}
+		}
+		if metrics.OpenPositions != 0 {
+			return []string{fmt.Sprintf("arbitrage=open_positions_%d", metrics.OpenPositions)}
+		}
+		return nil
+	}
+
+	var blockers []string
+	if metrics.ClosedTrades < minimumReadinessClosedTrades(strategy) {
+		blockers = append(blockers, fmt.Sprintf("%s=insufficient_closed_trades", strategy))
+	}
+	if metrics.ClosedTrades < metrics.WinningTrades+metrics.LosingTrades {
+		blockers = append(blockers, fmt.Sprintf("%s=inconsistent_trade_counts", strategy))
+	}
+	if metrics.WinningTrades <= 0 {
+		blockers = append(blockers, fmt.Sprintf("%s=no_winning_trades", strategy))
+	}
+	if metrics.LosingTrades <= 0 {
+		blockers = append(blockers, fmt.Sprintf("%s=no_losing_trades", strategy))
+	}
+	if metrics.OpenPositions != 0 {
+		blockers = append(blockers, fmt.Sprintf("%s=open_positions_%d", strategy, metrics.OpenPositions))
+	}
+	if !positiveDecimalString(metrics.NetPnL) {
+		blockers = append(blockers, fmt.Sprintf("%s=non_positive_net_pnl", strategy))
+	}
+	if !positiveDecimalString(metrics.AvgNetPnL) {
+		blockers = append(blockers, fmt.Sprintf("%s=non_positive_avg_net_pnl", strategy))
+	}
+	if !positiveDecimalString(metrics.MaxDrawdownPct) {
+		blockers = append(blockers, fmt.Sprintf("%s=missing_observed_drawdown", strategy))
+	}
+	return blockers
+}
+
+func minimumReadinessClosedTrades(strategy string) int {
+	switch strategy {
+	case "scalping":
+		return 20
+	default:
+		return 2
+	}
+}
+
+func positiveDecimalString(raw string) bool {
+	value, err := decimal.NewFromString(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	return value.GreaterThan(decimal.Zero)
 }
 
 func normalizeReadinessManifestStrategies(strategies map[string]StrategyLiveReadiness) map[string]StrategyLiveReadiness {

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -58,9 +58,9 @@ func DefaultLiveReadinessStrategies() []string {
 }
 
 type cachedManifest struct {
-	manifest  LiveReadinessManifest
-	err       error
-	loadedAt  time.Time
+	manifest LiveReadinessManifest
+	err      error
+	loadedAt time.Time
 }
 
 // ManifestLiveModeGuard requires a JSON manifest with ready=true and non-empty

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -536,6 +536,20 @@ func (h *IntegratedQuestHandlers) handleDailyPerformanceReport(ctx context.Conte
 		quest.Metadata = make(map[string]string)
 	}
 
+	clearDailyPerformanceMetrics := func(cp map[string]interface{}) {
+		if cp == nil {
+			return
+		}
+		delete(cp, "daily_report_closed_trades")
+		delete(cp, "daily_report_wins")
+		delete(cp, "daily_report_losses")
+		delete(cp, "daily_report_breakeven")
+		delete(cp, "daily_report_net_pnl")
+		delete(cp, "daily_report_gross_pnl")
+		delete(cp, "daily_report_fees")
+		delete(cp, "daily_report_avg_net_pnl")
+	}
+
 	now := time.Now().UTC()
 	since := now.Add(-24 * time.Hour)
 	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
@@ -555,6 +569,7 @@ func (h *IntegratedQuestHandlers) handleDailyPerformanceReport(ctx context.Conte
 	quest.Checkpoint["daily_report_exchange"] = exchange
 
 	if h.lifecycleStore == nil {
+		clearDailyPerformanceMetrics(quest.Checkpoint)
 		blockers = append(blockers, "lifecycle_store_unavailable")
 		writeDailyTradingReadinessCheckpoint(quest, blockers)
 		quest.CurrentCount++
@@ -564,6 +579,7 @@ func (h *IntegratedQuestHandlers) handleDailyPerformanceReport(ctx context.Conte
 	writeDailyTradingReadinessCheckpoint(quest, blockers)
 	summary, err := h.lifecycleStore.GetRealizedPerformance(ctx, chatID, exchange, since)
 	if err != nil {
+		clearDailyPerformanceMetrics(quest.Checkpoint)
 		blockers = append(blockers, "realized_performance_query_failed")
 		writeDailyTradingReadinessCheckpoint(quest, blockers)
 		return fmt.Errorf("daily performance report: realized performance: %w", err)

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -505,6 +505,8 @@ func (h *IntegratedQuestHandlers) ExecuteRoutine(ctx context.Context, quest *Que
 		err = h.handleFundingRateScan(ctx, quest)
 	case "portfolio_health":
 		err = h.handlePortfolioHealthWithRisk(ctx, quest)
+	case "daily_report":
+		err = h.handleDailyPerformanceReport(ctx, quest)
 	case "fund_growth":
 		err = h.handleFundGrowthGoal(ctx, quest)
 	case "scalping_execution":
@@ -521,6 +523,90 @@ func (h *IntegratedQuestHandlers) ExecuteArbitrage(ctx context.Context, quest *Q
 	err := h.handleArbitrageExecution(ctx, quest)
 	h.recordQuestResult(quest, err == nil, decimal.Zero)
 	return err
+}
+
+func (h *IntegratedQuestHandlers) handleDailyPerformanceReport(ctx context.Context, quest *Quest) error {
+	if quest == nil {
+		return fmt.Errorf("quest is nil")
+	}
+	if quest.Checkpoint == nil {
+		quest.Checkpoint = make(map[string]interface{})
+	}
+	if quest.Metadata == nil {
+		quest.Metadata = make(map[string]string)
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-24 * time.Hour)
+	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
+	exchange := strings.TrimSpace(quest.Metadata["exchange"])
+	if exchange == "" {
+		exchange = strings.TrimSpace(scalpingExchangeFromContext(ctx))
+	}
+
+	blockers := []string{
+		"daily_trading_strategy_not_implemented",
+		"daily_report_is_reporting_only",
+	}
+	quest.Checkpoint["daily_report_generated_at"] = now.Format(time.RFC3339)
+	quest.Checkpoint["daily_report_window_start"] = since.Format(time.RFC3339)
+	quest.Checkpoint["daily_report_window_end"] = now.Format(time.RFC3339)
+	quest.Checkpoint["daily_report_chat_id"] = chatID
+	quest.Checkpoint["daily_report_exchange"] = exchange
+
+	if h.lifecycleStore == nil {
+		blockers = append(blockers, "lifecycle_store_unavailable")
+		writeDailyTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
+
+	writeDailyTradingReadinessCheckpoint(quest, blockers)
+	summary, err := h.lifecycleStore.GetRealizedPerformance(ctx, chatID, exchange, since)
+	if err != nil {
+		blockers = append(blockers, "realized_performance_query_failed")
+		writeDailyTradingReadinessCheckpoint(quest, blockers)
+		return fmt.Errorf("daily performance report: realized performance: %w", err)
+	}
+
+	quest.Checkpoint["daily_report_closed_trades"] = summary.Trades
+	quest.Checkpoint["daily_report_wins"] = summary.Wins
+	quest.Checkpoint["daily_report_losses"] = summary.Losses
+	quest.Checkpoint["daily_report_breakeven"] = summary.Breakeven
+	quest.Checkpoint["daily_report_net_pnl"] = summary.RealizedPnL.String()
+	quest.Checkpoint["daily_report_gross_pnl"] = summary.GrossPnL.String()
+	quest.Checkpoint["daily_report_fees"] = summary.Fees.String()
+	quest.Checkpoint["daily_report_avg_net_pnl"] = summary.AvgNetPnL.String()
+	quest.Checkpoint["daily_report_win_rate"] = summary.WinRate.String()
+	quest.Checkpoint["daily_report_best_trade"] = summary.BestTrade.String()
+	quest.Checkpoint["daily_report_worst_trade"] = summary.WorstTrade.String()
+
+	if summary.Trades == 0 {
+		blockers = append(blockers, "no_closed_trades_in_24h")
+	}
+	if summary.Wins == 0 {
+		blockers = append(blockers, "no_winning_trade_observed")
+	}
+	if summary.Losses == 0 {
+		blockers = append(blockers, "no_losing_trade_observed")
+	}
+	if summary.RealizedPnL.LessThanOrEqual(decimal.Zero) {
+		blockers = append(blockers, "non_positive_net_pnl")
+	}
+	if summary.Trades > 0 && summary.AvgNetPnL.LessThanOrEqual(decimal.Zero) {
+		blockers = append(blockers, "non_positive_avg_net_pnl")
+	}
+
+	writeDailyTradingReadinessCheckpoint(quest, blockers)
+	quest.CurrentCount++
+	return nil
+}
+
+func writeDailyTradingReadinessCheckpoint(quest *Quest, blockers []string) {
+	quest.Checkpoint["daily_trading_live_ready"] = false
+	quest.Checkpoint["daily_trading_readiness_status"] = "blocked"
+	quest.Checkpoint["daily_trading_readiness_blockers"] = append([]string(nil), blockers...)
+	quest.Checkpoint["daily_trading_readiness_note"] = "daily trading has no executable strategy path or readiness evidence; keep live-money use blocked"
 }
 
 func (h *IntegratedQuestHandlers) handleVolatilityWatch(ctx context.Context, quest *Quest) error {

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -548,6 +548,9 @@ func (h *IntegratedQuestHandlers) handleDailyPerformanceReport(ctx context.Conte
 		delete(cp, "daily_report_gross_pnl")
 		delete(cp, "daily_report_fees")
 		delete(cp, "daily_report_avg_net_pnl")
+		delete(cp, "daily_report_win_rate")
+		delete(cp, "daily_report_best_trade")
+		delete(cp, "daily_report_worst_trade")
 	}
 
 	now := time.Now().UTC()

--- a/services/backend-api/internal/services/quest_handlers_integrated_daily_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_daily_test.go
@@ -1,0 +1,36 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteRoutineDailyReportBlocksLiveReadinessWithoutStrategyProof(t *testing.T) {
+	handlers := &IntegratedQuestHandlers{}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "daily_report",
+			"chat_id":       "daily-chat",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err := handlers.ExecuteRoutine(context.Background(), quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, false, quest.Checkpoint["daily_trading_live_ready"])
+	assert.Equal(t, "blocked", quest.Checkpoint["daily_trading_readiness_status"])
+	assert.Equal(t, "daily-chat", quest.Checkpoint["daily_report_chat_id"])
+	assert.Equal(t, "bitget", quest.Checkpoint["daily_report_exchange"])
+	assert.Equal(t, 1, quest.CurrentCount)
+
+	blockers, ok := quest.Checkpoint["daily_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "daily_trading_strategy_not_implemented")
+	assert.Contains(t, blockers, "daily_report_is_reporting_only")
+	assert.Contains(t, blockers, "lifecycle_store_unavailable")
+}


### PR DESCRIPTION
## Summary

- add an optional `OperationalModeService` live-mode guard that runs before a chat can enter real-money `live` mode
- install a manifest-backed readiness guard in route setup by default
- require verified evidence entries for `paper_trading`, `scalping`, `daily_trading`, `swing_trading`, and `arbitrage` before global live mode is allowed
- document `NEURATRADE_LIVE_READINESS_MANIFEST`, `NEURATRADE_LIVE_READINESS_STRATEGIES`, and the diagnostic-only opt-out `NEURATRADE_REQUIRE_LIVE_READINESS_PROOF=false`

## Why

The current objective requires paper trading, scalping, daily trading, swing trading, and arbitrage to be ready before real-money use. The audit found that scalping has dedicated rollout/live gating, but the global `/mode live` path only enforced operator confirmations. Daily/swing/arbitrage readiness proof is still missing, so live mode should fail closed until those proofs exist.

## Validation

- `git diff --check`
- `go test ./internal/services -run 'TestOperationalModeService|TestManifestLiveModeGuard|TestRuntimeModeOverride'`
- `go test ./internal/api -run 'Test.*Routes|Test.*TradingMode|TestSetupRoutes'`
- `go test ./internal/services ./internal/api ./internal/api/handlers`
- `make build`
- `make lint`

## Readiness Status

This PR is a safety/control PR, not a readiness proof. It intentionally blocks real-money live mode unless a manifest points to verified evidence for all required strategy surfaces. The broader real-money readiness objective remains open until paper/live-market evidence exists for scalping, daily trading, swing trading, and arbitrage.

## Summary by Sourcery

Add a manifest-backed live-readiness guard that blocks transitions to real-money live mode until required strategies have verified evidence, and wire it into route setup with configurable environment-based overrides.

New Features:
- Introduce an optional live-mode guard hook in the operational mode service to preflight live-mode transitions.
- Add a manifest-based live readiness guard that validates strategy readiness and evidence before enabling global live mode.
- Provide configuration for required strategies and manifest path via environment variables, with an opt-out flag for diagnostics.
- Document the live readiness manifest format and environment configuration for controlling live-mode readiness checks.

Enhancements:
- Refactor operational mode transitions to support pluggable live-mode preflight checks while preserving confirmation requirements.

Build:
- Update telegram-service dependency overrides to the latest brace-expansion patch version.

Tests:
- Add unit tests covering the live-mode guard hook, manifest-based readiness validation, error reporting, and route-level configuration behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented live readiness verification system that gates real-money trading mode, requiring documented evidence of strategy performance before activation.
  * Added daily performance reporting functionality to track 24-hour trading metrics.

* **Documentation**
  * Added comprehensive documentation on daily trading readiness requirements and live readiness verification process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->