### PR TITLE
Require zero open positions for scalping acceptance

### DIFF
--- a/services/backend-api/docs/SCALPING_SOAK_ACCEPTANCE.md
+++ b/services/backend-api/docs/SCALPING_SOAK_ACCEPTANCE.md
@@ -80,7 +80,7 @@ full proof window before copying or promoting the evidence into the live
 readiness manifest. `open_positions` is sourced from the retained
 `SOAK_DB_PATH` SQLite `trading_positions` rows with status `open`, `pending`, or
 `partial`; the wrapper fails instead of emitting a manifest if lifecycle
-position evidence is unavailable.
+position evidence is unavailable or any such open lifecycle positions remain.
 
 For manual runs, use the same defaults explicitly:
 

--- a/services/backend-api/scripts/scalping-soak-acceptance.sh
+++ b/services/backend-api/scripts/scalping-soak-acceptance.sh
@@ -156,6 +156,8 @@ write_manifest() {
   git_commit="$(git_value unknown rev-parse HEAD)"
   git_status="$(git_value unknown status --short --branch)"
   open_positions="$(query_open_positions)"
+  [ "$open_positions" = "0" ] \
+    || fail "open_positions='${open_positions}'; scalping acceptance requires zero open lifecycle positions"
 
   mkdir -p "$(dirname "$ACCEPTANCE_MANIFEST_FILE")"
   jq -n \

--- a/services/backend-api/scripts/scalping-soak-acceptance_test.sh
+++ b/services/backend-api/scripts/scalping-soak-acceptance_test.sh
@@ -35,6 +35,7 @@ empty_artifact_path="${tmp_dir}/empty-gate-evidence/scalping-soak-acceptance-emp
 empty_manifest_path="${tmp_dir}/empty-gate-evidence/scalping-soak-acceptance-empty-gate.acceptance.json"
 empty_log_path="${tmp_dir}/empty-gate-logs/acceptance.log"
 invalid_output="${tmp_dir}/invalid.out"
+open_positions_output="${tmp_dir}/open-positions.out"
 
 cat >"$fake_soak" <<'SH'
 #!/usr/bin/env bash
@@ -167,6 +168,7 @@ RUN_HEALTH_PREFLIGHT=false \
   CHECK_GATEWAY_STATUS=false \
   SCALPING_SOAK_SCRIPT="$fake_soak" \
   SCALPING_SOAK_VERIFIER="$fake_verifier" \
+  FAKE_OPEN_POSITIONS=0 \
   DATA_DIR="${tmp_dir}/evidence" \
   LOG_DIR="${tmp_dir}/logs" \
   STAMP=fixed \
@@ -205,7 +207,7 @@ jq -e \
     and .live_readiness.manifest_entry.evidence_metrics.closed_trades == 1
     and .live_readiness.manifest_entry.evidence_metrics.winning_trades == 1
     and .live_readiness.manifest_entry.evidence_metrics.losing_trades == 0
-    and .live_readiness.manifest_entry.evidence_metrics.open_positions == 1
+    and .live_readiness.manifest_entry.evidence_metrics.open_positions == 0
     and .live_readiness.manifest_entry.evidence_metrics.net_pnl == "0.1"
     and .live_readiness.manifest_entry.evidence_metrics.avg_net_pnl == "0.1"
     and .live_readiness.manifest_entry.evidence_metrics.max_drawdown_pct == "0"
@@ -290,6 +292,24 @@ RUN_HEALTH_PREFLIGHT=false \
 }
 
 jq -e '.gates.max_hold_ratio == ""' "$empty_manifest_path" >/dev/null
+
+if RUN_HEALTH_PREFLIGHT=false \
+  CHECK_GATEWAY_STATUS=false \
+  SCALPING_SOAK_SCRIPT="$fake_soak" \
+  SCALPING_SOAK_VERIFIER="$fake_verifier" \
+  DATA_DIR="${tmp_dir}/open-position-evidence" \
+  LOG_DIR="${tmp_dir}/open-position-logs" \
+  STAMP=open-position \
+  bash "$ACCEPTANCE_SCRIPT" run >"$open_positions_output" 2>&1; then
+  echo "expected open lifecycle positions to fail acceptance" >&2
+  exit 1
+fi
+
+grep -q "open_positions='1'; scalping acceptance requires zero open lifecycle positions" "$open_positions_output"
+[ ! -f "${tmp_dir}/open-position-evidence/scalping-soak-acceptance-open-position.acceptance.json" ] || {
+  echo "open-position failure should not write acceptance manifest" >&2
+  exit 1
+}
 
 if RUN_HEALTH_PREFLIGHT=treu \
   CHECK_GATEWAY_STATUS=false \


### PR DESCRIPTION
## Summary
- fail scalping soak acceptance before manifest emission when retained lifecycle evidence shows open/pending/partial positions
- keep acceptance manifests limited to zero-open-position evidence
- document the zero-open-position requirement and cover the failure path in the wrapper test

## Validation
- `rtk git diff --check`
- `rtk bash services/backend-api/scripts/scalping-soak-acceptance_test.sh`
- `rtk bash services/backend-api/scripts/verify-scalping-soak-artifact_test.sh`
- `rtk make test-scripts`
- `rtk make lint`
- `rtk make build`

## Summary by Sourcery

Enforce that scalping soak acceptance only succeeds when there are zero open lifecycle positions and ensure this constraint is documented and test-covered.

Bug Fixes:
- Prevent scalping soak acceptance from emitting manifests when retained lifecycle evidence shows any open, pending, or partial positions.

Enhancements:
- Add a hard check in the scalping soak acceptance wrapper to require zero open lifecycle positions before writing an acceptance manifest.

Documentation:
- Document the requirement that scalping soak acceptance only passes when lifecycle evidence exists and there are no remaining open positions.

Tests:
- Extend the scalping soak acceptance wrapper tests to cover the zero-open-positions requirement and the failure path without manifest emission.