### PR TITLE
Emit arbitrage readiness evidence metrics

### DIFF
--- a/services/backend-api/docs/ARBITRAGE_READINESS.md
+++ b/services/backend-api/docs/ARBITRAGE_READINESS.md
@@ -9,12 +9,30 @@ mistaken for real-money proof. It always writes:
 - `arbitrage_live_ready=false`
 - `arbitrage_readiness_status=blocked`
 - `arbitrage_readiness_blockers`
+- `arbitrage_lifecycle_storage_verified`
+- `arbitrage_readiness_evidence_metrics`
 - `arbitrage_no_trade_safety=false`
 
 The review captures lifecycle context over the previous 7 days, including
 closed opportunities, wins, losses, net PnL, average net PnL, fees, open
 positions, and inventory/exposure blockers. These metrics are diagnostic only
 until the arbitrage execution path has realistic market evidence.
+
+`arbitrage_readiness_evidence_metrics` mirrors the manifest proof fields:
+
+- `closed_trades`
+- `winning_trades`
+- `losing_trades`
+- `open_positions`
+- `net_pnl`
+- `avg_net_pnl`
+- `max_drawdown_pct`
+- `no_trade_safety`
+- `no_trade_reason`
+
+`max_drawdown_pct` remains `0.00` and `no_trade_safety` remains false until a
+real arbitrage exposure verifier or no-trade safety window supplies proof, so
+the generated metrics cannot satisfy the live-readiness manifest by accident.
 
 Minimum proof before the live-readiness manifest can mark `arbitrage` ready:
 

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -1167,6 +1167,11 @@ func (h *IntegratedQuestHandlers) handleArbitrageReadinessReview(ctx context.Con
 		quest.CurrentCount++
 		return nil
 	}
