### PR TITLE
Reject diagnostic live readiness evidence

### DIFF
--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -59,6 +59,7 @@ Required paper-trading metrics:
 
 - `paper_runtime_probe_passed`: must be true.
 - `lifecycle_storage_verified`: must be true.
+- `diagnostic_only`: must be absent or false.
 - `closed_trades`: at least 1 persisted closed paper trade.
 - `open_positions`: must be 0.
 - `net_pnl` and `avg_net_pnl`: decimal strings greater than 0.
@@ -69,6 +70,8 @@ Required trading-strategy metrics:
 - `winning_trades` and `losing_trades`: both must be positive.
 - `open_positions`: must be 0.
 - `net_pnl`, `avg_net_pnl`, and `max_drawdown_pct`: decimal strings greater than 0.
+- `drawdown_verified`: must be true.
+- `diagnostic_only`: must be absent or false.
 
 Arbitrage may use no-trade safety evidence instead of closed-trade metrics only
 when an observed window proves no executable spreads/opportunities after costs:

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -32,15 +32,17 @@ type StrategyLiveReadiness struct {
 // StrategyReadinessEvidence records the minimum proof needed before a trading
 // strategy may be represented as live-ready in the operator manifest.
 type StrategyReadinessEvidence struct {
-	ClosedTrades   int    `json:"closed_trades,omitempty"`
-	WinningTrades  int    `json:"winning_trades,omitempty"`
-	LosingTrades   int    `json:"losing_trades,omitempty"`
-	OpenPositions  int    `json:"open_positions,omitempty"`
-	NetPnL         string `json:"net_pnl,omitempty"`
-	AvgNetPnL      string `json:"avg_net_pnl,omitempty"`
-	MaxDrawdownPct string `json:"max_drawdown_pct,omitempty"`
-	NoTradeSafety  bool   `json:"no_trade_safety,omitempty"`
-	NoTradeReason  string `json:"no_trade_reason,omitempty"`
+	ClosedTrades     int    `json:"closed_trades,omitempty"`
+	WinningTrades    int    `json:"winning_trades,omitempty"`
+	LosingTrades     int    `json:"losing_trades,omitempty"`
+	OpenPositions    int    `json:"open_positions,omitempty"`
+	NetPnL           string `json:"net_pnl,omitempty"`
+	AvgNetPnL        string `json:"avg_net_pnl,omitempty"`
+	MaxDrawdownPct   string `json:"max_drawdown_pct,omitempty"`
+	DrawdownVerified bool   `json:"drawdown_verified,omitempty"`
+	DiagnosticOnly   bool   `json:"diagnostic_only,omitempty"`
+	NoTradeSafety    bool   `json:"no_trade_safety,omitempty"`
+	NoTradeReason    string `json:"no_trade_reason,omitempty"`
 	// PaperRuntimeProbePassed and LifecycleStorageVerified are required only for
 	// paper_trading evidence, where simulator and persistence proof are the base
 	// readiness contract rather than strategy profitability.
@@ -138,20 +140,23 @@ func strategyReadinessEvidenceBlockers(strategy string, status StrategyLiveReadi
 	if metrics == nil {
 		return []string{fmt.Sprintf("%s=missing_evidence_metrics", strategy)}
 	}
+	var blockers []string
+	if metrics.DiagnosticOnly {
+		blockers = append(blockers, fmt.Sprintf("%s=diagnostic_only", strategy))
+	}
 	if strategy == "paper_trading" {
-		return paperTradingReadinessEvidenceBlockers(metrics)
+		return append(blockers, paperTradingReadinessEvidenceBlockers(metrics)...)
 	}
 	if strategy == "arbitrage" && metrics.NoTradeSafety {
 		if strings.TrimSpace(metrics.NoTradeReason) == "" {
-			return []string{"arbitrage=missing_no_trade_reason"}
+			blockers = append(blockers, "arbitrage=missing_no_trade_reason")
 		}
 		if metrics.OpenPositions != 0 {
-			return []string{fmt.Sprintf("arbitrage=open_positions_%d", metrics.OpenPositions)}
+			blockers = append(blockers, fmt.Sprintf("arbitrage=open_positions_%d", metrics.OpenPositions))
 		}
-		return nil
+		return blockers
 	}
 
-	var blockers []string
 	if metrics.ClosedTrades < minimumReadinessClosedTrades(strategy) {
 		blockers = append(blockers, fmt.Sprintf("%s=insufficient_closed_trades", strategy))
 	}
@@ -175,6 +180,9 @@ func strategyReadinessEvidenceBlockers(strategy string, status StrategyLiveReadi
 	}
 	if !positiveDecimalString(metrics.MaxDrawdownPct) {
 		blockers = append(blockers, fmt.Sprintf("%s=missing_observed_drawdown", strategy))
+	}
+	if !metrics.DrawdownVerified {
+		blockers = append(blockers, fmt.Sprintf("%s=drawdown_not_verified", strategy))
 	}
 	return blockers
 }

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -149,10 +149,10 @@ func strategyReadinessEvidenceBlockers(strategy string, status StrategyLiveReadi
 	}
 	if strategy == "arbitrage" && metrics.NoTradeSafety {
 		if strings.TrimSpace(metrics.NoTradeReason) == "" {
-			blockers = append(blockers, "arbitrage=missing_no_trade_reason")
+			blockers = append(blockers, fmt.Sprintf("%s=%q", strategy, "missing_no_trade_reason"))
 		}
 		if metrics.OpenPositions != 0 {
-			blockers = append(blockers, fmt.Sprintf("arbitrage=open_positions_%d", metrics.OpenPositions))
+			blockers = append(blockers, fmt.Sprintf("%s=open_positions_%q", strategy, fmt.Sprint(metrics.OpenPositions)))
 		}
 		return blockers
 	}

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -157,10 +157,11 @@ func TestManifestLiveModeGuardRequiresPaperTradingProofMetrics(t *testing.T) {
 				Ready:    true,
 				Evidence: "paper-readiness.json",
 				EvidenceMetrics: &StrategyReadinessEvidence{
-					ClosedTrades:  0,
-					OpenPositions: 1,
-					NetPnL:        "0",
-					AvgNetPnL:     "-0.01",
+					ClosedTrades:   0,
+					OpenPositions:  1,
+					NetPnL:         "0",
+					AvgNetPnL:      "-0.01",
+					DiagnosticOnly: true,
 				},
 			},
 		},
@@ -178,6 +179,7 @@ func TestManifestLiveModeGuardRequiresPaperTradingProofMetrics(t *testing.T) {
 	assert.Contains(t, err.Error(), "paper_trading=open_positions_1")
 	assert.Contains(t, err.Error(), "paper_trading=non_positive_net_pnl")
 	assert.Contains(t, err.Error(), "paper_trading=non_positive_avg_net_pnl")
+	assert.Contains(t, err.Error(), "paper_trading=diagnostic_only")
 }
 
 func TestManifestLiveModeGuardRequiresTradingProofMetrics(t *testing.T) {
@@ -195,6 +197,7 @@ func TestManifestLiveModeGuardRequiresTradingProofMetrics(t *testing.T) {
 					NetPnL:         "-1.25",
 					AvgNetPnL:      "0",
 					MaxDrawdownPct: "0",
+					DiagnosticOnly: true,
 				},
 			},
 		},
