### PR TITLE
Expose swing trading readiness blockers

### DIFF
--- a/services/backend-api/docs/SWING_TRADING_READINESS.md
+++ b/services/backend-api/docs/SWING_TRADING_READINESS.md
@@ -1,0 +1,26 @@
+# Swing Trading Readiness
+
+Swing trading is not approved for real-money use.
+
+The `swing_trading_review` routine records explicit readiness status in its quest
+checkpoint so operators do not infer readiness from generic lifecycle activity.
+It always writes:
+
+- `swing_trading_live_ready=false`
+- `swing_trading_readiness_status=blocked`
+- `swing_trading_readiness_blockers`
+
+The review captures lifecycle context over the previous 14 days, including
+closed trades, wins, losses, net PnL, average net PnL, open positions, and stale
+open positions. These metrics are diagnostic only until an executable swing
+signal path and paper/live-market hold-window proof exist.
+
+Minimum proof before the live-readiness manifest can mark `swing_trading` ready:
+
+- executable swing signal path with documented entry and exit rules
+- paper/live-market lifecycle evidence over representative longer holds
+- at least two closed trades with both a win and a loss
+- no open positions at proof cutoff
+- positive net and average net PnL after fees
+- observed and bounded drawdown
+- stale-position handling demonstrated

--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -397,6 +397,16 @@ func (e *QuestEngine) registerDefaultDefinitions() {
 		Prompt:      "Generate comprehensive daily report including PnL, win rate, and strategy performance",
 	})
 
