### PR TITLE
Verify scalping acceptance open positions

### DIFF
--- a/services/backend-api/docs/SCALPING_SOAK_ACCEPTANCE.md
+++ b/services/backend-api/docs/SCALPING_SOAK_ACCEPTANCE.md
@@ -77,7 +77,10 @@ the `NEURATRADE_LIVE_READINESS_MANIFEST` evidence shape:
 
 The generated entry always keeps `ready=false`; operators must still review the
 full proof window before copying or promoting the evidence into the live
-readiness manifest.
+readiness manifest. `open_positions` is sourced from the retained
+`SOAK_DB_PATH` SQLite `trading_positions` rows with status `open`, `pending`, or
+`partial`; the wrapper fails instead of emitting a manifest if lifecycle
+position evidence is unavailable.
 
 For manual runs, use the same defaults explicitly:
 

--- a/services/backend-api/scripts/scalping-soak-acceptance.sh
+++ b/services/backend-api/scripts/scalping-soak-acceptance.sh
@@ -73,7 +73,7 @@ USAGE
 
 log() {
   mkdir -p "$LOG_DIR"
-  printf '[%s] [SCALPING-SOAK-ACCEPTANCE] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" | tee -a "$LOG_FILE"
+  printf '[%s] [SCALPING-SOAK-ACCEPTANCE] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" | tee -a "$LOG_FILE" >&2
 }
 
 fail() {
@@ -83,6 +83,26 @@ fail() {
 
 require_file() {
   [ -f "$1" ] || fail "required file not found: $1"
+}
+
+query_open_positions() {
+  command -v sqlite3 >/dev/null 2>&1 || fail "sqlite3 is required to verify open positions"
+  require_file "$SOAK_DB_PATH"
+
+  local has_table
+  has_table="$(sqlite3 -noheader -list "$SOAK_DB_PATH" "select count(*) from sqlite_master where type = 'table' and name = 'trading_positions';")" \
+    || fail "failed to inspect trading_positions table in ${SOAK_DB_PATH}"
+  [ "$has_table" = "1" ] || fail "trading_positions table missing from ${SOAK_DB_PATH}; cannot prove open_positions"
+
+  local open_positions
+  open_positions="$(sqlite3 -noheader -list "$SOAK_DB_PATH" "select count(*) from trading_positions where lower(coalesce(status, '')) in ('open', 'pending', 'partial');")" \
+    || fail "failed to query open trading_positions in ${SOAK_DB_PATH}"
+  case "$open_positions" in
+    '' | *[!0-9]*)
+      fail "open position count from ${SOAK_DB_PATH} is not numeric: \"${open_positions}\""
+      ;;
+  esac
+  printf '%s\n' "$open_positions"
 }
 
 validate_boolean() {
@@ -131,9 +151,11 @@ write_manifest() {
   local git_branch
   local git_commit
   local git_status
+  local open_positions
   git_branch="$(git_value unknown rev-parse --abbrev-ref HEAD)"
   git_commit="$(git_value unknown rev-parse HEAD)"
   git_status="$(git_value unknown status --short --branch)"
+  open_positions="$(query_open_positions)"
 
   mkdir -p "$(dirname "$ACCEPTANCE_MANIFEST_FILE")"
   jq -n \
@@ -145,6 +167,7 @@ write_manifest() {
     --arg artifact "$SOAK_OUTPUT_FILE" \
     --arg db_path "$SOAK_DB_PATH" \
     --arg log_file "$LOG_FILE" \
+    --argjson open_positions "$open_positions" \
     --argjson report "$(jq '.result.report' "$SOAK_OUTPUT_FILE")" \
     '{
       created_at: $created_at,
@@ -179,6 +202,7 @@ write_manifest() {
       live_readiness: {
         strategy: "scalping",
         metrics_status: "verified_artifact_diagnostic",
+        open_positions_source: "SOAK_DB_PATH trading_positions rows with status open, pending, or partial",
         note: "ready remains false until an operator references this evidence from NEURATRADE_LIVE_READINESS_MANIFEST after confirming the full live-readiness proof window",
         manifest_entry: {
           ready: false,
@@ -188,7 +212,7 @@ write_manifest() {
             closed_trades: ($report.trade_summary.closed_trades // 0),
             winning_trades: ($report.trade_summary.wins // 0),
             losing_trades: ($report.trade_summary.losses // 0),
-            open_positions: 0,
+            open_positions: $open_positions,
             net_pnl: (($report.trade_summary.net_pnl // "0") | tostring),
             avg_net_pnl: (($report.trade_summary.avg_net_pnl_per_trade // "0") | tostring),
             max_drawdown_pct: (($report.trade_summary.max_drawdown_pct // "0") | tostring)

--- a/services/backend-api/scripts/scalping-soak-acceptance_test.sh
+++ b/services/backend-api/scripts/scalping-soak-acceptance_test.sh
@@ -13,6 +13,7 @@ require_binary() {
 }
 
 require_binary jq
+require_binary sqlite3
 
 tmp_dir="$(mktemp -d /tmp/neuratrade-scalping-acceptance-test.XXXXXX)"
 trap 'rm -rf "$tmp_dir"' EXIT
@@ -58,7 +59,16 @@ expected_max_hold_ratio="${EXPECTED_MAX_HOLD_RATIO-0.745}"
 }
 
 mkdir -p "$(dirname "$SOAK_OUTPUT_FILE")" "$(dirname "$SOAK_DB_PATH")"
-: >"$SOAK_DB_PATH"
+sqlite3 "$SOAK_DB_PATH" <<SQL
+CREATE TABLE trading_positions (
+  position_id TEXT PRIMARY KEY,
+  status TEXT
+);
+SQL
+if [ "${FAKE_OPEN_POSITIONS:-1}" != "0" ]; then
+  sqlite3 "$SOAK_DB_PATH" "INSERT INTO trading_positions(position_id, status) VALUES ('open-position-1', 'open');"
+fi
+sqlite3 "$SOAK_DB_PATH" "INSERT INTO trading_positions(position_id, status) VALUES ('closed-position-1', 'closed');"
 jq -n --arg db_path "$SOAK_DB_PATH" '{
   db_path: $db_path,
   result: {
@@ -189,12 +199,13 @@ jq -e \
     and .gates.max_hold_ratio == "0.745"
     and .live_readiness.strategy == "scalping"
     and .live_readiness.metrics_status == "verified_artifact_diagnostic"
+    and .live_readiness.open_positions_source == "SOAK_DB_PATH trading_positions rows with status open, pending, or partial"
     and .live_readiness.manifest_entry.ready == false
     and .live_readiness.manifest_entry.evidence == $artifact
     and .live_readiness.manifest_entry.evidence_metrics.closed_trades == 1
     and .live_readiness.manifest_entry.evidence_metrics.winning_trades == 1
     and .live_readiness.manifest_entry.evidence_metrics.losing_trades == 0
-    and .live_readiness.manifest_entry.evidence_metrics.open_positions == 0
+    and .live_readiness.manifest_entry.evidence_metrics.open_positions == 1
     and .live_readiness.manifest_entry.evidence_metrics.net_pnl == "0.1"
     and .live_readiness.manifest_entry.evidence_metrics.avg_net_pnl == "0.1"
     and .live_readiness.manifest_entry.evidence_metrics.max_drawdown_pct == "0"
@@ -209,6 +220,7 @@ env -u RUN_HEALTH_PREFLIGHT -u CHECK_GATEWAY_STATUS -u BACKEND_URL \
   GATEWAY_BIN="$fake_gateway" \
   SCALPING_SOAK_SCRIPT="$fake_soak" \
   SCALPING_SOAK_VERIFIER="$fake_verifier" \
+  FAKE_OPEN_POSITIONS=0 \
   DATA_DIR="${tmp_dir}/default-evidence" \
   LOG_DIR="${tmp_dir}/default-logs" \
   STAMP=default \
@@ -240,6 +252,7 @@ jq -e \
     and .evidence.log_file == $log_file
     and .gates.max_hold_ratio == "0.745"
     and .live_readiness.strategy == "scalping"
+    and .live_readiness.open_positions_source == "SOAK_DB_PATH trading_positions rows with status open, pending, or partial"
     and .live_readiness.manifest_entry.ready == false
     and .live_readiness.manifest_entry.evidence == $artifact
     and .live_readiness.manifest_entry.evidence_metrics.closed_trades == 1
@@ -260,6 +273,7 @@ RUN_HEALTH_PREFLIGHT=false \
   EXPECTED_MAX_HOLD_RATIO= \
   SCALPING_SOAK_SCRIPT="$fake_soak" \
   SCALPING_SOAK_VERIFIER="$fake_verifier" \
+  FAKE_OPEN_POSITIONS=0 \
   DATA_DIR="${tmp_dir}/empty-gate-evidence" \
   LOG_DIR="${tmp_dir}/empty-gate-logs" \
   STAMP=empty-gate \


### PR DESCRIPTION
## Summary
- make scalping soak acceptance manifests query open positions from the retained SQLite `trading_positions` lifecycle table
- fail closed when lifecycle position evidence is missing instead of emitting an unproven zero
- document the `open_positions` source and cover zero/nonzero cases in the wrapper test

## Validation
- `rtk git diff --check`
- `rtk bash services/backend-api/scripts/scalping-soak-acceptance_test.sh`
- `rtk bash services/backend-api/scripts/verify-scalping-soak-artifact_test.sh`
- `rtk make test-scripts`
- `rtk make lint`
- `rtk make build`

## Summary by Sourcery

Verify scalping soak acceptance manifests against the retained SQLite trading_positions lifecycle table and surface the proven open position count in the generated live-readiness evidence.

New Features:
- Add querying of open trading positions from the retained SQLite trading_positions lifecycle table into scalping soak acceptance manifests.
- Expose the source of the open_positions metric in the live_readiness section of the scalping soak acceptance manifest.

Bug Fixes:
- Fail manifest generation when lifecycle position evidence is missing or invalid instead of emitting an unproven open_positions value.

Enhancements:
- Route scalping soak acceptance logging to stderr while still teeing to the log file.
- Extend the scalping soak acceptance wrapper tests to cover zero and nonzero open_positions scenarios and assert the documented open_positions source.

Documentation:
- Document how open_positions is derived for scalping soak acceptance, including failure behavior when lifecycle position evidence is unavailable.