### PR TITLE
Require proof metrics for live readiness

### DIFF
--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -5,7 +5,8 @@ manifest from `NEURATRADE_LIVE_READINESS_MANIFEST`.
 
 The manifest is intentionally a final gate, not proof by itself. Each entry must
 point to evidence produced by the relevant paper/live-market verifier for that
-strategy.
+strategy. Trading strategies also require structured `evidence_metrics`; a
+non-empty evidence path alone is not enough to permit live mode.
 
 ```json
 {
@@ -19,6 +20,15 @@ strategy.
     "scalping": {
       "ready": true,
       "evidence": "/path/to/scalping-live-trial-ready.json",
+      "evidence_metrics": {
+        "closed_trades": 20,
+        "winning_trades": 9,
+        "losing_trades": 11,
+        "open_positions": 0,
+        "net_pnl": "1.25",
+        "avg_net_pnl": "0.0625",
+        "max_drawdown_pct": "0.42"
+      },
       "verified_at": "2026-05-21T00:00:00Z"
     },
     "daily_trading": {
@@ -33,6 +43,28 @@ strategy.
       "ready": false,
       "reason": "paper/live-market proof missing"
     }
+  }
+}
+```
+
+Required trading-strategy metrics:
+
+- `closed_trades`: at least 20 for `scalping`; at least 2 for `daily_trading`, `swing_trading`, and `arbitrage` unless arbitrage uses documented no-trade safety.
+- `winning_trades` and `losing_trades`: both must be positive.
+- `open_positions`: must be 0.
+- `net_pnl`, `avg_net_pnl`, and `max_drawdown_pct`: decimal strings greater than 0.
+
+Arbitrage may use no-trade safety evidence instead of closed-trade metrics only
+when an observed window proves no executable spreads/opportunities after costs:
+
+```json
+{
+  "ready": true,
+  "evidence": "/path/to/arbitrage-no-trade-safety.json",
+  "evidence_metrics": {
+    "no_trade_safety": true,
+    "no_trade_reason": "no executable spreads after fees across observed window",
+    "open_positions": 0
   }
 }
 ```

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/shopspring/decimal"
 )
 
 const (
@@ -20,10 +22,25 @@ type LiveModeGuard func(ctx context.Context, chatID string, changedBy string) er
 
 // StrategyLiveReadiness records one strategy's live-readiness evidence.
 type StrategyLiveReadiness struct {
-	Ready      bool   `json:"ready"`
-	Evidence   string `json:"evidence,omitempty"`
-	Reason     string `json:"reason,omitempty"`
-	VerifiedAt string `json:"verified_at,omitempty"`
+	Ready           bool                       `json:"ready"`
+	Evidence        string                     `json:"evidence,omitempty"`
+	EvidenceMetrics *StrategyReadinessEvidence `json:"evidence_metrics,omitempty"`
+	Reason          string                     `json:"reason,omitempty"`
+	VerifiedAt      string                     `json:"verified_at,omitempty"`
+}
+
+// StrategyReadinessEvidence records the minimum proof needed before a trading
+// strategy may be represented as live-ready in the operator manifest.
+type StrategyReadinessEvidence struct {
+	ClosedTrades   int    `json:"closed_trades,omitempty"`
+	WinningTrades  int    `json:"winning_trades,omitempty"`
+	LosingTrades   int    `json:"losing_trades,omitempty"`
+	OpenPositions  int    `json:"open_positions,omitempty"`
+	NetPnL         string `json:"net_pnl,omitempty"`
+	AvgNetPnL      string `json:"avg_net_pnl,omitempty"`
+	MaxDrawdownPct string `json:"max_drawdown_pct,omitempty"`
+	NoTradeSafety  bool   `json:"no_trade_safety,omitempty"`
+	NoTradeReason  string `json:"no_trade_reason,omitempty"`
 }
 
 // LiveReadinessManifest is the file format consumed by ManifestLiveModeGuard.
@@ -81,6 +98,8 @@ func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) Liv
 				blockers = append(blockers, fmt.Sprintf("%s=%s", strategy, reason))
 			case strings.TrimSpace(status.Evidence) == "":
 				blockers = append(blockers, fmt.Sprintf("%s=missing_evidence", strategy))