+	// Swing trading readiness review - runs daily
+	e.RegisterDefinition(&QuestDefinition{
+		ID:          "swing_trading_review",
+		Name:        "Swing Trading Readiness Review",
+		Description: "Record swing trading readiness blockers and lifecycle context",
+		Type:        QuestTypeRoutine,
+		Cadence:     CadenceDaily,
+		Prompt:      "Review swing trading lifecycle evidence, open-position age, and readiness blockers",
+	})
+
 	// Funding rate check - runs every 5 minutes
 	e.RegisterDefinition(&QuestDefinition{
 		ID:          "funding_rate_scan",

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -505,6 +505,8 @@ func (h *IntegratedQuestHandlers) ExecuteRoutine(ctx context.Context, quest *Que
 		err = h.handleFundingRateScan(ctx, quest)
 	case "portfolio_health":
 		err = h.handlePortfolioHealthWithRisk(ctx, quest)
+	case "swing_trading_review":
+		err = h.handleSwingTradingReadinessReview(ctx, quest)
 	case "fund_growth":
 		err = h.handleFundGrowthGoal(ctx, quest)
 	case "scalping_execution":
@@ -521,6 +523,109 @@ func (h *IntegratedQuestHandlers) ExecuteArbitrage(ctx context.Context, quest *Q
 	err := h.handleArbitrageExecution(ctx, quest)
 	h.recordQuestResult(quest, err == nil, decimal.Zero)
 	return err
+}
+
+func (h *IntegratedQuestHandlers) handleSwingTradingReadinessReview(ctx context.Context, quest *Quest) error {
+	if quest == nil {
+		return fmt.Errorf("quest is nil")
+	}
+	if quest.Checkpoint == nil {
+		quest.Checkpoint = make(map[string]interface{})
+	}
+	if quest.Metadata == nil {
+		quest.Metadata = make(map[string]string)
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-14 * 24 * time.Hour)
+	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
+	exchange := strings.TrimSpace(quest.Metadata["exchange"])
+	if exchange == "" {
+		exchange = strings.TrimSpace(scalpingExchangeFromContext(ctx))
+	}
+
+	blockers := []string{
+		"swing_trading_strategy_not_implemented",
+		"swing_review_is_readiness_status_only",
+		"no_swing_signal_engine",
+		"missing_paper_live_market_hold_window_evidence",
+	}
+	quest.Checkpoint["swing_review_generated_at"] = now.Format(time.RFC3339)
+	quest.Checkpoint["swing_review_window_start"] = since.Format(time.RFC3339)
+	quest.Checkpoint["swing_review_window_end"] = now.Format(time.RFC3339)
+	quest.Checkpoint["swing_review_chat_id"] = chatID
+	quest.Checkpoint["swing_review_exchange"] = exchange
+
+	if h.lifecycleStore == nil {
+		blockers = append(blockers, "lifecycle_store_unavailable")
+		writeSwingTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
+
+	summary, err := h.lifecycleStore.GetRealizedPerformance(ctx, chatID, exchange, since)
+	if err != nil {
+		blockers = append(blockers, "realized_performance_query_failed")
+		writeSwingTradingReadinessCheckpoint(quest, blockers)
+		return fmt.Errorf("swing trading readiness review: realized performance: %w", err)
+	}
+	positions, err := h.lifecycleStore.ListManagedOpenPositions(ctx, chatID, exchange, 0)
+	if err != nil {
+		blockers = append(blockers, "open_position_query_failed")
+		writeSwingTradingReadinessCheckpoint(quest, blockers)
+		return fmt.Errorf("swing trading readiness review: open positions: %w", err)
+	}
+	staleOpenPositions := 0
+	for _, position := range positions {
+		if !position.OpenedAt.IsZero() && position.OpenedAt.Before(since) {
+			staleOpenPositions++
+		}
+	}
+
+	quest.Checkpoint["swing_review_closed_trades"] = summary.Trades
+	quest.Checkpoint["swing_review_wins"] = summary.Wins
+	quest.Checkpoint["swing_review_losses"] = summary.Losses
+	quest.Checkpoint["swing_review_breakeven"] = summary.Breakeven
+	quest.Checkpoint["swing_review_net_pnl"] = summary.RealizedPnL.String()
+	quest.Checkpoint["swing_review_gross_pnl"] = summary.GrossPnL.String()
+	quest.Checkpoint["swing_review_fees"] = summary.Fees.String()
+	quest.Checkpoint["swing_review_avg_net_pnl"] = summary.AvgNetPnL.String()
+	quest.Checkpoint["swing_review_win_rate"] = summary.WinRate.String()
+	quest.Checkpoint["swing_review_open_positions"] = len(positions)
+	quest.Checkpoint["swing_review_stale_open_positions"] = staleOpenPositions
+
+	if summary.Trades < 2 {
+		blockers = append(blockers, "no_representative_closed_trade_sample")
+	}
+	if summary.Wins == 0 {
+		blockers = append(blockers, "no_winning_trade_observed")
+	}
+	if summary.Losses == 0 {
+		blockers = append(blockers, "no_losing_trade_observed")
+	}
+	if summary.RealizedPnL.LessThanOrEqual(decimal.Zero) {
+		blockers = append(blockers, "non_positive_net_pnl")
+	}
+	if summary.Trades > 0 && summary.AvgNetPnL.LessThanOrEqual(decimal.Zero) {
+		blockers = append(blockers, "non_positive_avg_net_pnl")
+	}
+	if len(positions) > 0 {
+		blockers = append(blockers, "open_positions_need_lifecycle_review")
+	}
+	if staleOpenPositions > 0 {
+		blockers = append(blockers, "stale_open_positions_detected")
+	}
+
+	writeSwingTradingReadinessCheckpoint(quest, blockers)
+	quest.CurrentCount++
+	return nil
+}
+
+func writeSwingTradingReadinessCheckpoint(quest *Quest, blockers []string) {
+	quest.Checkpoint["swing_trading_live_ready"] = false
+	quest.Checkpoint["swing_trading_readiness_status"] = "blocked"
+	quest.Checkpoint["swing_trading_readiness_blockers"] = append([]string(nil), blockers...)
+	quest.Checkpoint["swing_trading_readiness_note"] = "swing trading has no executable strategy path or readiness evidence; keep live-money use blocked"
 }
 
 func (h *IntegratedQuestHandlers) handleVolatilityWatch(ctx context.Context, quest *Quest) error {

--- a/services/backend-api/internal/services/quest_handlers_integrated_swing_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_swing_test.go
@@ -1,0 +1,113 @@
+package services
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/irfndi/neuratrade/internal/database"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteRoutineSwingTradingReviewBlocksLiveReadinessWithoutStrategyProof(t *testing.T) {
+	handlers := &IntegratedQuestHandlers{}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "swing_trading_review",
+			"chat_id":       "swing-chat",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err := handlers.ExecuteRoutine(context.Background(), quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, false, quest.Checkpoint["swing_trading_live_ready"])
+	assert.Equal(t, "blocked", quest.Checkpoint["swing_trading_readiness_status"])
+	assert.Equal(t, "swing-chat", quest.Checkpoint["swing_review_chat_id"])
+	assert.Equal(t, "bitget", quest.Checkpoint["swing_review_exchange"])
+	assert.Equal(t, 1, quest.CurrentCount)
+
+	blockers, ok := quest.Checkpoint["swing_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "swing_trading_strategy_not_implemented")
+	assert.Contains(t, blockers, "swing_review_is_readiness_status_only")
+	assert.Contains(t, blockers, "no_swing_signal_engine")
+	assert.Contains(t, blockers, "missing_paper_live_market_hold_window_evidence")
+	assert.Contains(t, blockers, "lifecycle_store_unavailable")
+}
+
+func TestExecuteRoutineSwingTradingReviewRecordsLifecycleBlockers(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "swing-readiness.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	require.NoError(t, lifecycleStore.RecordClosedOrder(ctx, LifecycleCloseRecord{
+		OrderID:     "swing-loss-1",
+		ChatID:      "swing-chat",
+		Exchange:    "bitget",
+		Symbol:      "BTC/USDT",
+		Side:        "buy",
+		MarketType:  "spot",
+		Filled:      decimal.NewFromInt(1),
+		EntryPrice:  decimal.NewFromInt(100),
+		ExitPrice:   decimal.NewFromInt(99),
+		RealizedPnL: decimal.NewFromInt(-1),
+		Fees:        decimal.NewFromFloat(0.1),
+		Source:      "swing_trading",
+		ClosedAt:    now.Add(-2 * time.Hour),
+	}))
+	require.NoError(t, lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
+		OrderID:    "stale-swing-open",
+		ChatID:     "swing-chat",
+		Exchange:   "bitget",
+		Symbol:     "ETH/USDT",
+		Side:       "buy",
+		OrderType:  "market",
+		MarketType: "spot",
+		Amount:     decimal.NewFromFloat(0.5),
+		EntryPrice: decimal.NewFromInt(2000),
+		Source:     "swing_trading",
+		OpenedAt:   now.Add(-20 * 24 * time.Hour),
+	}))
+
+	handlers := &IntegratedQuestHandlers{lifecycleStore: lifecycleStore}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "swing_trading_review",
+			"chat_id":       "swing-chat",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err = handlers.ExecuteRoutine(ctx, quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, false, quest.Checkpoint["swing_trading_live_ready"])
+	assert.Equal(t, 1, quest.Checkpoint["swing_review_closed_trades"])
+	assert.Equal(t, 0, quest.Checkpoint["swing_review_wins"])
+	assert.Equal(t, 1, quest.Checkpoint["swing_review_losses"])
+	assert.Equal(t, 1, quest.Checkpoint["swing_review_open_positions"])
+	assert.Equal(t, 1, quest.Checkpoint["swing_review_stale_open_positions"])
+	assert.Equal(t, 1, quest.CurrentCount)
+
+	blockers, ok := quest.Checkpoint["swing_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "no_representative_closed_trade_sample")
+	assert.Contains(t, blockers, "no_winning_trade_observed")
+	assert.Contains(t, blockers, "non_positive_net_pnl")
+	assert.Contains(t, blockers, "non_positive_avg_net_pnl")
+	assert.Contains(t, blockers, "open_positions_need_lifecycle_review")
+	assert.Contains(t, blockers, "stale_open_positions_detected")
+}


### PR DESCRIPTION
## Summary
- add a daily swing_trading_review routine that records explicit blocked readiness checkpoints
- capture 14-day lifecycle diagnostics for closed trades, PnL, open positions, and stale open positions without marking swing trading live-ready
- document the missing proof required before swing_trading can be accepted in the live-readiness manifest

## Validation
- git diff --check
- go test ./internal/services -run 'TestExecuteRoutineSwingTradingReview|TestManifestLiveModeGuard|TestOperationalModeService_LiveModeGuard'
- go test ./internal/services
- make lint
- make build

This is a safety/status PR only. It does not make swing trading real-money ready.

## Summary by Sourcery

Add a daily swing trading readiness review routine that records explicit blockers and lifecycle diagnostics without enabling live trading.

New Features:
- Introduce a scheduled swing_trading_review quest that evaluates swing trading readiness and records diagnostic metrics over a 14‑day window.

Documentation:
- Document swing trading readiness criteria and required proof before enabling live trading in a dedicated readiness guide.

Tests:
- Add integration-style tests to verify the swing trading readiness review routine records blockers and lifecycle metrics under different lifecycle store conditions.