### PR TITLE
Mark daily readiness metrics diagnostic

### DIFF
--- a/services/backend-api/docs/DAILY_TRADING_READINESS.md
+++ b/services/backend-api/docs/DAILY_TRADING_READINESS.md
@@ -8,6 +8,8 @@ instead of failing as an unknown routine. It always writes:
 - `daily_trading_live_ready=false`
 - `daily_trading_readiness_status=blocked`
 - `daily_trading_lifecycle_storage_verified`
+- `daily_trading_drawdown_verified=false`
+- `daily_trading_readiness_evidence_metrics_status`
 - `daily_trading_readiness_evidence_metrics`
 - `daily_trading_readiness_blockers`
 
@@ -27,7 +29,10 @@ executable daily strategy path, drawdown proof, and evidence artifact exist.
 - `max_drawdown_pct`
 
 `max_drawdown_pct` remains `0.00` until a real drawdown verifier supplies proof,
-so the generated metrics cannot satisfy the live-readiness manifest by accident.
+and the metrics include `diagnostic_only=true` and `drawdown_verified=false` so
+downstream consumers can distinguish placeholder diagnostics from a
+manifest-ready evidence artifact. These fields also keep the generated metrics
+from satisfying the live-readiness manifest by accident.
 
 Minimum proof before the live-readiness manifest can mark `daily_trading` ready:
 

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -646,14 +646,21 @@ func writeDailyTradingReadinessEvidenceMetrics(
 	openPositions int,
 ) {
 	quest.Checkpoint["daily_trading_lifecycle_storage_verified"] = lifecycleStorageVerified
+	quest.Checkpoint["daily_trading_drawdown_verified"] = false
+	quest.Checkpoint["daily_trading_readiness_evidence_metrics_status"] = "diagnostic_placeholder"
+	if lifecycleStorageVerified {
+		quest.Checkpoint["daily_trading_readiness_evidence_metrics_status"] = "diagnostic_lifecycle"
+	}
 	quest.Checkpoint["daily_trading_readiness_evidence_metrics"] = map[string]interface{}{
-		"closed_trades":    summary.Trades,
-		"winning_trades":   summary.Wins,
-		"losing_trades":    summary.Losses,
-		"open_positions":   openPositions,
-		"net_pnl":          summary.RealizedPnL.StringFixed(2),
-		"avg_net_pnl":      summary.AvgNetPnL.StringFixed(2),
-		"max_drawdown_pct": "0.00",
+		"closed_trades":     summary.Trades,
+		"winning_trades":    summary.Wins,
+		"losing_trades":     summary.Losses,
+		"open_positions":    openPositions,
+		"net_pnl":           summary.RealizedPnL.StringFixed(2),
+		"avg_net_pnl":       summary.AvgNetPnL.StringFixed(2),
+		"max_drawdown_pct":  "0.00",
+		"drawdown_verified": false,
+		"diagnostic_only":   true,
 	}
 }
 

