### PR TITLE
Expose daily trading readiness blockers

### DIFF
--- a/services/backend-api/docs/DAILY_TRADING_READINESS.md
+++ b/services/backend-api/docs/DAILY_TRADING_READINESS.md
@@ -1,0 +1,18 @@
+# Daily Trading Readiness
+
+Daily trading is not real-money ready.
+
+The backend registers a `daily_report` quest, but this is a reporting quest, not an executable daily trading strategy. It now writes explicit checkpoint fields so operators and tests can distinguish daily performance reporting from live-money trading readiness:
+
+- `daily_trading_live_ready=false`
+- `daily_trading_readiness_status=blocked`
+- `daily_trading_readiness_blockers`
+
+Current hard blockers:
+
+- No dedicated `daily_trading` strategy implementation exists.
+- No daily paper order lifecycle has been proven with representative closed wins and losses.
+- No positive daily net/average PnL evidence exists after fees.
+- No readiness evidence should mark daily trading ready until the above proof exists.
+
+The `daily_report` quest may summarize the last 24 hours of realized lifecycle performance when a lifecycle store is configured. That report is observability only and must not be used as live-money authorization.

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -505,6 +505,8 @@ func (h *IntegratedQuestHandlers) ExecuteRoutine(ctx context.Context, quest *Que
 		err = h.handleFundingRateScan(ctx, quest)
 	case "portfolio_health":
 		err = h.handlePortfolioHealthWithRisk(ctx, quest)
+	case "daily_report":
+		err = h.handleDailyPerformanceReport(ctx, quest)
 	case "fund_growth":
 		err = h.handleFundGrowthGoal(ctx, quest)
 	case "scalping_execution":
@@ -521,6 +523,90 @@ func (h *IntegratedQuestHandlers) ExecuteArbitrage(ctx context.Context, quest *Q
 	err := h.handleArbitrageExecution(ctx, quest)
 	h.recordQuestResult(quest, err == nil, decimal.Zero)
 	return err
+}
+
+func (h *IntegratedQuestHandlers) handleDailyPerformanceReport(ctx context.Context, quest *Quest) error {
+	if quest == nil {
+		return fmt.Errorf("quest is nil")
+	}
+	if quest.Checkpoint == nil {
+		quest.Checkpoint = make(map[string]interface{})
+	}
+	if quest.Metadata == nil {
+		quest.Metadata = make(map[string]string)
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-24 * time.Hour)
+	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
+	exchange := strings.TrimSpace(quest.Metadata["exchange"])
+	if exchange == "" {
+		exchange = strings.TrimSpace(scalpingExchangeFromContext(ctx))
+	}
+
+	blockers := []string{
+		"daily_trading_strategy_not_implemented",
+		"daily_report_is_reporting_only",
+	}
+	quest.Checkpoint["daily_report_generated_at"] = now.Format(time.RFC3339)
+	quest.Checkpoint["daily_report_window_start"] = since.Format(time.RFC3339)
+	quest.Checkpoint["daily_report_window_end"] = now.Format(time.RFC3339)
+	quest.Checkpoint["daily_report_chat_id"] = chatID
+	quest.Checkpoint["daily_report_exchange"] = exchange
+
+	if h.lifecycleStore == nil {
+		blockers = append(blockers, "lifecycle_store_unavailable")
+		writeDailyTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
+
+	writeDailyTradingReadinessCheckpoint(quest, blockers)
+	summary, err := h.lifecycleStore.GetRealizedPerformance(ctx, chatID, exchange, since)
+	if err != nil {
+		blockers = append(blockers, "realized_performance_query_failed")
+		writeDailyTradingReadinessCheckpoint(quest, blockers)
+		return fmt.Errorf("daily performance report: realized performance: %w", err)
+	}
+
+	quest.Checkpoint["daily_report_closed_trades"] = summary.Trades
+	quest.Checkpoint["daily_report_wins"] = summary.Wins
+	quest.Checkpoint["daily_report_losses"] = summary.Losses
+	quest.Checkpoint["daily_report_breakeven"] = summary.Breakeven
+	quest.Checkpoint["daily_report_net_pnl"] = summary.RealizedPnL.String()
+	quest.Checkpoint["daily_report_gross_pnl"] = summary.GrossPnL.String()
+	quest.Checkpoint["daily_report_fees"] = summary.Fees.String()
+	quest.Checkpoint["daily_report_avg_net_pnl"] = summary.AvgNetPnL.String()
+	quest.Checkpoint["daily_report_win_rate"] = summary.WinRate.String()
+	quest.Checkpoint["daily_report_best_trade"] = summary.BestTrade.String()
+	quest.Checkpoint["daily_report_worst_trade"] = summary.WorstTrade.String()
+
+	if summary.Trades == 0 {
+		blockers = append(blockers, "no_closed_trades_in_24h")
+	}
+	if summary.Wins == 0 {
+		blockers = append(blockers, "no_winning_trade_observed")
+	}
+	if summary.Losses == 0 {
+		blockers = append(blockers, "no_losing_trade_observed")
+	}
+	if summary.RealizedPnL.LessThanOrEqual(decimal.Zero) {
+		blockers = append(blockers, "non_positive_net_pnl")
+	}
+	if summary.Trades > 0 && summary.AvgNetPnL.LessThanOrEqual(decimal.Zero) {
+		blockers = append(blockers, "non_positive_avg_net_pnl")
+	}
+
+	writeDailyTradingReadinessCheckpoint(quest, blockers)
+	quest.CurrentCount++
+	return nil
+}
+
+func writeDailyTradingReadinessCheckpoint(quest *Quest, blockers []string) {
+	quest.Checkpoint["daily_trading_live_ready"] = false
+	quest.Checkpoint["daily_trading_readiness_status"] = "blocked"
+	quest.Checkpoint["daily_trading_readiness_blockers"] = append([]string(nil), blockers...)
+	quest.Checkpoint["daily_trading_readiness_note"] = "daily trading has no executable strategy path or readiness evidence; keep live-money use blocked"
 }
 
 func (h *IntegratedQuestHandlers) handleVolatilityWatch(ctx context.Context, quest *Quest) error {

--- a/services/backend-api/internal/services/quest_handlers_integrated_daily_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_daily_test.go
@@ -1,0 +1,36 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteRoutineDailyReportBlocksLiveReadinessWithoutStrategyProof(t *testing.T) {
+	handlers := &IntegratedQuestHandlers{}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "daily_report",
+			"chat_id":       "daily-chat",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err := handlers.ExecuteRoutine(context.Background(), quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, false, quest.Checkpoint["daily_trading_live_ready"])
+	assert.Equal(t, "blocked", quest.Checkpoint["daily_trading_readiness_status"])
+	assert.Equal(t, "daily-chat", quest.Checkpoint["daily_report_chat_id"])
+	assert.Equal(t, "bitget", quest.Checkpoint["daily_report_exchange"])
+	assert.Equal(t, 1, quest.CurrentCount)
+
+	blockers, ok := quest.Checkpoint["daily_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "daily_trading_strategy_not_implemented")
+	assert.Contains(t, blockers, "daily_report_is_reporting_only")
+	assert.Contains(t, blockers, "lifecycle_store_unavailable")
+}


### PR DESCRIPTION
## Summary
- route the registered daily_report routine quest to an executable report handler instead of leaving it as unknown
- write explicit daily_trading readiness checkpoint blockers so reporting cannot be mistaken for live-money readiness
- document that daily trading remains blocked until a real strategy path and paper/live evidence exist

## Stack
- Stacked on PR #379 / fix/global-live-readiness-gate so this branch inherits the live-readiness manifest gate and Telegram security dependency bump.

## Validation
- git diff --check
- go test ./internal/services -run 'TestExecuteRoutineDailyReport|TestQuestEngine|TestShouldExecute_DailyCadence'\n- go test ./internal/services\n- go test ./internal/api/handlers -run 'TestAutonomous|TestAgentControl|TestBudget|TestRisk'\n- make lint\n- make build\n\n## Readiness\nThis PR does not make daily trading real-money ready. It makes the blocker visible at runtime: no dedicated daily_trading strategy or representative paper/live evidence exists yet.

## Summary by Sourcery

Route the registered daily report quest to a real handler that generates a 24h performance summary while explicitly marking daily trading as not live-money ready.

New Features:
- Add a daily performance report handler that records realized performance metrics in quest checkpoints.

Enhancements:
- Introduce explicit daily trading readiness checkpoint fields and blockers to prevent confusing reporting with live trading readiness.

Documentation:
- Document that daily trading remains blocked for real-money use and describe the new readiness checkpoint fields.

Tests:
- Add tests to ensure the daily report quest writes readiness blockers and metadata when executed without a lifecycle store.