### PR TITLE
Require paper trading proof metrics

### DIFF
--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -5,7 +5,7 @@ manifest from `NEURATRADE_LIVE_READINESS_MANIFEST`.
 
 The manifest is intentionally a final gate, not proof by itself. Each entry must
 point to evidence produced by the relevant paper/live-market verifier for that
-strategy. Trading strategies also require structured `evidence_metrics`; a
+strategy. Required entries also require structured `evidence_metrics`; a
 non-empty evidence path alone is not enough to permit live mode.
 
 ```json
@@ -15,6 +15,14 @@ non-empty evidence path alone is not enough to permit live mode.
     "paper_trading": {
       "ready": true,
       "evidence": "/path/to/paper-trading-verification.json",
+      "evidence_metrics": {
+        "paper_runtime_probe_passed": true,
+        "lifecycle_storage_verified": true,
+        "closed_trades": 1,
+        "open_positions": 0,
+        "net_pnl": "1.25",
+        "avg_net_pnl": "1.25"
+      },
       "verified_at": "2026-05-21T00:00:00Z"
     },
     "scalping": {
@@ -46,6 +54,14 @@ non-empty evidence path alone is not enough to permit live mode.
   }
 }
 ```
+
+Required paper-trading metrics:
+
+- `paper_runtime_probe_passed`: must be true.
+- `lifecycle_storage_verified`: must be true.
+- `closed_trades`: at least 1 persisted closed paper trade.
+- `open_positions`: must be 0.
+- `net_pnl` and `avg_net_pnl`: decimal strings greater than 0.
 
 Required trading-strategy metrics:
 

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -188,7 +188,7 @@ func paperTradingReadinessEvidenceBlockers(metrics *StrategyReadinessEvidence) [
 		blockers = append(blockers, "paper_trading=lifecycle_storage_not_verified")
 	}
 	if metrics.ClosedTrades < 1 {
-		blockers = append(blockers, "paper_trading=no_persisted_closed_paper_trades")
+		blockers = append(blockers, "paper_trading=insufficient_closed_trades")
 	}
 	if metrics.OpenPositions != 0 {
 		blockers = append(blockers, fmt.Sprintf("paper_trading=open_positions_%d", metrics.OpenPositions))

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -41,6 +41,11 @@ type StrategyReadinessEvidence struct {
 	MaxDrawdownPct string `json:"max_drawdown_pct,omitempty"`
 	NoTradeSafety  bool   `json:"no_trade_safety,omitempty"`
 	NoTradeReason  string `json:"no_trade_reason,omitempty"`
+	// PaperRuntimeProbePassed and LifecycleStorageVerified are required only for
+	// paper_trading evidence, where simulator and persistence proof are the base
+	// readiness contract rather than strategy profitability.
+	PaperRuntimeProbePassed  bool `json:"paper_runtime_probe_passed,omitempty"`
+	LifecycleStorageVerified bool `json:"lifecycle_storage_verified,omitempty"`
 }
 
 // LiveReadinessManifest is the file format consumed by ManifestLiveModeGuard.
@@ -129,12 +134,12 @@ func normalizeReadinessStrategies(strategies []string) []string {
 }
 
 func strategyReadinessEvidenceBlockers(strategy string, status StrategyLiveReadiness) []string {
-	if strategy == "paper_trading" {
-		return nil
-	}
 	metrics := status.EvidenceMetrics
 	if metrics == nil {
 		return []string{fmt.Sprintf("%s=missing_evidence_metrics", strategy)}
+	}
+	if strategy == "paper_trading" {
+		return paperTradingReadinessEvidenceBlockers(metrics)
 	}
 	if strategy == "arbitrage" && metrics.NoTradeSafety {
 		if strings.TrimSpace(metrics.NoTradeReason) == "" {
@@ -170,6 +175,29 @@ func strategyReadinessEvidenceBlockers(strategy string, status StrategyLiveReadi
 	}
 	if !positiveDecimalString(metrics.MaxDrawdownPct) {
 		blockers = append(blockers, fmt.Sprintf("%s=missing_observed_drawdown", strategy))
+	}
+	return blockers
+}
+
+func paperTradingReadinessEvidenceBlockers(metrics *StrategyReadinessEvidence) []string {
+	var blockers []string
+	if !metrics.PaperRuntimeProbePassed {
+		blockers = append(blockers, "paper_trading=runtime_probe_not_passed")
+	}
+	if !metrics.LifecycleStorageVerified {
+		blockers = append(blockers, "paper_trading=lifecycle_storage_not_verified")
+	}
+	if metrics.ClosedTrades < 1 {
+		blockers = append(blockers, "paper_trading=no_persisted_closed_paper_trades")
+	}
+	if metrics.OpenPositions != 0 {
+		blockers = append(blockers, fmt.Sprintf("paper_trading=open_positions_%d", metrics.OpenPositions))
+	}
+	if !positiveDecimalString(metrics.NetPnL) {
+		blockers = append(blockers, "paper_trading=non_positive_net_pnl")
+	}
+	if !positiveDecimalString(metrics.AvgNetPnL) {
+		blockers = append(blockers, "paper_trading=non_positive_avg_net_pnl")
 	}
 	return blockers
 }

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -174,7 +174,7 @@ func TestManifestLiveModeGuardRequiresPaperTradingProofMetrics(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "paper_trading=runtime_probe_not_passed")
 	assert.Contains(t, err.Error(), "paper_trading=lifecycle_storage_not_verified")
-	assert.Contains(t, err.Error(), "paper_trading=no_persisted_closed_paper_trades")
+	assert.Contains(t, err.Error(), "paper_trading=insufficient_closed_trades")
 	assert.Contains(t, err.Error(), "paper_trading=open_positions_1")
 	assert.Contains(t, err.Error(), "paper_trading=non_positive_net_pnl")
 	assert.Contains(t, err.Error(), "paper_trading=non_positive_avg_net_pnl")

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -136,6 +136,7 @@ func TestManifestLiveModeGuardAllowsVerifiedStrategies(t *testing.T) {
 	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
+			"paper_trading": {Ready: true, Evidence: "paper-readiness.json", EvidenceMetrics: passingPaperReadinessEvidence()},
 			"daily_trading": {Ready: true, Evidence: "paper-soak:daily.json", EvidenceMetrics: passingReadinessEvidence(2)},
 			"swing_trading": {Ready: true, Evidence: "paper-soak:swing.json", EvidenceMetrics: passingReadinessEvidence(2)},
 		},
@@ -144,8 +145,39 @@ func TestManifestLiveModeGuardAllowsVerifiedStrategies(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
 
-	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading", "swing_trading"})
+	guard := ManifestLiveModeGuard(manifestPath, []string{"paper_trading", "daily_trading", "swing_trading"})
 	require.NoError(t, guard(context.Background(), "chat-1", "tester"))
+}
+
+func TestManifestLiveModeGuardRequiresPaperTradingProofMetrics(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"paper_trading": {
+				Ready:    true,
+				Evidence: "paper-readiness.json",
+				EvidenceMetrics: &StrategyReadinessEvidence{
+					ClosedTrades:  0,
+					OpenPositions: 1,
+					NetPnL:        "0",
+					AvgNetPnL:     "-0.01",
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"paper_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "paper_trading=runtime_probe_not_passed")
+	assert.Contains(t, err.Error(), "paper_trading=lifecycle_storage_not_verified")
+	assert.Contains(t, err.Error(), "paper_trading=no_persisted_closed_paper_trades")
+	assert.Contains(t, err.Error(), "paper_trading=open_positions_1")
+	assert.Contains(t, err.Error(), "paper_trading=non_positive_net_pnl")
+	assert.Contains(t, err.Error(), "paper_trading=non_positive_avg_net_pnl")
 }
 
 func TestManifestLiveModeGuardRequiresTradingProofMetrics(t *testing.T) {
@@ -229,6 +261,17 @@ func passingReadinessEvidence(closedTrades int) *StrategyReadinessEvidence {
 		NetPnL:         "1.25",
 		AvgNetPnL:      "0.10",
 		MaxDrawdownPct: "0.05",
+	}
+}
+
+func passingPaperReadinessEvidence() *StrategyReadinessEvidence {
+	return &StrategyReadinessEvidence{
+		ClosedTrades:             1,
+		OpenPositions:            0,
+		NetPnL:                   "1.25",
+		AvgNetPnL:                "1.25",
+		PaperRuntimeProbePassed:  true,
+		LifecycleStorageVerified: true,
 	}
 }
 


### PR DESCRIPTION
## Summary
- require paper_trading live-readiness manifest entries to include structured proof metrics instead of accepting evidence-only readiness
- add paper simulator/runtime and lifecycle storage proof fields to the manifest evidence contract
- document the paper_trading evidence_metrics JSON shape and add regression coverage for missing paper proof blockers

## Validation
- git diff --check
- go test ./internal/services -run 'TestManifestLiveModeGuard|TestOperationalModeService_LiveModeGuard'\n- go test ./internal/services\n- make lint\n- make build\n\n## Readiness note\nThis is a guard/status PR only. It prevents paper_trading from being marked live-ready without simulator and persistence proof metrics; it does not make paper trading, strategy trading, or real-money execution ready by itself.

## Summary by Sourcery

Tighten the live-readiness guard for paper trading by requiring structured proof metrics and documenting the manifest contract.

Enhancements:
- Enforce metric-based readiness checks for paper_trading, including simulator and lifecycle storage proofs, instead of allowing evidence-only readiness.
- Add paper-trading-specific readiness fields to the manifest evidence schema and validation logic.
- Extend the live readiness manifest documentation to define the required evidence_metrics JSON shape for paper trading.

Documentation:
- Document the required paper_trading evidence_metrics fields and constraints in the LIVE_READINESS_MANIFEST guide.

Tests:
- Add and update tests to verify that paper_trading requires full proof metrics and to cover failure modes when required metrics are missing or invalid.