+			default:
+				blockers = append(blockers, strategyReadinessEvidenceBlockers(strategy, status)...)
 			}
 		}
 		if len(blockers) > 0 {
@@ -107,6 +126,69 @@ func normalizeReadinessStrategies(strategies []string) []string {
 	}
 	sort.Strings(normalized)
 	return normalized
+}
+
+func strategyReadinessEvidenceBlockers(strategy string, status StrategyLiveReadiness) []string {
+	if strategy == "paper_trading" {
+		return nil
+	}
+	metrics := status.EvidenceMetrics
+	if metrics == nil {
+		return []string{fmt.Sprintf("%s=missing_evidence_metrics", strategy)}
+	}
+	if strategy == "arbitrage" && metrics.NoTradeSafety {
+		if strings.TrimSpace(metrics.NoTradeReason) == "" {
+			return []string{"arbitrage=missing_no_trade_reason"}
+		}
+		if metrics.OpenPositions != 0 {
+			return []string{fmt.Sprintf("arbitrage=open_positions_%d", metrics.OpenPositions)}
+		}
+		return nil
+	}
+
+	var blockers []string
+	if metrics.ClosedTrades < minimumReadinessClosedTrades(strategy) {
+		blockers = append(blockers, fmt.Sprintf("%s=insufficient_closed_trades", strategy))
+	}
+	if metrics.ClosedTrades < metrics.WinningTrades+metrics.LosingTrades {
+		blockers = append(blockers, fmt.Sprintf("%s=inconsistent_trade_counts", strategy))
+	}
+	if metrics.WinningTrades <= 0 {
+		blockers = append(blockers, fmt.Sprintf("%s=no_winning_trades", strategy))
+	}
+	if metrics.LosingTrades <= 0 {
+		blockers = append(blockers, fmt.Sprintf("%s=no_losing_trades", strategy))
+	}
+	if metrics.OpenPositions != 0 {
+		blockers = append(blockers, fmt.Sprintf("%s=open_positions_%d", strategy, metrics.OpenPositions))
+	}
+	if !positiveDecimalString(metrics.NetPnL) {
+		blockers = append(blockers, fmt.Sprintf("%s=non_positive_net_pnl", strategy))
+	}
+	if !positiveDecimalString(metrics.AvgNetPnL) {
+		blockers = append(blockers, fmt.Sprintf("%s=non_positive_avg_net_pnl", strategy))
+	}
+	if !positiveDecimalString(metrics.MaxDrawdownPct) {
+		blockers = append(blockers, fmt.Sprintf("%s=missing_observed_drawdown", strategy))
+	}
+	return blockers
+}
+
+func minimumReadinessClosedTrades(strategy string) int {
+	switch strategy {
+	case "scalping":
+		return 20
+	default:
+		return 2
+	}
+}
+
+func positiveDecimalString(raw string) bool {
+	value, err := decimal.NewFromString(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	return value.GreaterThan(decimal.Zero)
 }
 
 func normalizeReadinessManifestStrategies(strategies map[string]StrategyLiveReadiness) map[string]StrategyLiveReadiness {

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -117,6 +117,7 @@ func TestManifestLiveModeGuardRequiresAllStrategyEvidence(t *testing.T) {
 	guard = ManifestLiveModeGuard(manifestPath, []string{"daily_trading", "swing_trading", "arbitrage"})
 	err = guard(context.Background(), "chat-1", "tester")
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daily_trading=missing_evidence_metrics")
 	assert.Contains(t, err.Error(), "swing_trading=paper_window_missing")
 	assert.Contains(t, err.Error(), "arbitrage=missing_evidence")
 }
@@ -135,8 +136,8 @@ func TestManifestLiveModeGuardAllowsVerifiedStrategies(t *testing.T) {
 	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
-			"daily_trading": {Ready: true, Evidence: "paper-soak:daily.json"},
-			"swing_trading": {Ready: true, Evidence: "paper-soak:swing.json"},
+			"daily_trading": {Ready: true, Evidence: "paper-soak:daily.json", EvidenceMetrics: passingReadinessEvidence(2)},
+			"swing_trading": {Ready: true, Evidence: "paper-soak:swing.json", EvidenceMetrics: passingReadinessEvidence(2)},
 		},
 	}
 	raw, err := json.Marshal(manifest)
@@ -145,6 +146,90 @@ func TestManifestLiveModeGuardAllowsVerifiedStrategies(t *testing.T) {
 
 	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading", "swing_trading"})
 	require.NoError(t, guard(context.Background(), "chat-1", "tester"))
+}
+
+func TestManifestLiveModeGuardRequiresTradingProofMetrics(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"swing_trading": {
+				Ready:    true,
+				Evidence: "paper-soak:swing.json",
+				EvidenceMetrics: &StrategyReadinessEvidence{
+					ClosedTrades:   1,
+					WinningTrades:  1,
+					LosingTrades:   1,
+					OpenPositions:  1,
+					NetPnL:         "-1.25",
+					AvgNetPnL:      "0",
+					MaxDrawdownPct: "0",
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"swing_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "swing_trading=insufficient_closed_trades")
+	assert.Contains(t, err.Error(), "swing_trading=inconsistent_trade_counts")
+	assert.Contains(t, err.Error(), "swing_trading=open_positions_1")
+	assert.Contains(t, err.Error(), "swing_trading=non_positive_net_pnl")
+	assert.Contains(t, err.Error(), "swing_trading=non_positive_avg_net_pnl")
+	assert.Contains(t, err.Error(), "swing_trading=missing_observed_drawdown")
+}
+
+func TestManifestLiveModeGuardRequiresScalpingMinimumTradeProof(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"scalping": {Ready: true, Evidence: "paper-soak:scalping.json", EvidenceMetrics: passingReadinessEvidence(19)},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"scalping"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scalping=insufficient_closed_trades")
+}
+
+func TestManifestLiveModeGuardAllowsArbitrageNoTradeSafetyEvidence(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"arbitrage": {
+				Ready:    true,
+				Evidence: "paper-safety:arbitrage.json",
+				EvidenceMetrics: &StrategyReadinessEvidence{
+					NoTradeSafety: true,
+					NoTradeReason: "no executable spreads after fees across observed window",
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"arbitrage"})
+	require.NoError(t, guard(context.Background(), "chat-1", "tester"))
+}
+
+func passingReadinessEvidence(closedTrades int) *StrategyReadinessEvidence {
+	return &StrategyReadinessEvidence{
+		ClosedTrades:   closedTrades,
+		WinningTrades:  1,
+		LosingTrades:   1,
+		NetPnL:         "1.25",
+		AvgNetPnL:      "0.10",
+		MaxDrawdownPct: "0.05",
+	}
 }
 
 func TestRuntimeModeOverrideFromEnv_HonorsSingularAndPluralAliases(t *testing.T) {


### PR DESCRIPTION
## Summary
- require structured evidence_metrics for trading strategies marked ready in the live-readiness manifest
- enforce closed-trade, win/loss, zero-open-position, positive net/avg PnL, and observed drawdown proof before live mode can pass
- preserve an explicit arbitrage no-trade-safety path when observed evidence proves no executable opportunities after costs
- document the stronger manifest schema

## Stack
- Stacked on PR #379 / fix/global-live-readiness-gate.

## Validation
- git diff --check
- go test ./internal/services -run 'TestManifestLiveModeGuard|TestOperationalModeService_LiveModeGuard'\n- go test ./internal/services\n- make lint\n- make build\n\n## Readiness\nThis PR does not make swing, daily, scalping, or arbitrage real-money ready. It prevents the global live-mode manifest from accepting weak proof for those strategies.

## Summary by Sourcery

Tighten the live-readiness guard to require structured trading proof metrics for non-paper strategies before enabling live mode and document the strengthened manifest schema.

New Features:
- Add structured evidence_metrics to the live-readiness manifest to capture minimum proof for each trading strategy, including trade counts, PnL, drawdown, and optional no-trade safety for arbitrage.

Enhancements:
- Enforce stricter validation in the live-readiness guard, including minimum closed trades per strategy, consistent win/loss counts, zero open positions, positive net and average PnL, and observed drawdown, while allowing a documented no-trade safety path for arbitrage.
- Extend tests to cover the new metrics-based gating rules, scalping-specific minimum trade requirements, and arbitrage no-trade safety scenarios.

Documentation:
- Update live readiness manifest documentation with the new evidence_metrics schema, required trading-strategy metrics, and the arbitrage no-trade safety example.

Tests:
- Add tests that verify missing metrics are rejected, insufficient or inconsistent metrics block live readiness, and valid metrics (including arbitrage no-trade safety) permit live mode.