### PR TITLE
Emit scalping acceptance evidence metrics

### DIFF
--- a/services/backend-api/docs/SCALPING_SOAK_ACCEPTANCE.md
+++ b/services/backend-api/docs/SCALPING_SOAK_ACCEPTANCE.md
@@ -63,6 +63,22 @@ The acceptance wrapper performs runtime health preflight, writes timestamped
 artifact and SQLite evidence paths, runs the artifact verifier, and emits a
 small `.acceptance.json` manifest next to the soak artifact.
 
+The acceptance manifest includes a non-authorizing
+`live_readiness.manifest_entry` block for the `scalping` strategy. It mirrors
+the `NEURATRADE_LIVE_READINESS_MANIFEST` evidence shape:
+
+- `closed_trades`
+- `winning_trades`
+- `losing_trades`
+- `open_positions`
+- `net_pnl`
+- `avg_net_pnl`
+- `max_drawdown_pct`
+
+The generated entry always keeps `ready=false`; operators must still review the
+full proof window before copying or promoting the evidence into the live
+readiness manifest.
+
 For manual runs, use the same defaults explicitly:
 
 ```bash
@@ -99,20 +115,20 @@ Record the verifier output and these artifact fields in the tracking issue:
 
 ```bash
 jq -r '
-  .result.report
-  | {
-      total_cycles,
-      action_split,
-      regime_split,
-      rejection_by_reason,
-      gate_block_by_code,
-      signal_quality,
-      trade_summary,
-      ai_provider_degradation,
-      baseline_comparison,
-      insufficient_trade_proof
-    }
-' "$SOAK_OUTPUT_FILE"
+  {
+    live_readiness,
+    total_cycles: .report.total_cycles,
+    action_split: .report.action_split,
+    regime_split: .report.regime_split,
+    rejection_by_reason: .report.rejection_by_reason,
+    gate_block_by_code: .report.gate_block_by_code,
+    signal_quality: .report.signal_quality,
+    trade_summary: .report.trade_summary,
+    ai_provider_degradation: .report.ai_provider_degradation,
+    baseline_comparison: .report.baseline_comparison,
+    insufficient_trade_proof: .report.insufficient_trade_proof
+  }
+' "${SOAK_OUTPUT_FILE%.json}.acceptance.json"
 ```
 
 Also verify persistence if the verifier did not already check the DB path:

--- a/services/backend-api/scripts/scalping-soak-acceptance.sh
+++ b/services/backend-api/scripts/scalping-soak-acceptance.sh
@@ -176,6 +176,25 @@ write_manifest() {
         min_baseline_net_pnl_delta: env.MIN_BASELINE_NET_PNL_DELTA,
         min_baseline_avg_pnl_delta: env.MIN_BASELINE_AVG_PNL_DELTA
       },
+      live_readiness: {
+        strategy: "scalping",
+        metrics_status: "verified_artifact_diagnostic",
+        note: "ready remains false until an operator references this evidence from NEURATRADE_LIVE_READINESS_MANIFEST after confirming the full live-readiness proof window",
+        manifest_entry: {
+          ready: false,
+          evidence: $artifact,
+          reason: "scalping acceptance evidence generated; operator review and live-readiness manifest promotion still required",
+          evidence_metrics: {
+            closed_trades: ($report.trade_summary.closed_trades // 0),
+            winning_trades: ($report.trade_summary.wins // 0),
+            losing_trades: ($report.trade_summary.losses // 0),
+            open_positions: 0,
+            net_pnl: (($report.trade_summary.net_pnl // "0") | tostring),
+            avg_net_pnl: (($report.trade_summary.avg_net_pnl_per_trade // "0") | tostring),
+            max_drawdown_pct: (($report.trade_summary.max_drawdown_pct // "0") | tostring)
+          }
+        }
+      },
       report: {
         total_cycles: $report.total_cycles,
         action_split: $report.action_split,

--- a/services/backend-api/scripts/scalping-soak-acceptance_test.sh
+++ b/services/backend-api/scripts/scalping-soak-acceptance_test.sh
@@ -187,6 +187,17 @@ jq -e \
     and .evidence.db_path == $db_path
     and .evidence.log_file == $log_file
     and .gates.max_hold_ratio == "0.745"
+    and .live_readiness.strategy == "scalping"
+    and .live_readiness.metrics_status == "verified_artifact_diagnostic"
+    and .live_readiness.manifest_entry.ready == false
+    and .live_readiness.manifest_entry.evidence == $artifact
+    and .live_readiness.manifest_entry.evidence_metrics.closed_trades == 1
+    and .live_readiness.manifest_entry.evidence_metrics.winning_trades == 1
+    and .live_readiness.manifest_entry.evidence_metrics.losing_trades == 0
+    and .live_readiness.manifest_entry.evidence_metrics.open_positions == 0
+    and .live_readiness.manifest_entry.evidence_metrics.net_pnl == "0.1"
+    and .live_readiness.manifest_entry.evidence_metrics.avg_net_pnl == "0.1"
+    and .live_readiness.manifest_entry.evidence_metrics.max_drawdown_pct == "0"
     and .report.rejection_by_reason.no_directional_edge == 1
     and .report.trade_summary.closed_trades == 1
     and .report.insufficient_trade_proof == false' \
@@ -228,6 +239,13 @@ jq -e \
     and .evidence.db_path == $db_path
     and .evidence.log_file == $log_file
     and .gates.max_hold_ratio == "0.745"
+    and .live_readiness.strategy == "scalping"
+    and .live_readiness.manifest_entry.ready == false
+    and .live_readiness.manifest_entry.evidence == $artifact
+    and .live_readiness.manifest_entry.evidence_metrics.closed_trades == 1
+    and .live_readiness.manifest_entry.evidence_metrics.winning_trades == 1
+    and .live_readiness.manifest_entry.evidence_metrics.losing_trades == 0
+    and .live_readiness.manifest_entry.evidence_metrics.open_positions == 0
     and .report.rejection_by_reason.no_directional_edge == 1
     and .report.trade_summary.closed_trades == 1
     and .report.insufficient_trade_proof == false' \


### PR DESCRIPTION
## Summary
- add a non-authorizing `live_readiness.manifest_entry` block to scalping soak acceptance manifests
- expose manifest-shaped scalping evidence metrics for operator review while keeping `ready=false`
- document the acceptance manifest fields and update tests for the generated metrics

## Validation
- `rtk git diff --check`
- `rtk bash services/backend-api/scripts/scalping-soak-acceptance_test.sh`
- `rtk bash services/backend-api/scripts/verify-scalping-soak-artifact_test.sh`
- `rtk make test-scripts`
- `rtk make lint`
- `rtk make build`

## Summary by Sourcery

Emit non-authorizing scalping live readiness manifest entries in acceptance artifacts with evidence metrics for operator review while keeping readiness false.

Enhancements:
- Augment the scalping soak acceptance manifest with a live_readiness section that surfaces trade evidence metrics without changing readiness state.
- Adjust acceptance manifest generation to output a manifest-focused JSON structure including live_readiness alongside summarized report fields.

Documentation:
- Document the scalping acceptance manifest live_readiness block and its evidence metrics shape in the scalping soak acceptance guide.

Tests:
- Extend scalping soak acceptance tests to validate the new live_readiness manifest fields and evidence metrics in the acceptance manifest.