### PR TITLE
Emit swing readiness evidence metrics

### DIFF
--- a/services/backend-api/docs/SWING_TRADING_READINESS.md
+++ b/services/backend-api/docs/SWING_TRADING_READINESS.md
@@ -8,12 +8,28 @@ It always writes:
 
 - `swing_trading_live_ready=false`
 - `swing_trading_readiness_status=blocked`
+- `swing_trading_lifecycle_storage_verified`
+- `swing_trading_readiness_evidence_metrics`
 - `swing_trading_readiness_blockers`
 
 The review captures lifecycle context over the previous 14 days, including
 closed trades, wins, losses, net PnL, average net PnL, open positions, and stale
 open positions. These metrics are diagnostic only until an executable swing
 signal path and paper/live-market hold-window proof exist.
+
+`swing_trading_readiness_evidence_metrics` mirrors the manifest proof fields:
+
+- `closed_trades`
+- `winning_trades`
+- `losing_trades`
+- `open_positions`
+- `net_pnl`
+- `avg_net_pnl`
+- `max_drawdown_pct`
+
+`max_drawdown_pct` remains `0.00` until a real swing drawdown verifier supplies
+proof, so the generated metrics cannot satisfy the live-readiness manifest by
+accident.
 
 Minimum proof before the live-readiness manifest can mark `swing_trading` ready:
 

--- a/services/backend-api/docs/SWING_TRADING_READINESS.md
+++ b/services/backend-api/docs/SWING_TRADING_READINESS.md
@@ -9,6 +9,8 @@ It always writes:
 - `swing_trading_live_ready=false`
 - `swing_trading_readiness_status=blocked`
 - `swing_trading_lifecycle_storage_verified`
+- `swing_trading_drawdown_verified=false`
+- `swing_trading_readiness_evidence_metrics_status`
 - `swing_trading_readiness_evidence_metrics`
 - `swing_trading_readiness_blockers`
 
@@ -28,8 +30,10 @@ signal path and paper/live-market hold-window proof exist.
 - `max_drawdown_pct`
 
 `max_drawdown_pct` remains `0.00` until a real swing drawdown verifier supplies