@@ -212,6 +215,32 @@ func TestManifestLiveModeGuardRequiresTradingProofMetrics(t *testing.T) {
 	assert.Contains(t, err.Error(), "swing_trading=non_positive_net_pnl")
 	assert.Contains(t, err.Error(), "swing_trading=non_positive_avg_net_pnl")
 	assert.Contains(t, err.Error(), "swing_trading=missing_observed_drawdown")
+	assert.Contains(t, err.Error(), "swing_trading=drawdown_not_verified")
+	assert.Contains(t, err.Error(), "swing_trading=diagnostic_only")
+}
+
+func TestManifestLiveModeGuardRejectsUnverifiedDrawdownEvenWithPositiveMetric(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {Ready: true, Evidence: "paper-soak:daily.json", EvidenceMetrics: &StrategyReadinessEvidence{
+				ClosedTrades:   2,
+				WinningTrades:  1,
+				LosingTrades:   1,
+				NetPnL:         "1.25",
+				AvgNetPnL:      "0.10",
+				MaxDrawdownPct: "0.05",
+			}},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daily_trading=drawdown_not_verified")
 }
 
 func TestManifestLiveModeGuardRequiresScalpingMinimumTradeProof(t *testing.T) {
@@ -255,12 +284,13 @@ func TestManifestLiveModeGuardAllowsArbitrageNoTradeSafetyEvidence(t *testing.T)
 
 func passingReadinessEvidence(closedTrades int) *StrategyReadinessEvidence {
 	return &StrategyReadinessEvidence{
-		ClosedTrades:   closedTrades,
-		WinningTrades:  1,
-		LosingTrades:   1,
-		NetPnL:         "1.25",
-		AvgNetPnL:      "0.10",
-		MaxDrawdownPct: "0.05",
+		ClosedTrades:     closedTrades,
+		WinningTrades:    1,
+		LosingTrades:     1,
+		NetPnL:           "1.25",
+		AvgNetPnL:        "0.10",
+		MaxDrawdownPct:   "0.05",
+		DrawdownVerified: true,
 	}
 }
 

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -282,6 +282,31 @@ func TestManifestLiveModeGuardAllowsArbitrageNoTradeSafetyEvidence(t *testing.T)
 	require.NoError(t, guard(context.Background(), "chat-1", "tester"))
 }
 
