### PR TITLE
Expose paper trading readiness probe

### DIFF
--- a/services/backend-api/docs/PAPER_TRADING_READINESS.md
+++ b/services/backend-api/docs/PAPER_TRADING_READINESS.md
@@ -1,0 +1,27 @@
+# Paper Trading Readiness
+
+Paper trading is the simulation layer used before any strategy can be considered
+for real-money execution.
+
+The `paper_trading_review` routine records an explicit readiness checkpoint. It
+runs a deterministic simulator probe covering market entry, limit take-profit,
+stop-loss, and position close PnL. The routine writes:
+
+- `paper_trading_ready=false`
+- `paper_trading_readiness_status=blocked`
+- `paper_trading_runtime_probe_passed`
+- `paper_trading_readiness_blockers`
+
+The runtime probe is diagnostic only. It proves the local simulator path can
+create and fill representative paper orders, but it is not enough by itself to
+mark `paper_trading` ready in the live-readiness manifest.
+
+Minimum proof before the live-readiness manifest can mark `paper_trading` ready:
+
+- deterministic simulator probe passes
+- lifecycle storage is available
+- paper order open, close, cancellation, take-profit, and stop-loss flows are
+  persisted and queryable
+- fees, cost basis, realized PnL, and open-position state are recorded
+- the evidence artifact is written and referenced by
+  `NEURATRADE_LIVE_READINESS_MANIFEST`

--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -397,6 +397,16 @@ func (e *QuestEngine) registerDefaultDefinitions() {
 		Prompt:      "Generate comprehensive daily report including PnL, win rate, and strategy performance",
 	})
 