-proof, so the generated metrics cannot satisfy the live-readiness manifest by
-accident.
+proof, and the metrics include `diagnostic_only=true` and
+`drawdown_verified=false` so downstream consumers can distinguish placeholder
+diagnostics from a manifest-ready evidence artifact. These fields also keep the
+generated metrics from satisfying the live-readiness manifest by accident.
 
 Minimum proof before the live-readiness manifest can mark `swing_trading` ready:
 

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -487,7 +487,7 @@ func nonPaperManagedPositions(positions []ManagedOpenPosition) []ManagedOpenPosi
 
 // recordQuestResult records quest execution result for monitoring
 func (h *IntegratedQuestHandlers) recordQuestResult(quest *Quest, success bool, pnl decimal.Decimal) {
-	chatID := quest.Metadata["chat_id"]
+	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
 	if h.monitoring != nil && chatID != "" {
 		h.monitoring.RecordQuestExecution(chatID, success, pnl)
 	}
@@ -1054,7 +1054,7 @@ func (h *IntegratedQuestHandlers) handleMarketScanWithTA(ctx context.Context, qu
 	symbolsWithSignals := 0
 
 	// Get chat ID from quest metadata
-	chatID := quest.Metadata["chat_id"]
+	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
 
 	// Scan major trading pairs
 	majorPairs := []string{
@@ -1097,7 +1097,7 @@ func (h *IntegratedQuestHandlers) handleFundingRateScan(ctx context.Context, que
 	negativeRates := 0
 
 	// Get chat ID from quest metadata
-	chatID := quest.Metadata["chat_id"]
+	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
 
 	// Track funding rate exchanges
 	exchanges := []string{"binance", "bybit", "okx"}
@@ -1231,7 +1231,7 @@ func (h *IntegratedQuestHandlers) handlePortfolioHealthWithRisk(ctx context.Cont
 	startTime := time.Now()
 
 	// Get chat ID from quest metadata
-	chatID := quest.Metadata["chat_id"]
+	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
 
 	// Initialize health metrics
 	healthStatus := "healthy"
@@ -1284,7 +1284,7 @@ func (h *IntegratedQuestHandlers) handleScalpingExecution(ctx context.Context, q
 		quest.Checkpoint = make(map[string]interface{})
 	}
 
-	chatID := quest.Metadata["chat_id"]
+	chatID := strings.TrimSpace(quest.Metadata["chat_id"])
 
 	h.aiScalpingMu.RLock()
 	aiSvc := h.aiScalpingService

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -548,6 +548,12 @@ func (h *IntegratedQuestHandlers) handleDailyTradingReport(ctx context.Context, 
 	if exchange == "" {
 		exchange = "bitget"
 	}
+	if exchange == "" && chatID != "" {
+		exchange = h.getUserExchange(chatID)
+	}
+	if exchange == "" {
+		exchange = "bitget"
+	}
 
 	blockers := []string{
 		"daily_trading_strategy_not_implemented",
@@ -891,6 +897,12 @@ func (h *IntegratedQuestHandlers) handleSwingTradingReadinessReview(ctx context.
 	if exchange == "" {
 		exchange = strings.TrimSpace(scalpingExchangeFromContext(ctx))
 	}
+	if exchange == "" && chatID != "" {
+		exchange = h.getUserExchange(chatID)
+	}
+	if exchange == "" {
+		exchange = "bitget"
+	}
 
 	blockers := []string{
 		"swing_trading_strategy_not_implemented",
@@ -992,14 +1004,21 @@ func writeSwingTradingReadinessEvidenceMetrics(
 	openPositions int,
 ) {
 	quest.Checkpoint["swing_trading_lifecycle_storage_verified"] = lifecycleStorageVerified
+	quest.Checkpoint["swing_trading_drawdown_verified"] = false
+	quest.Checkpoint["swing_trading_readiness_evidence_metrics_status"] = "diagnostic_placeholder"
+	if lifecycleStorageVerified {
+		quest.Checkpoint["swing_trading_readiness_evidence_metrics_status"] = "diagnostic_lifecycle"
+	}
 	quest.Checkpoint["swing_trading_readiness_evidence_metrics"] = map[string]interface{}{
-		"closed_trades":    summary.Trades,
-		"winning_trades":   summary.Wins,
-		"losing_trades":    summary.Losses,
-		"open_positions":   openPositions,
-		"net_pnl":          summary.RealizedPnL.StringFixed(2),
-		"avg_net_pnl":      summary.AvgNetPnL.StringFixed(2),
-		"max_drawdown_pct": "0.00",
+		"closed_trades":     summary.Trades,
+		"winning_trades":    summary.Wins,
+		"losing_trades":     summary.Losses,
+		"open_positions":    openPositions,
+		"net_pnl":           summary.RealizedPnL.StringFixed(2),
+		"avg_net_pnl":       summary.AvgNetPnL.StringFixed(2),
+		"max_drawdown_pct":  "0.00",
+		"drawdown_verified": false,
+		"diagnostic_only":   true,
 	}
 }
 

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -903,6 +903,14 @@ func (h *IntegratedQuestHandlers) handleSwingTradingReadinessReview(ctx context.
 	quest.Checkpoint["swing_review_window_end"] = now.Format(time.RFC3339)
 	quest.Checkpoint["swing_review_chat_id"] = chatID
 	quest.Checkpoint["swing_review_exchange"] = exchange
+	writeSwingTradingReadinessEvidenceMetrics(quest, false, LifecyclePerformanceSummary{}, 0)
+
+	if chatID == "" {
+		blockers = append(blockers, "missing_chat_id_metadata")
+		writeSwingTradingReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
 
 	if h.lifecycleStore == nil {
 		blockers = append(blockers, "lifecycle_store_unavailable")
@@ -941,6 +949,7 @@ func (h *IntegratedQuestHandlers) handleSwingTradingReadinessReview(ctx context.
 	quest.Checkpoint["swing_review_win_rate"] = summary.WinRate.String()
 	quest.Checkpoint["swing_review_open_positions"] = len(positions)
 	quest.Checkpoint["swing_review_stale_open_positions"] = staleOpenPositions
+	writeSwingTradingReadinessEvidenceMetrics(quest, true, summary, len(positions))
 
 	if summary.Trades < 2 {
 		blockers = append(blockers, "no_representative_closed_trade_sample")
@@ -974,6 +983,24 @@ func writeSwingTradingReadinessCheckpoint(quest *Quest, blockers []string) {
 	quest.Checkpoint["swing_trading_readiness_status"] = "blocked"
 	quest.Checkpoint["swing_trading_readiness_blockers"] = append([]string(nil), blockers...)
 	quest.Checkpoint["swing_trading_readiness_note"] = "swing trading has no executable strategy path or readiness evidence; keep live-money use blocked"
+}
+
+func writeSwingTradingReadinessEvidenceMetrics(
+	quest *Quest,
+	lifecycleStorageVerified bool,
+	summary LifecyclePerformanceSummary,
+	openPositions int,
+) {
+	quest.Checkpoint["swing_trading_lifecycle_storage_verified"] = lifecycleStorageVerified
+	quest.Checkpoint["swing_trading_readiness_evidence_metrics"] = map[string]interface{}{
+		"closed_trades":    summary.Trades,
+		"winning_trades":   summary.Wins,
+		"losing_trades":    summary.Losses,
+		"open_positions":   openPositions,
+		"net_pnl":          summary.RealizedPnL.StringFixed(2),
+		"avg_net_pnl":      summary.AvgNetPnL.StringFixed(2),
+		"max_drawdown_pct": "0.00",
+	}
 }
 
 func (h *IntegratedQuestHandlers) handleVolatilityWatch(ctx context.Context, quest *Quest) error {

--- a/services/backend-api/internal/services/quest_handlers_integrated_swing_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_swing_test.go
@@ -18,7 +18,6 @@ func TestExecuteRoutineSwingTradingReviewBlocksLiveReadinessWithoutStrategyProof
 		Metadata: map[string]string{
 			"definition_id": "swing_trading_review",
 			"chat_id":       "swing-chat",
-			"exchange":      "bitget",
 		},
 		Checkpoint: map[string]interface{}{},
 	}
@@ -31,6 +30,8 @@ func TestExecuteRoutineSwingTradingReviewBlocksLiveReadinessWithoutStrategyProof
 	assert.Equal(t, "swing-chat", quest.Checkpoint["swing_review_chat_id"])
 	assert.Equal(t, "bitget", quest.Checkpoint["swing_review_exchange"])
 	assert.Equal(t, false, quest.Checkpoint["swing_trading_lifecycle_storage_verified"])
+	assert.Equal(t, false, quest.Checkpoint["swing_trading_drawdown_verified"])
+	assert.Equal(t, "diagnostic_placeholder", quest.Checkpoint["swing_trading_readiness_evidence_metrics_status"])
 	assert.Equal(t, 1, quest.CurrentCount)
 
 	metrics, ok := quest.Checkpoint["swing_trading_readiness_evidence_metrics"].(map[string]interface{})
@@ -42,6 +43,8 @@ func TestExecuteRoutineSwingTradingReviewBlocksLiveReadinessWithoutStrategyProof
 	assert.Equal(t, "0.00", metrics["net_pnl"])
 	assert.Equal(t, "0.00", metrics["avg_net_pnl"])
 	assert.Equal(t, "0.00", metrics["max_drawdown_pct"])
+	assert.Equal(t, false, metrics["drawdown_verified"])
+	assert.Equal(t, true, metrics["diagnostic_only"])
 
 	blockers, ok := quest.Checkpoint["swing_trading_readiness_blockers"].([]string)
 	require.True(t, ok)
@@ -93,6 +96,7 @@ func TestExecuteRoutineSwingTradingReviewBlocksMissingChatIDBeforeLifecycleQueri
 	require.NoError(t, err)
 	assert.Equal(t, "", quest.Checkpoint["swing_review_chat_id"])
 	assert.Equal(t, false, quest.Checkpoint["swing_trading_lifecycle_storage_verified"])
+	assert.Equal(t, "diagnostic_placeholder", quest.Checkpoint["swing_trading_readiness_evidence_metrics_status"])
 	assert.Equal(t, 1, quest.CurrentCount)
 
 	metrics, ok := quest.Checkpoint["swing_trading_readiness_evidence_metrics"].(map[string]interface{})
@@ -166,6 +170,8 @@ func TestExecuteRoutineSwingTradingReviewRecordsLifecycleBlockers(t *testing.T) 
 	assert.Equal(t, 1, quest.Checkpoint["swing_review_open_positions"])
 	assert.Equal(t, 1, quest.Checkpoint["swing_review_stale_open_positions"])
 	assert.Equal(t, true, quest.Checkpoint["swing_trading_lifecycle_storage_verified"])
+	assert.Equal(t, false, quest.Checkpoint["swing_trading_drawdown_verified"])
+	assert.Equal(t, "diagnostic_lifecycle", quest.Checkpoint["swing_trading_readiness_evidence_metrics_status"])
 	assert.Equal(t, 1, quest.CurrentCount)
 
 	metrics, ok := quest.Checkpoint["swing_trading_readiness_evidence_metrics"].(map[string]interface{})
@@ -177,6 +183,8 @@ func TestExecuteRoutineSwingTradingReviewRecordsLifecycleBlockers(t *testing.T) 
 	assert.Equal(t, "-1.10", metrics["net_pnl"])
 	assert.Equal(t, "-1.10", metrics["avg_net_pnl"])
 	assert.Equal(t, "0.00", metrics["max_drawdown_pct"])
+	assert.Equal(t, false, metrics["drawdown_verified"])
+	assert.Equal(t, true, metrics["diagnostic_only"])
 
 	blockers, ok := quest.Checkpoint["swing_trading_readiness_blockers"].([]string)
 	require.True(t, ok)

--- a/services/backend-api/internal/services/quest_handlers_integrated_swing_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_swing_test.go
@@ -30,7 +30,18 @@ func TestExecuteRoutineSwingTradingReviewBlocksLiveReadinessWithoutStrategyProof
 	assert.Equal(t, "blocked", quest.Checkpoint["swing_trading_readiness_status"])
 	assert.Equal(t, "swing-chat", quest.Checkpoint["swing_review_chat_id"])
 	assert.Equal(t, "bitget", quest.Checkpoint["swing_review_exchange"])
+	assert.Equal(t, false, quest.Checkpoint["swing_trading_lifecycle_storage_verified"])
 	assert.Equal(t, 1, quest.CurrentCount)
+
+	metrics, ok := quest.Checkpoint["swing_trading_readiness_evidence_metrics"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 0, metrics["closed_trades"])
+	assert.Equal(t, 0, metrics["winning_trades"])
+	assert.Equal(t, 0, metrics["losing_trades"])
+	assert.Equal(t, 0, metrics["open_positions"])
+	assert.Equal(t, "0.00", metrics["net_pnl"])
+	assert.Equal(t, "0.00", metrics["avg_net_pnl"])
+	assert.Equal(t, "0.00", metrics["max_drawdown_pct"])
 
 	blockers, ok := quest.Checkpoint["swing_trading_readiness_blockers"].([]string)
 	require.True(t, ok)
@@ -39,6 +50,60 @@ func TestExecuteRoutineSwingTradingReviewBlocksLiveReadinessWithoutStrategyProof
 	assert.Contains(t, blockers, "no_swing_signal_engine")
 	assert.Contains(t, blockers, "missing_paper_live_market_hold_window_evidence")
 	assert.Contains(t, blockers, "lifecycle_store_unavailable")
+}
+
+func TestExecuteRoutineSwingTradingReviewBlocksMissingChatIDBeforeLifecycleQueries(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "swing-missing-chat.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, lifecycleStore.RecordClosedOrder(ctx, LifecycleCloseRecord{
+		OrderID:     "other-swing-close",
+		ChatID:      "other-chat",
+		Exchange:    "bitget",
+		Symbol:      "BTC/USDT",
+		Side:        "buy",
+		MarketType:  "spot",
+		Filled:      decimal.NewFromInt(1),
+		EntryPrice:  decimal.NewFromInt(100),
+		ExitPrice:   decimal.NewFromInt(103),
+		RealizedPnL: decimal.NewFromInt(3),
+		Fees:        decimal.New(1, -1),
+		Source:      "swing_trading",
+		ClosedAt:    time.Now().UTC().Add(-2 * time.Hour),
+	}))
+
+	handlers := &IntegratedQuestHandlers{lifecycleStore: lifecycleStore}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "swing_trading_review",
+			"chat_id":       "   ",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err = handlers.ExecuteRoutine(ctx, quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, "", quest.Checkpoint["swing_review_chat_id"])
+	assert.Equal(t, false, quest.Checkpoint["swing_trading_lifecycle_storage_verified"])
+	assert.Equal(t, 1, quest.CurrentCount)
+
+	metrics, ok := quest.Checkpoint["swing_trading_readiness_evidence_metrics"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 0, metrics["closed_trades"])
+	assert.Equal(t, "0.00", metrics["net_pnl"])
+
+	blockers, ok := quest.Checkpoint["swing_trading_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "missing_chat_id_metadata")
+	assert.NotContains(t, blockers, "lifecycle_store_unavailable")
 }
 
 func TestExecuteRoutineSwingTradingReviewRecordsLifecycleBlockers(t *testing.T) {
@@ -100,7 +165,18 @@ func TestExecuteRoutineSwingTradingReviewRecordsLifecycleBlockers(t *testing.T) 
 	assert.Equal(t, 1, quest.Checkpoint["swing_review_losses"])
 	assert.Equal(t, 1, quest.Checkpoint["swing_review_open_positions"])
 	assert.Equal(t, 1, quest.Checkpoint["swing_review_stale_open_positions"])
+	assert.Equal(t, true, quest.Checkpoint["swing_trading_lifecycle_storage_verified"])
 	assert.Equal(t, 1, quest.CurrentCount)
+
+	metrics, ok := quest.Checkpoint["swing_trading_readiness_evidence_metrics"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 1, metrics["closed_trades"])
+	assert.Equal(t, 0, metrics["winning_trades"])
+	assert.Equal(t, 1, metrics["losing_trades"])
+	assert.Equal(t, 1, metrics["open_positions"])
+	assert.Equal(t, "-1.10", metrics["net_pnl"])
+	assert.Equal(t, "-1.10", metrics["avg_net_pnl"])
+	assert.Equal(t, "0.00", metrics["max_drawdown_pct"])
 
 	blockers, ok := quest.Checkpoint["swing_trading_readiness_blockers"].([]string)
 	require.True(t, ok)


### PR DESCRIPTION
## Summary
- make swing_trading_review emit manifest-shaped readiness evidence metrics
- record lifecycle storage verification and guard blank chat_id metadata before lifecycle reads
- document why generated swing metrics remain diagnostic and cannot satisfy live readiness without drawdown proof

## Validation
- git diff --check
- go test ./internal/services -run 'TestExecuteRoutineSwingTradingReview|TestManifestLiveModeGuard'\n- go test ./internal/services\n- make lint\n- make build\n\n## Readiness note\nThis is readiness/status plumbing only. It keeps swing_trading_live_ready=false and does not approve real-money swing trading without executable swing strategy, hold-window evidence, and drawdown proof.

## Summary by Sourcery

Emit diagnostic swing trading readiness evidence metrics and guard swing readiness review when chat metadata is missing.

New Features:
- Add manifest-shaped swing trading readiness evidence metrics to the swing review checkpoint, including lifecycle and drawdown status flags.

Bug Fixes:
- Normalize chat metadata usage across handlers by trimming whitespace and treating blank chat IDs as missing, preventing invalid monitoring and lifecycle queries.

Enhancements:
- Fallback to a user exchange lookup and default exchange when swing and daily trading reviews lack explicit exchange metadata.
- Refine swing trading readiness review flow to short-circuit and record blockers when required chat metadata is absent.

Documentation:
- Document the new swing trading readiness evidence metrics fields and clarify that they remain diagnostic-only until real drawdown proof exists.

Tests:
- Extend integrated swing trading tests to cover readiness evidence metric emission, lifecycle verification flags, and handling of missing chat ID metadata.