--- a/services/backend-api/internal/services/quest_handlers_integrated_daily_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_daily_test.go
@@ -31,6 +31,8 @@ func TestExecuteRoutineDailyReportRecordsBlockedReadinessWithoutLifecycleStore(t
 	assert.Equal(t, "daily-chat", quest.Checkpoint["daily_report_chat_id"])
 	assert.Equal(t, "bitget", quest.Checkpoint["daily_report_exchange"])
 	assert.Equal(t, false, quest.Checkpoint["daily_trading_lifecycle_storage_verified"])
+	assert.Equal(t, false, quest.Checkpoint["daily_trading_drawdown_verified"])
+	assert.Equal(t, "diagnostic_placeholder", quest.Checkpoint["daily_trading_readiness_evidence_metrics_status"])
 	assert.Equal(t, 1, quest.CurrentCount)
 
 	metrics, ok := quest.Checkpoint["daily_trading_readiness_evidence_metrics"].(map[string]interface{})
@@ -42,6 +44,8 @@ func TestExecuteRoutineDailyReportRecordsBlockedReadinessWithoutLifecycleStore(t
 	assert.Equal(t, "0.00", metrics["net_pnl"])
 	assert.Equal(t, "0.00", metrics["avg_net_pnl"])
 	assert.Equal(t, "0.00", metrics["max_drawdown_pct"])
+	assert.Equal(t, false, metrics["drawdown_verified"])
+	assert.Equal(t, true, metrics["diagnostic_only"])
 
 	blockers, ok := quest.Checkpoint["daily_trading_readiness_blockers"].([]string)
 	require.True(t, ok)
@@ -94,6 +98,8 @@ func TestExecuteRoutineDailyReportBlocksMissingChatIDBeforeLifecycleQueries(t *t
 	require.NoError(t, err)
 	assert.Equal(t, "", quest.Checkpoint["daily_report_chat_id"])
 	assert.Equal(t, false, quest.Checkpoint["daily_trading_lifecycle_storage_verified"])
+	assert.Equal(t, false, quest.Checkpoint["daily_trading_drawdown_verified"])
+	assert.Equal(t, "diagnostic_placeholder", quest.Checkpoint["daily_trading_readiness_evidence_metrics_status"])
 	assert.Equal(t, 1, quest.CurrentCount)
 
 	metrics, ok := quest.Checkpoint["daily_trading_readiness_evidence_metrics"].(map[string]interface{})
@@ -197,6 +203,8 @@ func TestExecuteRoutineDailyReportRecordsLifecycleMetrics(t *testing.T) {
 	assert.Equal(t, 1, quest.Checkpoint["daily_report_losses"])
 	assert.Equal(t, 0, quest.Checkpoint["daily_report_open_positions"])
 	assert.Equal(t, true, quest.Checkpoint["daily_trading_lifecycle_storage_verified"])
+	assert.Equal(t, false, quest.Checkpoint["daily_trading_drawdown_verified"])
+	assert.Equal(t, "diagnostic_lifecycle", quest.Checkpoint["daily_trading_readiness_evidence_metrics_status"])
 	assert.Equal(t, 1, quest.CurrentCount)
 
 	metrics, ok := quest.Checkpoint["daily_trading_readiness_evidence_metrics"].(map[string]interface{})
@@ -208,6 +216,8 @@ func TestExecuteRoutineDailyReportRecordsLifecycleMetrics(t *testing.T) {
 	assert.Equal(t, "1.80", metrics["net_pnl"])
 	assert.Equal(t, "0.90", metrics["avg_net_pnl"])
 	assert.Equal(t, "0.00", metrics["max_drawdown_pct"])
+	assert.Equal(t, false, metrics["drawdown_verified"])
+	assert.Equal(t, true, metrics["diagnostic_only"])
 
 	blockers, ok := quest.Checkpoint["daily_trading_readiness_blockers"].([]string)
 	require.True(t, ok)


### PR DESCRIPTION
## Summary
- mark daily readiness evidence metrics as diagnostic-only in quest checkpoints
- expose `daily_trading_drawdown_verified=false` and `daily_trading_readiness_evidence_metrics_status`
- document that daily readiness metrics remain placeholders until real drawdown proof and an executable daily strategy evidence artifact exist

## Validation
- `rtk git diff --check`
- `rtk go test ./internal/services -run 'TestExecuteRoutineDailyReport|TestManifestLiveModeGuard'`\n- `rtk go test ./internal/services -run 'TestExecuteRoutineSwingTradingReview|TestExecuteRoutineArbitrageReadinessReview'`\n- `rtk go test ./internal/services`\n- `rtk make lint`\n- `rtk make build`

## Summary by Sourcery

Mark daily trading readiness evidence metrics as diagnostic-only placeholders and expose explicit readiness status flags for downstream consumers.

New Features:
- Expose a daily_trading_drawdown_verified flag in quest checkpoints and readiness metrics.
- Expose a daily_trading_readiness_evidence_metrics_status field to indicate placeholder vs lifecycle-derived diagnostics.

Enhancements:
- Extend daily readiness evidence metrics with diagnostic_only and drawdown_verified markers to prevent placeholder data from satisfying live-readiness manifests.
- Clarify daily trading readiness documentation to describe the new diagnostic flags and their placeholder nature.

Documentation:
- Update DAILY_TRADING_READINESS documentation to describe new readiness flags and the diagnostic-only status of current metrics.

Tests:
- Adjust daily report readiness tests to assert the new drawdown and diagnostic status fields in quest checkpoints and metrics.