### PR TITLE
Require live readiness evidence artifact files

### DIFF
--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -7,6 +7,8 @@ The manifest is intentionally a final gate, not proof by itself. Each entry must
 point to evidence produced by the relevant paper/live-market verifier for that
 strategy. Required entries also require structured `evidence_metrics`; a
 non-empty evidence path alone is not enough to permit live mode.
+Evidence paths must resolve to readable, non-empty files. Relative evidence
+paths are resolved from the manifest file's directory.
 
 ```json
 {

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -105,6 +106,7 @@ func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) Liv
 		}
 
 		strategies := normalizeReadinessManifestStrategies(manifest.Strategies)
+		manifestDir := filepath.Dir(path)
 		var blockers []string
 		for _, strategy := range required {
 			status, ok := strategies[strategy]
@@ -120,6 +122,7 @@ func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) Liv
 			case strings.TrimSpace(status.Evidence) == "":
 				blockers = append(blockers, fmt.Sprintf("%s=missing_evidence", strategy))
 			default:
+				blockers = append(blockers, evidenceArtifactBlockers(strategy, status.Evidence, manifestDir)...)
 				blockers = append(blockers, strategyReadinessEvidenceBlockers(strategy, status)...)
 			}
 		}
@@ -129,6 +132,26 @@ func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) Liv
 
 		return nil
 	}
+}
+
+func evidenceArtifactBlockers(strategy string, evidence string, manifestDir string) []string {
+	evidence = strings.TrimSpace(evidence)
+	evidencePath := evidence
+	if !filepath.IsAbs(evidencePath) {
+		evidencePath = filepath.Join(manifestDir, evidencePath)
+	}
+
+	info, err := os.Stat(evidencePath)
+	if err != nil {
+		return []string{fmt.Sprintf("%s=evidence_unreadable_%q", strategy, evidence)}
+	}
+	if info.IsDir() {
+		return []string{fmt.Sprintf("%s=evidence_not_file_%q", strategy, evidence)}
+	}
+	if info.Size() == 0 {
+		return []string{fmt.Sprintf("%s=evidence_empty_%q", strategy, evidence)}
+	}
+	return nil
 }
 
 func normalizeReadinessStrategies(strategies []string) []string {

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -133,12 +133,16 @@ func TestManifestLiveModeGuardQuotesManifestPathErrors(t *testing.T) {
 }
 
 func TestManifestLiveModeGuardAllowsVerifiedStrategies(t *testing.T) {
-	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-readiness.json")
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/daily.json")
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/swing.json")
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
 			"paper_trading": {Ready: true, Evidence: "paper-readiness.json", EvidenceMetrics: passingPaperReadinessEvidence()},
-			"daily_trading": {Ready: true, Evidence: "paper-soak:daily.json", EvidenceMetrics: passingReadinessEvidence(2)},
-			"swing_trading": {Ready: true, Evidence: "paper-soak:swing.json", EvidenceMetrics: passingReadinessEvidence(2)},
+			"daily_trading": {Ready: true, Evidence: "paper-soak/daily.json", EvidenceMetrics: passingReadinessEvidence(2)},
+			"swing_trading": {Ready: true, Evidence: "paper-soak/swing.json", EvidenceMetrics: passingReadinessEvidence(2)},
 		},
 	}
 	raw, err := json.Marshal(manifest)
@@ -147,6 +151,23 @@ func TestManifestLiveModeGuardAllowsVerifiedStrategies(t *testing.T) {
 
 	guard := ManifestLiveModeGuard(manifestPath, []string{"paper_trading", "daily_trading", "swing_trading"})
 	require.NoError(t, guard(context.Background(), "chat-1", "tester"))
+}
+
+func TestManifestLiveModeGuardRequiresReadableEvidenceArtifact(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {Ready: true, Evidence: "missing-evidence.json", EvidenceMetrics: passingReadinessEvidence(2)},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=evidence_unreadable_"missing-evidence.json"`)
 }
 
 func TestManifestLiveModeGuardRequiresPaperTradingProofMetrics(t *testing.T) {
@@ -338,12 +359,14 @@ func TestManifestLiveModeGuardRequiresScalpingMinimumTradeProof(t *testing.T) {
 }
 
 func TestManifestLiveModeGuardAllowsArbitrageNoTradeSafetyEvidence(t *testing.T) {
-	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-safety/arbitrage.json")
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
 			"arbitrage": {
 				Ready:    true,
-				Evidence: "paper-safety:arbitrage.json",
+				Evidence: "paper-safety/arbitrage.json",
 				EvidenceMetrics: &StrategyReadinessEvidence{
 					NoTradeSafety:          true,
 					NoTradeReason:          "no executable spreads after fees across observed window",
@@ -388,6 +411,16 @@ func TestManifestLiveModeGuardQuotesArbitrageNoTradeSafetyBlockers(t *testing.T)
 	assert.Contains(t, err.Error(), "arbitrage=market_data_not_verified")
 	assert.Contains(t, err.Error(), "arbitrage=cost_accounting_not_verified")
 	assert.Contains(t, err.Error(), "arbitrage=exposure_safety_not_verified")
+}
+
+func writeReadinessEvidenceArtifact(t *testing.T, manifestDir string, evidence string) {
+	t.Helper()
+	path := evidence
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(manifestDir, path)
+	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte(`{"verified":true}`), 0o600))
 }
 
 func passingReadinessEvidence(closedTrades int) *StrategyReadinessEvidence {

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/irfndi/neuratrade/internal/database"
@@ -102,10 +103,12 @@ func TestManifestLiveModeGuardRequiresAllStrategyEvidence(t *testing.T) {
 	assert.Contains(t, err.Error(), "daily_trading")
 	assert.Contains(t, err.Error(), "swing_trading")
 
-	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/daily.json")
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
-			"daily_trading": {Ready: true, Evidence: "paper-soak:daily.json"},
+			"daily_trading": {Ready: true, Evidence: "paper-soak/daily.json"},
 			"swing_trading": {Ready: false, Reason: "paper_window_missing"},
 			"arbitrage":     {Ready: true},
 		},
@@ -171,7 +174,9 @@ func TestManifestLiveModeGuardRequiresReadableEvidenceArtifact(t *testing.T) {
 }
 
 func TestManifestLiveModeGuardRequiresPaperTradingProofMetrics(t *testing.T) {
-	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-readiness.json")
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
 			"paper_trading": {
@@ -208,7 +213,9 @@ func TestManifestLiveModeGuardRequiresPaperTradingProofMetrics(t *testing.T) {
 }
 
 func TestManifestLiveModeGuardRequiresPaperTradingAcceptanceMetrics(t *testing.T) {
-	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-readiness.json")
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
 			"paper_trading": {
@@ -242,12 +249,14 @@ func TestManifestLiveModeGuardRequiresPaperTradingAcceptanceMetrics(t *testing.T
 }
 
 func TestManifestLiveModeGuardRequiresTradingProofMetrics(t *testing.T) {
-	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/swing.json")
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
 			"swing_trading": {
 				Ready:    true,
-				Evidence: "paper-soak:swing.json",
+				Evidence: "paper-soak/swing.json",
 				EvidenceMetrics: &StrategyReadinessEvidence{
 					ClosedTrades:   1,
 					WinningTrades:  1,
@@ -284,12 +293,14 @@ func TestManifestLiveModeGuardRequiresTradingProofMetrics(t *testing.T) {
 }
 
 func TestManifestLiveModeGuardRequiresStrategyAcceptanceMetrics(t *testing.T) {
-	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/daily.json")
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
 			"daily_trading": {
 				Ready:    true,
-				Evidence: "paper-soak:daily.json",
+				Evidence: "paper-soak/daily.json",
 				EvidenceMetrics: &StrategyReadinessEvidence{
 					ClosedTrades:     2,
 					WinningTrades:    1,
@@ -318,10 +329,12 @@ func TestManifestLiveModeGuardRequiresStrategyAcceptanceMetrics(t *testing.T) {
 }
 
 func TestManifestLiveModeGuardRejectsUnverifiedDrawdownEvenWithPositiveMetric(t *testing.T) {
-	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/daily.json")
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
-			"daily_trading": {Ready: true, Evidence: "paper-soak:daily.json", EvidenceMetrics: &StrategyReadinessEvidence{
+			"daily_trading": {Ready: true, Evidence: "paper-soak/daily.json", EvidenceMetrics: &StrategyReadinessEvidence{
 				ClosedTrades:   2,
 				WinningTrades:  1,
 				LosingTrades:   1,
@@ -342,10 +355,12 @@ func TestManifestLiveModeGuardRejectsUnverifiedDrawdownEvenWithPositiveMetric(t 
 }
 
 func TestManifestLiveModeGuardRequiresScalpingMinimumTradeProof(t *testing.T) {
-	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/scalping.json")
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
-			"scalping": {Ready: true, Evidence: "paper-soak:scalping.json", EvidenceMetrics: passingReadinessEvidence(19)},
+			"scalping": {Ready: true, Evidence: "paper-soak/scalping.json", EvidenceMetrics: passingReadinessEvidence(19)},
 		},
 	}
 	raw, err := json.Marshal(manifest)
@@ -386,12 +401,14 @@ func TestManifestLiveModeGuardAllowsArbitrageNoTradeSafetyEvidence(t *testing.T)
 }
 
 func TestManifestLiveModeGuardQuotesArbitrageNoTradeSafetyBlockers(t *testing.T) {
-	manifestPath := filepath.Join(t.TempDir(), "live-readiness.json")
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-safety/arbitrage.json")
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
 			"arbitrage": {
 				Ready:    true,
-				Evidence: "paper-safety:arbitrage.json",
+				Evidence: "paper-safety/arbitrage.json",
 				EvidenceMetrics: &StrategyReadinessEvidence{
 					NoTradeSafety: true,
 					OpenPositions: 2,
@@ -415,7 +432,7 @@ func TestManifestLiveModeGuardQuotesArbitrageNoTradeSafetyBlockers(t *testing.T)
 
 func writeReadinessEvidenceArtifact(t *testing.T, manifestDir string, evidence string) {
 	t.Helper()
-	path := evidence
+	path := strings.TrimSpace(evidence)
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(manifestDir, path)
 	}


### PR DESCRIPTION
## Summary
- require every ready live-readiness manifest entry to reference a readable non-empty evidence file
- resolve relative evidence paths from the manifest directory so retained verifier artifacts can live next to the manifest
- document the artifact-file requirement and cover missing evidence files in guard tests

## Validation
- git diff --check
- go test ./internal/services -run 'TestManifestLiveModeGuard'\n- go test ./internal/services\n- make lint\n- make build\n\n## Notes\n- Stacked on PR #397 / fix/strategy-readiness-acceptance-metrics.\n- This hardens the final live-mode gate; it does not create the missing real-market evidence artifacts.

## Summary by Sourcery

Enforce that live-readiness manifest entries reference concrete evidence artifact files and enhance the readiness guard to validate those artifacts before permitting live trading.

New Features:
- Add validation that each ready strategy in the live-readiness manifest has an evidence artifact that exists, is a regular file, and is non-empty.

Enhancements:
- Resolve relative evidence paths in the manifest against the manifest file directory to support colocated verifier artifacts.
- Refactor test setup to create realistic evidence artifact files used by live-readiness guard tests.

Documentation:
- Document the requirement that evidence paths in the live-readiness manifest must point to readable, non-empty files and that relative paths are resolved from the manifest directory.

Tests:
- Extend live-readiness guard tests to cover missing or unreadable evidence artifacts and the new evidence path resolution behavior.