### PR TITLE
Add daily report readiness checkpoint

### DIFF
--- a/services/backend-api/docs/DAILY_TRADING_READINESS.md
+++ b/services/backend-api/docs/DAILY_TRADING_READINESS.md
@@ -1,0 +1,40 @@
+# Daily Trading Readiness
+
+Daily trading is not approved for real-money use.
+
+The registered `daily_report` routine records an explicit readiness checkpoint
+instead of failing as an unknown routine. It always writes:
+
+- `daily_trading_live_ready=false`
+- `daily_trading_readiness_status=blocked`
+- `daily_trading_lifecycle_storage_verified`
+- `daily_trading_readiness_evidence_metrics`
+- `daily_trading_readiness_blockers`
+
+The report captures lifecycle context over the previous 24 hours, including
+closed trades, wins, losses, net PnL, average net PnL, open positions, and a
+manifest-shaped metrics object. These metrics are diagnostic only until an
+executable daily strategy path, drawdown proof, and evidence artifact exist.
+
+`daily_trading_readiness_evidence_metrics` mirrors the manifest proof fields:
+
+- `closed_trades`
+- `winning_trades`
+- `losing_trades`
+- `open_positions`
+- `net_pnl`
+- `avg_net_pnl`
+- `max_drawdown_pct`
+
+`max_drawdown_pct` remains `0.00` until a real drawdown verifier supplies proof,
+so the generated metrics cannot satisfy the live-readiness manifest by accident.
+
+Minimum proof before the live-readiness manifest can mark `daily_trading` ready:
+
+- executable daily signal path with documented entry and exit rules
+- paper/live-market lifecycle evidence over representative daily cadence
+- at least two closed trades with both a win and a loss
+- no open positions at proof cutoff
+- positive net and average net PnL after fees
+- observed and bounded drawdown
+- evidence artifact written and referenced by `NEURATRADE_LIVE_READINESS_MANIFEST`

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -499,6 +499,8 @@ func (h *IntegratedQuestHandlers) ExecuteRoutine(ctx context.Context, quest *Que
 	switch quest.Metadata["definition_id"] {
 	case "market_scan":
 		err = h.handleMarketScanWithTA(ctx, quest)
+	case "daily_report":
+		err = h.handleDailyTradingReport(ctx, quest)
 	case "volatility_watch":
 		err = h.handleVolatilityWatch(ctx, quest)
 	case "paper_trading_review":
@@ -520,6 +522,128 @@ func (h *IntegratedQuestHandlers) ExecuteRoutine(ctx context.Context, quest *Que
 	}
 	h.recordQuestResult(quest, err == nil, decimal.Zero)
 	return err
+}
+
+func (h *IntegratedQuestHandlers) handleDailyTradingReport(ctx context.Context, quest *Quest) error {
+	if quest == nil {
+		return fmt.Errorf("quest is nil")
+	}
+	if quest.Checkpoint == nil {
+		quest.Checkpoint = make(map[string]interface{})
+	}
+	if quest.Metadata == nil {
+		quest.Metadata = make(map[string]string)
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-24 * time.Hour)
+	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
+	exchange := strings.TrimSpace(quest.Metadata["exchange"])
+	if exchange == "" {
+		exchange = strings.TrimSpace(scalpingExchangeFromContext(ctx))
+	}
+	if exchange == "" {
+		exchange = h.getUserExchange(chatID)
+	}
+	if exchange == "" {
+		exchange = "bitget"
+	}
+
+	blockers := []string{
+		"daily_trading_strategy_not_implemented",
+		"daily_report_is_readiness_status_only",
+		"missing_daily_trading_evidence_artifact",
+		"missing_daily_strategy_signal_proof",
+		"missing_drawdown_evidence",
+	}
+	quest.Checkpoint["daily_report_generated_at"] = now.Format(time.RFC3339)
+	quest.Checkpoint["daily_report_window_start"] = since.Format(time.RFC3339)
+	quest.Checkpoint["daily_report_window_end"] = now.Format(time.RFC3339)
+	quest.Checkpoint["daily_report_chat_id"] = chatID
+	quest.Checkpoint["daily_report_exchange"] = exchange
+	writeDailyTradingReadinessEvidenceMetrics(quest, false, LifecyclePerformanceSummary{}, 0)
+
+	if h.lifecycleStore == nil {
+		blockers = append(blockers, "lifecycle_store_unavailable")
+		writeDailyTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
+
+	summary, err := h.lifecycleStore.GetRealizedPerformance(ctx, chatID, exchange, since)
+	if err != nil {
+		blockers = append(blockers, "realized_performance_query_failed")
+		writeDailyTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
+	positions, err := h.lifecycleStore.ListManagedOpenPositions(ctx, chatID, exchange, 1000)
+	if err != nil {
+		blockers = append(blockers, "open_position_query_failed")
+		writeDailyTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
+
+	quest.Checkpoint["daily_report_closed_trades"] = summary.Trades
+	quest.Checkpoint["daily_report_wins"] = summary.Wins
+	quest.Checkpoint["daily_report_losses"] = summary.Losses
+	quest.Checkpoint["daily_report_breakeven"] = summary.Breakeven
+	quest.Checkpoint["daily_report_net_pnl"] = summary.RealizedPnL.String()
+	quest.Checkpoint["daily_report_gross_pnl"] = summary.GrossPnL.String()
+	quest.Checkpoint["daily_report_fees"] = summary.Fees.String()
+	quest.Checkpoint["daily_report_avg_net_pnl"] = summary.AvgNetPnL.String()
+	quest.Checkpoint["daily_report_win_rate"] = summary.WinRate.String()
+	quest.Checkpoint["daily_report_open_positions"] = len(positions)
+	writeDailyTradingReadinessEvidenceMetrics(quest, true, summary, len(positions))
+
+	if summary.Trades < 2 {
+		blockers = append(blockers, "no_representative_closed_trade_sample")
+	}
+	if summary.Wins == 0 {
+		blockers = append(blockers, "no_winning_trade_observed")
+	}
+	if summary.Losses == 0 {
+		blockers = append(blockers, "no_losing_trade_observed")
+	}
+	if summary.RealizedPnL.LessThanOrEqual(decimal.Zero) {
+		blockers = append(blockers, "non_positive_net_pnl")
+	}
+	if summary.Trades > 0 && summary.AvgNetPnL.LessThanOrEqual(decimal.Zero) {
+		blockers = append(blockers, "non_positive_avg_net_pnl")
+	}
+	if len(positions) > 0 {
+		blockers = append(blockers, "open_positions_need_lifecycle_review")
+	}
+
+	writeDailyTradingReadinessCheckpoint(quest, blockers)
+	quest.CurrentCount++
+	return nil
+}
+
+func writeDailyTradingReadinessCheckpoint(quest *Quest, blockers []string) {
+	quest.Checkpoint["daily_trading_live_ready"] = false
+	quest.Checkpoint["daily_trading_readiness_status"] = "blocked"
+	quest.Checkpoint["daily_trading_readiness_blockers"] = append([]string(nil), blockers...)
+	quest.Checkpoint["daily_trading_readiness_note"] = "daily trading has no executable strategy path, drawdown proof, or evidence artifact; keep live-money use blocked"
+}
+
+func writeDailyTradingReadinessEvidenceMetrics(
+	quest *Quest,
+	lifecycleStorageVerified bool,
+	summary LifecyclePerformanceSummary,
+	openPositions int,
+) {
+	quest.Checkpoint["daily_trading_lifecycle_storage_verified"] = lifecycleStorageVerified
+	quest.Checkpoint["daily_trading_readiness_evidence_metrics"] = map[string]interface{}{
+		"closed_trades":    summary.Trades,
+		"winning_trades":   summary.Wins,
+		"losing_trades":    summary.Losses,
+		"open_positions":   openPositions,
+		"net_pnl":          summary.RealizedPnL.StringFixed(2),
+		"avg_net_pnl":      summary.AvgNetPnL.StringFixed(2),
+		"max_drawdown_pct": "0.00",
+	}
 }
 
 // ExecuteArbitrage runs arbitrage quest execution and records monitoring outcomes.

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -542,7 +542,7 @@ func (h *IntegratedQuestHandlers) handleDailyTradingReport(ctx context.Context, 
 	if exchange == "" {
 		exchange = strings.TrimSpace(scalpingExchangeFromContext(ctx))
 	}
-	if exchange == "" {
+	if exchange == "" && chatID != "" {
 		exchange = h.getUserExchange(chatID)
 	}
 	if exchange == "" {
@@ -563,6 +563,13 @@ func (h *IntegratedQuestHandlers) handleDailyTradingReport(ctx context.Context, 
 	quest.Checkpoint["daily_report_exchange"] = exchange
 	writeDailyTradingReadinessEvidenceMetrics(quest, false, LifecyclePerformanceSummary{}, 0)
 
+	if chatID == "" {
+		blockers = append(blockers, "missing_chat_id_metadata")
+		writeDailyTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
+
 	if h.lifecycleStore == nil {
 		blockers = append(blockers, "lifecycle_store_unavailable")
 		writeDailyTradingReadinessCheckpoint(quest, blockers)
@@ -574,15 +581,13 @@ func (h *IntegratedQuestHandlers) handleDailyTradingReport(ctx context.Context, 
 	if err != nil {
 		blockers = append(blockers, "realized_performance_query_failed")
 		writeDailyTradingReadinessCheckpoint(quest, blockers)
-		quest.CurrentCount++
-		return nil
+		return fmt.Errorf("daily trading report: realized performance: %w", err)
 	}
 	positions, err := h.lifecycleStore.ListManagedOpenPositions(ctx, chatID, exchange, 1000)
 	if err != nil {
 		blockers = append(blockers, "open_position_query_failed")
 		writeDailyTradingReadinessCheckpoint(quest, blockers)
-		quest.CurrentCount++
-		return nil
+		return fmt.Errorf("daily trading report: open positions: %w", err)
 	}
 
 	quest.Checkpoint["daily_report_closed_trades"] = summary.Trades

--- a/services/backend-api/internal/services/quest_handlers_integrated_daily_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_daily_test.go
@@ -53,6 +53,89 @@ func TestExecuteRoutineDailyReportRecordsBlockedReadinessWithoutLifecycleStore(t
 	assert.Contains(t, blockers, "lifecycle_store_unavailable")
 }
 
+func TestExecuteRoutineDailyReportBlocksMissingChatIDBeforeLifecycleQueries(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "daily-missing-chat.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, lifecycleStore.RecordClosedOrder(ctx, LifecycleCloseRecord{
+		OrderID:     "other-user-close",
+		ChatID:      "other-chat",
+		Exchange:    "bitget",
+		Symbol:      "BTC/USDT",
+		Side:        "buy",
+		MarketType:  "spot",
+		Filled:      decimal.NewFromInt(1),
+		EntryPrice:  decimal.NewFromInt(100),
+		ExitPrice:   decimal.NewFromInt(103),
+		RealizedPnL: decimal.NewFromInt(3),
+		Fees:        decimal.New(1, -1),
+		Source:      "daily_trading",
+		ClosedAt:    time.Now().UTC().Add(-2 * time.Hour),
+	}))
+
+	handlers := &IntegratedQuestHandlers{lifecycleStore: lifecycleStore}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "daily_report",
+			"chat_id":       "   ",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err = handlers.ExecuteRoutine(ctx, quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, "", quest.Checkpoint["daily_report_chat_id"])
+	assert.Equal(t, false, quest.Checkpoint["daily_trading_lifecycle_storage_verified"])
+	assert.Equal(t, 1, quest.CurrentCount)
+
+	metrics, ok := quest.Checkpoint["daily_trading_readiness_evidence_metrics"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 0, metrics["closed_trades"])
+	assert.Equal(t, "0.00", metrics["net_pnl"])
+
+	blockers, ok := quest.Checkpoint["daily_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "missing_chat_id_metadata")
+	assert.NotContains(t, blockers, "lifecycle_store_unavailable")
+}
+
+func TestExecuteRoutineDailyReportReturnsLifecycleQueryErrors(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "daily-query-error.db"))
+	require.NoError(t, err)
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+	require.NoError(t, sqliteDB.Close())
+
+	handlers := &IntegratedQuestHandlers{lifecycleStore: lifecycleStore}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "daily_report",
+			"chat_id":       "daily-chat",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err = handlers.ExecuteRoutine(ctx, quest)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daily trading report: realized performance")
+	assert.Equal(t, 0, quest.CurrentCount)
+
+	blockers, ok := quest.Checkpoint["daily_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "realized_performance_query_failed")
+}
+
 func TestExecuteRoutineDailyReportRecordsLifecycleMetrics(t *testing.T) {
 	ctx := context.Background()
 	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "daily-readiness.db"))

--- a/services/backend-api/internal/services/quest_handlers_integrated_daily_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_daily_test.go
@@ -1,0 +1,139 @@
+package services
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/irfndi/neuratrade/internal/database"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteRoutineDailyReportRecordsBlockedReadinessWithoutLifecycleStore(t *testing.T) {
+	handlers := &IntegratedQuestHandlers{}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "daily_report",
+			"chat_id":       "daily-chat",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err := handlers.ExecuteRoutine(context.Background(), quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, false, quest.Checkpoint["daily_trading_live_ready"])
+	assert.Equal(t, "blocked", quest.Checkpoint["daily_trading_readiness_status"])
+	assert.Equal(t, "daily-chat", quest.Checkpoint["daily_report_chat_id"])
+	assert.Equal(t, "bitget", quest.Checkpoint["daily_report_exchange"])
+	assert.Equal(t, false, quest.Checkpoint["daily_trading_lifecycle_storage_verified"])
+	assert.Equal(t, 1, quest.CurrentCount)
+
+	metrics, ok := quest.Checkpoint["daily_trading_readiness_evidence_metrics"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 0, metrics["closed_trades"])
+	assert.Equal(t, 0, metrics["winning_trades"])
+	assert.Equal(t, 0, metrics["losing_trades"])
+	assert.Equal(t, 0, metrics["open_positions"])
+	assert.Equal(t, "0.00", metrics["net_pnl"])
+	assert.Equal(t, "0.00", metrics["avg_net_pnl"])
+	assert.Equal(t, "0.00", metrics["max_drawdown_pct"])
+
+	blockers, ok := quest.Checkpoint["daily_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "daily_trading_strategy_not_implemented")
+	assert.Contains(t, blockers, "daily_report_is_readiness_status_only")
+	assert.Contains(t, blockers, "missing_daily_trading_evidence_artifact")
+	assert.Contains(t, blockers, "missing_daily_strategy_signal_proof")
+	assert.Contains(t, blockers, "missing_drawdown_evidence")
+	assert.Contains(t, blockers, "lifecycle_store_unavailable")
+}
+
+func TestExecuteRoutineDailyReportRecordsLifecycleMetrics(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "daily-readiness.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	require.NoError(t, lifecycleStore.RecordClosedOrder(ctx, LifecycleCloseRecord{
+		OrderID:     "daily-win-1",
+		ChatID:      "daily-chat",
+		Exchange:    "bitget",
+		Symbol:      "BTC/USDT",
+		Side:        "buy",
+		MarketType:  "spot",
+		Filled:      decimal.NewFromInt(1),
+		EntryPrice:  decimal.NewFromInt(100),
+		ExitPrice:   decimal.NewFromInt(103),
+		RealizedPnL: decimal.NewFromInt(3),
+		Fees:        decimal.New(1, -1),
+		Source:      "daily_trading",
+		ClosedAt:    now.Add(-2 * time.Hour),
+	}))
+	require.NoError(t, lifecycleStore.RecordClosedOrder(ctx, LifecycleCloseRecord{
+		OrderID:     "daily-loss-1",
+		ChatID:      "daily-chat",
+		Exchange:    "bitget",
+		Symbol:      "ETH/USDT",
+		Side:        "buy",
+		MarketType:  "spot",
+		Filled:      decimal.NewFromInt(1),
+		EntryPrice:  decimal.NewFromInt(100),
+		ExitPrice:   decimal.NewFromInt(99),
+		RealizedPnL: decimal.NewFromInt(-1),
+		Fees:        decimal.New(1, -1),
+		Source:      "daily_trading",
+		ClosedAt:    now.Add(-1 * time.Hour),
+	}))
+
+	handlers := &IntegratedQuestHandlers{lifecycleStore: lifecycleStore}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "daily_report",
+			"chat_id":       "daily-chat",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err = handlers.ExecuteRoutine(ctx, quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, false, quest.Checkpoint["daily_trading_live_ready"])
+	assert.Equal(t, 2, quest.Checkpoint["daily_report_closed_trades"])
+	assert.Equal(t, 1, quest.Checkpoint["daily_report_wins"])
+	assert.Equal(t, 1, quest.Checkpoint["daily_report_losses"])
+	assert.Equal(t, 0, quest.Checkpoint["daily_report_open_positions"])
+	assert.Equal(t, true, quest.Checkpoint["daily_trading_lifecycle_storage_verified"])
+	assert.Equal(t, 1, quest.CurrentCount)
+
+	metrics, ok := quest.Checkpoint["daily_trading_readiness_evidence_metrics"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 2, metrics["closed_trades"])
+	assert.Equal(t, 1, metrics["winning_trades"])
+	assert.Equal(t, 1, metrics["losing_trades"])
+	assert.Equal(t, 0, metrics["open_positions"])
+	assert.Equal(t, "1.80", metrics["net_pnl"])
+	assert.Equal(t, "0.90", metrics["avg_net_pnl"])
+	assert.Equal(t, "0.00", metrics["max_drawdown_pct"])
+
+	blockers, ok := quest.Checkpoint["daily_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "daily_trading_strategy_not_implemented")
+	assert.Contains(t, blockers, "missing_drawdown_evidence")
+	assert.NotContains(t, blockers, "lifecycle_store_unavailable")
+	assert.NotContains(t, blockers, "no_representative_closed_trade_sample")
+	assert.NotContains(t, blockers, "no_winning_trade_observed")
+	assert.NotContains(t, blockers, "no_losing_trade_observed")
+	assert.NotContains(t, blockers, "non_positive_net_pnl")
+	assert.NotContains(t, blockers, "non_positive_avg_net_pnl")
+}


### PR DESCRIPTION
## Summary
- handle the registered daily_report routine instead of letting it fall through as unknown
- record daily_trading readiness blockers, lifecycle diagnostics, and manifest-shaped evidence metrics
- document why daily trading remains blocked until executable strategy, drawdown, and evidence proof exists

## Validation
- git diff --check
- go test ./internal/services -run 'TestExecuteRoutineDailyReport|TestManifestLiveModeGuard'\n- go test ./internal/services\n- make lint\n- make build\n\n## Readiness note\nThis is a readiness/status PR. It makes the daily report routine executable and auditable, but it still writes daily_trading_live_ready=false and does not approve real-money daily trading.

## Summary by Sourcery

Add handling for the registered daily_report routine to produce a daily trading readiness checkpoint while explicitly keeping live trading blocked.

New Features:
- Introduce a daily trading report routine that records readiness checkpoints and lifecycle performance diagnostics over the previous 24 hours.

Enhancements:
- Record standardized readiness evidence metrics and blockers for daily trading, including lifecycle storage verification and trade/position statistics.

Documentation:
- Document the daily trading readiness model, including required proof and metrics before daily trading can be marked live-ready.

Tests:
- Add integration tests covering daily_report readiness behavior, lifecycle store interactions, metric recording, and error handling paths.