+	if exchange == "" {
+		blockers = append(blockers, "missing_exchange_metadata")
+		writeArbitrageReadinessCheckpoint(quest, blockers)
+		return fmt.Errorf("arbitrage readiness review: missing exchange metadata for chat_id %q", chatID)
+	}
 
 	if h.orderExecutor == nil {
 		blockers = append(blockers, "order_executor_unavailable")

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -1159,6 +1159,14 @@ func (h *IntegratedQuestHandlers) handleArbitrageReadinessReview(ctx context.Con
 	quest.Checkpoint["arbitrage_review_exchange"] = exchange
 	quest.Checkpoint["arbitrage_no_trade_safety"] = false
 	quest.Checkpoint["arbitrage_no_trade_reason"] = ""
+	writeArbitrageReadinessEvidenceMetrics(quest, false, LifecyclePerformanceSummary{}, 0)
+
+	if chatID == "" {
+		blockers = append(blockers, "missing_chat_id_metadata")
+		writeArbitrageReadinessCheckpoint(quest, blockers)
+		quest.CurrentCount++
+		return nil
+	}
 
 	if h.orderExecutor == nil {
 		blockers = append(blockers, "order_executor_unavailable")
@@ -1192,6 +1200,7 @@ func (h *IntegratedQuestHandlers) handleArbitrageReadinessReview(ctx context.Con
 	quest.Checkpoint["arbitrage_review_avg_net_pnl"] = summary.AvgNetPnL.String()
 	quest.Checkpoint["arbitrage_review_win_rate"] = summary.WinRate.String()
 	quest.Checkpoint["arbitrage_review_open_positions"] = len(positions)
+	writeArbitrageReadinessEvidenceMetrics(quest, true, summary, len(positions))
 
 	if summary.Trades < 2 {
 		blockers = append(blockers, "no_representative_closed_opportunity_sample")
@@ -1222,6 +1231,26 @@ func writeArbitrageReadinessCheckpoint(quest *Quest, blockers []string) {
 	quest.Checkpoint["arbitrage_readiness_status"] = "blocked"
 	quest.Checkpoint["arbitrage_readiness_blockers"] = append([]string(nil), blockers...)
 	quest.Checkpoint["arbitrage_readiness_note"] = "arbitrage has no executable real-market proof or documented no-trade safety window; keep live-money use blocked"
+}
+
+func writeArbitrageReadinessEvidenceMetrics(
+	quest *Quest,
+	lifecycleStorageVerified bool,
+	summary LifecyclePerformanceSummary,
+	openPositions int,
+) {
+	quest.Checkpoint["arbitrage_lifecycle_storage_verified"] = lifecycleStorageVerified
+	quest.Checkpoint["arbitrage_readiness_evidence_metrics"] = map[string]interface{}{
+		"closed_trades":    summary.Trades,
+		"winning_trades":   summary.Wins,
+		"losing_trades":    summary.Losses,
+		"open_positions":   openPositions,
+		"net_pnl":          summary.RealizedPnL.StringFixed(2),
+		"avg_net_pnl":      summary.AvgNetPnL.StringFixed(2),
+		"max_drawdown_pct": "0.00",
+		"no_trade_safety":  false,
+		"no_trade_reason":  "",
+	}
 }
 
 // handlePortfolioHealthWithRisk checks portfolio health with risk management

--- a/services/backend-api/internal/services/quest_handlers_integrated_arbitrage_readiness_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_arbitrage_readiness_test.go
@@ -113,6 +113,39 @@ func TestExecuteRoutineArbitrageReadinessReviewBlocksMissingChatIDBeforeLifecycl
 	assert.NotContains(t, blockers, "lifecycle_store_unavailable")
 }
 
+func TestExecuteRoutineArbitrageReadinessReviewRequiresExchangeMetadata(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "arbitrage-missing-exchange.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	handlers := &IntegratedQuestHandlers{lifecycleStore: lifecycleStore}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "arbitrage_readiness_review",
+			"chat_id":       "arb-chat",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err = handlers.ExecuteRoutine(ctx, quest)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `missing exchange metadata for chat_id "arb-chat"`)
+	assert.Equal(t, "", quest.Checkpoint["arbitrage_review_exchange"])
+	assert.Equal(t, false, quest.Checkpoint["arbitrage_lifecycle_storage_verified"])
+	assert.Equal(t, 0, quest.CurrentCount)
+
+	blockers, ok := quest.Checkpoint["arbitrage_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "missing_exchange_metadata")
+	assert.NotContains(t, blockers, "lifecycle_store_unavailable")
+}
+
 func TestExecuteRoutineArbitrageReadinessReviewRecordsLifecycleBlockers(t *testing.T) {
 	ctx := context.Background()
 	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "arbitrage-readiness.db"))

--- a/services/backend-api/internal/services/quest_handlers_integrated_arbitrage_readiness_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_arbitrage_readiness_test.go
@@ -33,7 +33,20 @@ func TestExecuteRoutineArbitrageReadinessReviewBlocksLiveReadinessWithoutProof(t
 	assert.Equal(t, "bitget", quest.Checkpoint["arbitrage_review_exchange"])
 	assert.Equal(t, false, quest.Checkpoint["arbitrage_no_trade_safety"])
 	assert.Equal(t, "", quest.Checkpoint["arbitrage_no_trade_reason"])
+	assert.Equal(t, false, quest.Checkpoint["arbitrage_lifecycle_storage_verified"])
 	assert.Equal(t, 0, quest.CurrentCount)
+
+	metrics, ok := quest.Checkpoint["arbitrage_readiness_evidence_metrics"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 0, metrics["closed_trades"])
+	assert.Equal(t, 0, metrics["winning_trades"])
+	assert.Equal(t, 0, metrics["losing_trades"])
+	assert.Equal(t, 0, metrics["open_positions"])
+	assert.Equal(t, "0.00", metrics["net_pnl"])
+	assert.Equal(t, "0.00", metrics["avg_net_pnl"])
+	assert.Equal(t, "0.00", metrics["max_drawdown_pct"])
+	assert.Equal(t, false, metrics["no_trade_safety"])
+	assert.Equal(t, "", metrics["no_trade_reason"])
 
 	blockers, ok := quest.Checkpoint["arbitrage_readiness_blockers"].([]string)
 	require.True(t, ok)
@@ -44,6 +57,60 @@ func TestExecuteRoutineArbitrageReadinessReviewBlocksLiveReadinessWithoutProof(t
 	assert.Contains(t, blockers, "missing_no_trade_safety_window")
 	assert.Contains(t, blockers, "order_executor_unavailable")
 	assert.Contains(t, blockers, "lifecycle_store_unavailable")
+}
+
+func TestExecuteRoutineArbitrageReadinessReviewBlocksMissingChatIDBeforeLifecycleQueries(t *testing.T) {
+	ctx := context.Background()
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "arbitrage-missing-chat.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+	lifecycleStore, err := NewTradingLifecycleStore(sqliteDB, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, lifecycleStore.RecordClosedOrder(ctx, LifecycleCloseRecord{
+		OrderID:     "other-arb-close",
+		ChatID:      "other-chat",
+		Exchange:    "bitget",
+		Symbol:      "BTC/USDT",
+		Side:        "buy",
+		MarketType:  "spot",
+		Filled:      decimal.NewFromInt(1),
+		EntryPrice:  decimal.NewFromInt(100),
+		ExitPrice:   decimal.NewFromInt(103),
+		RealizedPnL: decimal.NewFromInt(3),
+		Fees:        decimal.New(1, -1),
+		Source:      "arbitrage",
+		ClosedAt:    time.Now().UTC().Add(-2 * time.Hour),
+	}))
+
+	handlers := &IntegratedQuestHandlers{lifecycleStore: lifecycleStore}
+	quest := &Quest{
+		Metadata: map[string]string{
+			"definition_id": "arbitrage_readiness_review",
+			"chat_id":       "   ",
+			"exchange":      "bitget",
+		},
+		Checkpoint: map[string]interface{}{},
+	}
+
+	err = handlers.ExecuteRoutine(ctx, quest)
+
+	require.NoError(t, err)
+	assert.Equal(t, "", quest.Checkpoint["arbitrage_review_chat_id"])
+	assert.Equal(t, false, quest.Checkpoint["arbitrage_lifecycle_storage_verified"])
+	assert.Equal(t, 1, quest.CurrentCount)
+
+	metrics, ok := quest.Checkpoint["arbitrage_readiness_evidence_metrics"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 0, metrics["closed_trades"])
+	assert.Equal(t, "0.00", metrics["net_pnl"])
+
+	blockers, ok := quest.Checkpoint["arbitrage_readiness_blockers"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, blockers, "missing_chat_id_metadata")
+	assert.NotContains(t, blockers, "lifecycle_store_unavailable")
 }
 
 func TestExecuteRoutineArbitrageReadinessReviewRecordsLifecycleBlockers(t *testing.T) {
@@ -104,7 +171,20 @@ func TestExecuteRoutineArbitrageReadinessReviewRecordsLifecycleBlockers(t *testi
 	assert.Equal(t, 0, quest.Checkpoint["arbitrage_review_wins"])
 	assert.Equal(t, 1, quest.Checkpoint["arbitrage_review_losses"])
 	assert.Equal(t, 1, quest.Checkpoint["arbitrage_review_open_positions"])
+	assert.Equal(t, true, quest.Checkpoint["arbitrage_lifecycle_storage_verified"])
 	assert.Equal(t, 1, quest.CurrentCount)
+
+	metrics, ok := quest.Checkpoint["arbitrage_readiness_evidence_metrics"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 1, metrics["closed_trades"])
+	assert.Equal(t, 0, metrics["winning_trades"])
+	assert.Equal(t, 1, metrics["losing_trades"])
+	assert.Equal(t, 1, metrics["open_positions"])
+	assert.Equal(t, "-1.20", metrics["net_pnl"])
+	assert.Equal(t, "-1.20", metrics["avg_net_pnl"])
+	assert.Equal(t, "0.00", metrics["max_drawdown_pct"])
+	assert.Equal(t, false, metrics["no_trade_safety"])
+	assert.Equal(t, "", metrics["no_trade_reason"])
 
 	blockers, ok := quest.Checkpoint["arbitrage_readiness_blockers"].([]string)
 	require.True(t, ok)


### PR DESCRIPTION
## Summary
- make arbitrage_readiness_review emit manifest-shaped readiness evidence metrics
- record lifecycle storage verification and guard blank chat_id metadata before lifecycle reads
- document why generated arbitrage metrics remain diagnostic and cannot satisfy live readiness without exposure or no-trade proof

## Validation
- git diff --check
- go test ./internal/services -run 'TestExecuteRoutineArbitrageReadinessReview|TestManifestLiveModeGuard'\n- go test ./internal/services\n- make lint\n- make build\n\n## Readiness note\nThis is readiness/status plumbing only. It keeps arbitrage_live_ready=false and does not approve real-money arbitrage without executable spread/funding proof, realistic cost accounting, exposure safety, and either representative lifecycle evidence or documented no-trade safety.

## Summary by Sourcery

Emit arbitrage readiness evidence metrics alongside lifecycle verification status and tighten metadata requirements for arbitrage readiness reviews.

New Features:
- Record manifest-shaped arbitrage readiness evidence metrics on readiness review checkpoints, including trade counts, PnL, and safety fields.

Bug Fixes:
- Guard against missing or blank chat_id metadata and missing exchange metadata before querying lifecycle storage during arbitrage readiness reviews.

Enhancements:
- Track and expose whether arbitrage lifecycle storage has been successfully verified as part of the readiness review checkpoint.

Documentation:
- Document the new arbitrage readiness checkpoint fields, their diagnostic nature, and why they cannot by themselves satisfy live readiness requirements.

Tests:
- Extend integrated arbitrage readiness tests to cover evidence metrics emission, lifecycle verification status, and error/blocker behavior for missing metadata.