+	// Paper trading readiness review - runs daily
+	e.RegisterDefinition(&QuestDefinition{
+		ID:          "paper_trading_review",
+		Name:        "Paper Trading Readiness Review",
+		Description: "Probe paper trading simulator and record readiness blockers",
+		Type:        QuestTypeRoutine,
+		Cadence:     CadenceDaily,
+		Prompt:      "Verify paper trading simulation, lifecycle storage, and readiness evidence",
+	})
+
 	// Swing trading readiness review - runs daily
 	e.RegisterDefinition(&QuestDefinition{
 		ID:          "swing_trading_review",

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -604,7 +604,7 @@ func (h *IntegratedQuestHandlers) handlePaperTradingReadinessReview(ctx context.
 	quest.Checkpoint["paper_trading_review_open_positions"] = len(positions)
 
 	if summary.Trades == 0 {
-		blockers = append(blockers, "no_persisted_closed_paper_trades")
+		blockers = append(blockers, "paper_trading=insufficient_closed_trades")
 	}
 	if len(positions) > 0 {
 		blockers = append(blockers, "open_paper_positions_need_review")

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -501,6 +501,8 @@ func (h *IntegratedQuestHandlers) ExecuteRoutine(ctx context.Context, quest *Que
 		err = h.handleMarketScanWithTA(ctx, quest)
 	case "volatility_watch":
 		err = h.handleVolatilityWatch(ctx, quest)
+	case "paper_trading_review":
+		err = h.handlePaperTradingReadinessReview(ctx, quest)
 	case "funding_rate_scan":
 		err = h.handleFundingRateScan(ctx, quest)
 	case "arbitrage_readiness_review":
@@ -525,6 +527,200 @@ func (h *IntegratedQuestHandlers) ExecuteArbitrage(ctx context.Context, quest *Q
 	err := h.handleArbitrageExecution(ctx, quest)
 	h.recordQuestResult(quest, err == nil, decimal.Zero)
 	return err
+}
+
+func (h *IntegratedQuestHandlers) handlePaperTradingReadinessReview(ctx context.Context, quest *Quest) error {
+	if quest == nil {
+		return fmt.Errorf("quest is nil")
+	}
+	if quest.Checkpoint == nil {
+		quest.Checkpoint = make(map[string]interface{})
+	}
+	if quest.Metadata == nil {
+		quest.Metadata = make(map[string]string)
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-7 * 24 * time.Hour)
+	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
+	exchange := strings.TrimSpace(quest.Metadata["exchange"])
+	if exchange == "" {
+		exchange = strings.TrimSpace(scalpingExchangeFromContext(ctx))
+	}
+	if exchange == "" {
+		exchange = h.getUserExchange(chatID)
+	}
+	if exchange == "" {
+		exchange = "paper-simulator"
+	}
+
+	blockers := []string{
+		"missing_paper_trading_evidence_artifact",
+		"paper_review_is_diagnostic_only",
+	}
+	quest.Checkpoint["paper_trading_review_generated_at"] = now.Format(time.RFC3339)
+	quest.Checkpoint["paper_trading_review_window_start"] = since.Format(time.RFC3339)
+	quest.Checkpoint["paper_trading_review_window_end"] = now.Format(time.RFC3339)
+	quest.Checkpoint["paper_trading_review_chat_id"] = chatID
+	quest.Checkpoint["paper_trading_review_exchange"] = exchange
+
+	probe := runPaperTradingReadinessProbe(ctx, chatID, exchange)
+	for key, value := range probe {
+		quest.Checkpoint[key] = value
+	}
+	if passed, _ := probe["paper_trading_runtime_probe_passed"].(bool); !passed {
+		blockers = append(blockers, "paper_runtime_probe_failed")
+	}
+
+	if h.lifecycleStore == nil {
+		blockers = append(blockers, "lifecycle_store_unavailable")
+		writePaperTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
+
+	summary, err := h.lifecycleStore.GetRealizedPerformance(ctx, chatID, exchange, since)
+	if err != nil {
+		blockers = append(blockers, "realized_performance_query_failed")
+		writePaperTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
+	positions, err := h.lifecycleStore.ListManagedOpenPositions(ctx, chatID, exchange, 0)
+	if err != nil {
+		blockers = append(blockers, "open_position_query_failed")
+		writePaperTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
+
+	quest.Checkpoint["paper_trading_review_closed_trades"] = summary.Trades
+	quest.Checkpoint["paper_trading_review_wins"] = summary.Wins
+	quest.Checkpoint["paper_trading_review_losses"] = summary.Losses
+	quest.Checkpoint["paper_trading_review_breakeven"] = summary.Breakeven
+	quest.Checkpoint["paper_trading_review_net_pnl"] = summary.RealizedPnL.String()
+	quest.Checkpoint["paper_trading_review_fees"] = summary.Fees.String()
+	quest.Checkpoint["paper_trading_review_avg_net_pnl"] = summary.AvgNetPnL.String()
+	quest.Checkpoint["paper_trading_review_open_positions"] = len(positions)
+
+	if summary.Trades == 0 {
+		blockers = append(blockers, "no_persisted_closed_paper_trades")
+	}
+	if len(positions) > 0 {
+		blockers = append(blockers, "open_paper_positions_need_review")
+	}
+
+	writePaperTradingReadinessCheckpoint(quest, blockers)
+	quest.CurrentCount++
+	return nil
+}
+
+func runPaperTradingReadinessProbe(ctx context.Context, chatID, exchange string) map[string]interface{} {
+	result := map[string]interface{}{
+		"paper_trading_runtime_probe_passed": false,
+	}
+	config := DefaultPaperExecutionConfig()
+	config.EnableRandomness = false
+	config.ExecutionDelayMs = 0
+	config.SlippagePercentage = decimal.Zero
+	simulator := NewPaperExecutionSimulator(config)
+	userID := strings.TrimSpace(chatID)
+	if userID == "" {
+		userID = "paper-readiness-probe"
+	}
+
+	entryPrice := decimal.NewFromInt(100)
+	size := decimal.NewFromInt(1)
+	entryOrder, err := simulator.CreateOrder(PaperOrderRequest{
+		UserID:   userID,
+		Exchange: exchange,
+		Symbol:   "BTC/USDT",
+		Type:     PaperOrderTypeMarket,
+		Side:     PaperOrderSideBuy,
+		Size:     size,
+	})
+	if err != nil {
+		result["paper_trading_runtime_probe_error"] = err.Error()
+		return result
+	}
+	entryFill, err := simulator.SimulateFill(ctx, entryOrder, entryPrice)
+	if err != nil {
+		result["paper_trading_runtime_probe_error"] = err.Error()
+		return result
+	}
+
+	takeProfitPrice := decimal.NewFromInt(102)
+	takeProfitOrder, err := simulator.CreateOrder(PaperOrderRequest{
+		UserID:   userID,
+		Exchange: exchange,
+		Symbol:   "BTC/USDT",
+		Type:     PaperOrderTypeLimit,
+		Side:     PaperOrderSideSell,
+		Size:     size,
+		Price:    takeProfitPrice,
+	})
+	if err != nil {
+		result["paper_trading_runtime_probe_error"] = err.Error()
+		return result
+	}
+	takeProfitFill, err := simulator.SimulateFill(ctx, takeProfitOrder, decimal.NewFromInt(103))
+	if err != nil {
+		result["paper_trading_runtime_probe_error"] = err.Error()
+		return result
+	}
+
+	stopLossPrice := decimal.NewFromInt(98)
+	stopLossOrder, err := simulator.CreateOrder(PaperOrderRequest{
+		UserID:    userID,
+		Exchange:  exchange,
+		Symbol:    "ETH/USDT",
+		Type:      PaperOrderTypeStop,
+		Side:      PaperOrderSideSell,
+		Size:      size,
+		StopPrice: stopLossPrice,
+	})
+	if err != nil {
+		result["paper_trading_runtime_probe_error"] = err.Error()
+		return result
+	}
+	stopLossFill, err := simulator.SimulateFill(ctx, stopLossOrder, stopLossPrice)
+	if err != nil {
+		result["paper_trading_runtime_probe_error"] = err.Error()
+		return result
+	}
+
+	position := PaperPosition{
+		ID:         "paper-readiness-position",
+		UserID:     userID,
+		Exchange:   exchange,
+		Symbol:     "BTC/USDT",
+		Side:       PaperOrderSideBuy,
+		Size:       entryFill.FilledSize,
+		EntryPrice: entryFill.AvgFillPrice,
+		OpenedAt:   time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+	}
+	realizedPnL := position.ClosePosition(takeProfitFill.AvgFillPrice)
+
+	result["paper_trading_runtime_probe_passed"] = entryFill.Status == PaperOrderStatusFilled &&
+		takeProfitFill.Status == PaperOrderStatusFilled &&
+		stopLossFill.Status == PaperOrderStatusFilled &&
+		realizedPnL.GreaterThan(decimal.Zero)
+	result["paper_trading_probe_entry_status"] = string(entryFill.Status)
+	result["paper_trading_probe_take_profit_status"] = string(takeProfitFill.Status)
+	result["paper_trading_probe_stop_loss_status"] = string(stopLossFill.Status)
+	result["paper_trading_probe_entry_fill_price"] = entryFill.AvgFillPrice.String()
+	result["paper_trading_probe_take_profit_fill_price"] = takeProfitFill.AvgFillPrice.String()
+	result["paper_trading_probe_stop_loss_fill_price"] = stopLossFill.AvgFillPrice.String()
+	result["paper_trading_probe_realized_pnl"] = realizedPnL.String()
+	return result
+}
+
+func writePaperTradingReadinessCheckpoint(quest *Quest, blockers []string) {
+	quest.Checkpoint["paper_trading_ready"] = false
+	quest.Checkpoint["paper_trading_readiness_status"] = "blocked"
+	quest.Checkpoint["paper_trading_readiness_blockers"] = append([]string(nil), blockers...)
+	quest.Checkpoint["paper_trading_readiness_note"] = "paper trading simulator probe is diagnostic; publish a concrete evidence artifact before marking paper_trading ready in the live-readiness manifest"
 }
 
 func (h *IntegratedQuestHandlers) handleSwingTradingReadinessReview(ctx context.Context, quest *Quest) error {

--- a/services/backend-api/internal/services/quest_handlers_integrated_paper_readiness_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_paper_readiness_test.go
@@ -95,5 +95,5 @@ func TestExecuteRoutinePaperTradingReviewRecordsLifecycleDiagnostics(t *testing.
 	require.True(t, ok)
 	assert.Contains(t, blockers, "missing_paper_trading_evidence_artifact")
 	assert.NotContains(t, blockers, "lifecycle_store_unavailable")
-	assert.NotContains(t, blockers, "no_persisted_closed_paper_trades")
+	assert.NotContains(t, blockers, "paper_trading=insufficient_closed_trades")
 }

--- a/services/backend-api/internal/services/quest_handlers_integrated_paper_readiness_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_paper_readiness_test.go
@@ -1,0 +1,99 @@
+package services
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/irfndi/neuratrade/internal/database"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteRoutinePaperTradingReviewBlocksUntilEvidenceArtifactExists(t *testing.T) {
+	handlers := &IntegratedQuestHandlers{}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "paper_trading_review",
+			"chat_id":       "paper-chat",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err := handlers.ExecuteRoutine(context.Background(), quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, false, quest.Checkpoint["paper_trading_ready"])
+	assert.Equal(t, "blocked", quest.Checkpoint["paper_trading_readiness_status"])
+	assert.Equal(t, "paper-chat", quest.Checkpoint["paper_trading_review_chat_id"])
+	assert.Equal(t, "bitget", quest.Checkpoint["paper_trading_review_exchange"])
+	assert.Equal(t, true, quest.Checkpoint["paper_trading_runtime_probe_passed"])
+	assert.Equal(t, "filled", quest.Checkpoint["paper_trading_probe_entry_status"])
+	assert.Equal(t, "filled", quest.Checkpoint["paper_trading_probe_take_profit_status"])
+	assert.Equal(t, "filled", quest.Checkpoint["paper_trading_probe_stop_loss_status"])
+	assert.Equal(t, "2", quest.Checkpoint["paper_trading_probe_realized_pnl"])
+	assert.Equal(t, 1, quest.CurrentCount)
+
+	blockers, ok := quest.Checkpoint["paper_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "missing_paper_trading_evidence_artifact")
+	assert.Contains(t, blockers, "paper_review_is_diagnostic_only")
+	assert.Contains(t, blockers, "lifecycle_store_unavailable")
+	assert.NotContains(t, blockers, "paper_runtime_probe_failed")
+}
+
+func TestExecuteRoutinePaperTradingReviewRecordsLifecycleDiagnostics(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "paper-readiness.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	require.NoError(t, lifecycleStore.RecordClosedOrder(ctx, LifecycleCloseRecord{
+		OrderID:     "paper-close-1",
+		ChatID:      "paper-chat",
+		Exchange:    "bitget",
+		Symbol:      "BTC/USDT",
+		Side:        "buy",
+		MarketType:  "spot",
+		Filled:      decimal.NewFromInt(1),
+		EntryPrice:  decimal.NewFromInt(100),
+		ExitPrice:   decimal.NewFromInt(102),
+		RealizedPnL: decimal.NewFromInt(2),
+		Fees:        decimal.New(1, -2),
+		Source:      scalpingPaperLifecycleSource,
+		ClosedAt:    now.Add(-2 * time.Hour),
+	}))
+
+	handlers := &IntegratedQuestHandlers{lifecycleStore: lifecycleStore}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "paper_trading_review",
+			"chat_id":       "paper-chat",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err = handlers.ExecuteRoutine(ctx, quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, false, quest.Checkpoint["paper_trading_ready"])
+	assert.Equal(t, true, quest.Checkpoint["paper_trading_runtime_probe_passed"])
+	assert.Equal(t, 1, quest.Checkpoint["paper_trading_review_closed_trades"])
+	assert.Equal(t, 1, quest.Checkpoint["paper_trading_review_wins"])
+	assert.Equal(t, 0, quest.Checkpoint["paper_trading_review_losses"])
+	assert.Equal(t, 0, quest.Checkpoint["paper_trading_review_open_positions"])
+
+	blockers, ok := quest.Checkpoint["paper_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "missing_paper_trading_evidence_artifact")
+	assert.NotContains(t, blockers, "lifecycle_store_unavailable")
+	assert.NotContains(t, blockers, "no_persisted_closed_paper_trades")
+}


### PR DESCRIPTION
## Summary
- add a daily paper_trading_review routine that runs a deterministic simulator probe
- record explicit paper readiness blockers plus simulator and lifecycle diagnostics
- document the evidence required before paper_trading can satisfy the live-readiness manifest

## Validation
- git diff --check
- go test ./internal/services -run 'TestExecuteRoutinePaperTradingReview|TestPaperDryRunValidationFlowRecordsPerformanceAndProtectionExits|TestManifestLiveModeGuard|TestOperationalModeService_LiveModeGuard'
- go test ./internal/services
- make lint
- make build

This is a readiness/status PR only. It does not make strategy live-money use ready.

## Summary by Sourcery

Add a daily paper trading readiness review routine that probes the simulator and records readiness blockers and diagnostics.

New Features:
- Introduce a scheduled paper_trading_review routine to assess paper trading readiness.
- Add a deterministic paper trading simulator probe that validates key order and position flows and records results in quest checkpoints.

Enhancements:
- Record lifecycle-based performance and protection diagnostics for paper trading, including trade counts, PnL, and open position state, as part of readiness review.
- Persist explicit paper trading readiness status and blocker metadata in quest checkpoints for downstream readiness evaluation.

Documentation:
- Add paper trading readiness documentation describing the review routine, recorded diagnostics, and required evidence before enabling live-readiness.

Tests:
- Add integration tests covering paper_trading_review routine behavior, lifecycle diagnostics recording, and readiness blocker conditions.