+func TestManifestLiveModeGuardQuotesArbitrageNoTradeSafetyBlockers(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"arbitrage": {
+				Ready:    true,
+				Evidence: "paper-safety:arbitrage.json",
+				EvidenceMetrics: &StrategyReadinessEvidence{
+					NoTradeSafety: true,
+					OpenPositions: 2,
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"arbitrage"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `arbitrage="missing_no_trade_reason"`)
+	assert.Contains(t, err.Error(), `arbitrage=open_positions_"2"`)
+}
+
 func passingReadinessEvidence(closedTrades int) *StrategyReadinessEvidence {
 	return &StrategyReadinessEvidence{
 		ClosedTrades:     closedTrades,


### PR DESCRIPTION
## Summary
- teach the live-readiness manifest guard to reject `diagnostic_only=true` evidence
- require non-paper trading evidence to set `drawdown_verified=true`, not just a positive drawdown number
- document the manifest fields and add guard regression tests

## Validation
- `rtk git diff --check`
- `rtk go test ./internal/services -run 'TestManifestLiveModeGuard|TestOperationalModeService_LiveModeGuard'`\n- `rtk go test ./internal/services -run 'TestExecuteRoutineDailyReport|TestExecuteRoutineSwingTradingReview|TestExecuteRoutineArbitrageReadinessReview'`\n- `rtk go test ./internal/services`\n- `rtk make lint`\n- `rtk make build`

## Summary by Sourcery

Tighten live-readiness manifest validation for trading strategies and update documentation and tests to reflect the stricter requirements.

New Features:
- Introduce diagnostic_only and drawdown_verified fields to strategy readiness evidence to distinguish diagnostic data from production-ready metrics and to confirm drawdown validation.

Bug Fixes:
- Prevent live-readiness approval when evidence is marked diagnostic_only, ensuring diagnostic runs cannot be used as readiness proof.
- Require non-paper trading strategies to explicitly set drawdown_verified=true, even when a positive max_drawdown_pct is present, avoiding acceptance of unverified drawdown metrics.
- Ensure arbitrage no-trade safety evidence reports specific blockers when missing a no-trade reason or when open positions are non-zero.

Enhancements:
- Extend readiness guard error reporting with more granular blocker messages for paper trading, swing trading, and arbitrage strategies.

Documentation:
- Document the new diagnostic_only and drawdown_verified manifest fields and clarify the required readiness metrics for paper-trading and trading strategies.

Tests:
- Add and update live-readiness guard tests to cover diagnostic_only rejection, drawdown_verified enforcement, and detailed arbitrage no-trade safety blockers.