### PR TITLE
Require JSON live readiness evidence artifacts

### DIFF
--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -8,7 +8,8 @@ point to evidence produced by the relevant paper/live-market verifier for that
 strategy. Required entries also require structured `evidence_metrics`; a
 non-empty evidence path alone is not enough to permit live mode.
 Evidence paths must resolve to readable, non-empty JSON files. Relative
-evidence paths are resolved from the manifest file's directory.
+evidence paths are resolved from the manifest file's directory. Evidence files
+larger than 1 MiB are rejected by the guard.
 
 ```json
 {

--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -7,8 +7,8 @@ The manifest is intentionally a final gate, not proof by itself. Each entry must
 point to evidence produced by the relevant paper/live-market verifier for that
 strategy. Required entries also require structured `evidence_metrics`; a
 non-empty evidence path alone is not enough to permit live mode.
-Evidence paths must resolve to readable, non-empty files. Relative evidence
-paths are resolved from the manifest file's directory.
+Evidence paths must resolve to readable, non-empty JSON files. Relative
+evidence paths are resolved from the manifest file's directory.
 
 ```json
 {

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -19,6 +19,7 @@ const (
 
 	minimumPaperTradingValidationHours = 168
 	minimumPaperTradingStrategyCount   = 2
+	maximumReadinessEvidenceBytes      = 1024 * 1024
 )
 
 // LiveModeGuard blocks or permits a transition into real-money live mode.
@@ -151,13 +152,15 @@ func evidenceArtifactBlockers(strategy string, evidence string, manifestDir stri
 	if info.Size() == 0 {
 		return []string{fmt.Sprintf("%s=evidence_empty_%q", strategy, evidence)}
 	}
+	if info.Size() > maximumReadinessEvidenceBytes {
+		return []string{fmt.Sprintf("%s=evidence_too_large_%q", strategy, evidence)}
+	}
 
 	raw, err := os.ReadFile(evidencePath)
 	if err != nil {
 		return []string{fmt.Sprintf("%s=evidence_unreadable_%q", strategy, evidence)}
 	}
-	var evidenceJSON interface{}
-	if err := json.Unmarshal(raw, &evidenceJSON); err != nil {
+	if !json.Valid(raw) {
 		return []string{fmt.Sprintf("%s=evidence_invalid_json_%q", strategy, evidence)}
 	}
 	return nil

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -151,6 +151,15 @@ func evidenceArtifactBlockers(strategy string, evidence string, manifestDir stri
 	if info.Size() == 0 {
 		return []string{fmt.Sprintf("%s=evidence_empty_%q", strategy, evidence)}
 	}
+
+	raw, err := os.ReadFile(evidencePath)
+	if err != nil {
+		return []string{fmt.Sprintf("%s=evidence_unreadable_%q", strategy, evidence)}
+	}
+	var evidenceJSON interface{}
+	if err := json.Unmarshal(raw, &evidenceJSON); err != nil {
+		return []string{fmt.Sprintf("%s=evidence_invalid_json_%q", strategy, evidence)}
+	}
 	return nil
 }
 

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -173,6 +173,25 @@ func TestManifestLiveModeGuardRequiresReadableEvidenceArtifact(t *testing.T) {
 	assert.Contains(t, err.Error(), `daily_trading=evidence_unreadable_"missing-evidence.json"`)
 }
 
+func TestManifestLiveModeGuardRequiresJSONEvidenceArtifact(t *testing.T) {
+	manifestDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(manifestDir, "daily.txt"), []byte("verified"), 0o600))
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {Ready: true, Evidence: "daily.txt", EvidenceMetrics: passingReadinessEvidence(2)},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=evidence_invalid_json_"daily.txt"`)
+}
+
 func TestManifestLiveModeGuardRequiresPaperTradingProofMetrics(t *testing.T) {
 	manifestDir := t.TempDir()
 	writeReadinessEvidenceArtifact(t, manifestDir, "paper-readiness.json")

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -192,6 +192,29 @@ func TestManifestLiveModeGuardRequiresJSONEvidenceArtifact(t *testing.T) {
 	assert.Contains(t, err.Error(), `daily_trading=evidence_invalid_json_"daily.txt"`)
 }
 
+func TestManifestLiveModeGuardRejectsOversizedEvidenceArtifact(t *testing.T) {
+	manifestDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(manifestDir, "daily.json"),
+		[]byte(strings.Repeat(" ", maximumReadinessEvidenceBytes+1)),
+		0o600,
+	))
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: passingReadinessEvidence(2)},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=evidence_too_large_"daily.json"`)
+}
+
 func TestManifestLiveModeGuardRequiresPaperTradingProofMetrics(t *testing.T) {
 	manifestDir := t.TempDir()
 	writeReadinessEvidenceArtifact(t, manifestDir, "paper-readiness.json")


### PR DESCRIPTION
## Summary
- require referenced live-readiness evidence artifact files to parse as JSON, not only exist and be non-empty
- document the JSON artifact requirement
- add a manifest guard regression for a non-JSON evidence file

## Validation
- git diff --check
- go test ./internal/services -run 'TestManifestLiveModeGuard'\n- go test ./internal/services\n- make lint\n- make build\n\n## Notes\n- Stacked on PR #398 / fix/live-readiness-evidence-artifact-paths.\n- This is final-gate hardening; it does not produce the missing real-market readiness artifacts.

## Summary by Sourcery

Tighten live-readiness manifest guarding by enforcing JSON validity and size constraints on referenced evidence artifacts.

Bug Fixes:
- Ensure live-readiness evidence artifacts are rejected when they are not valid JSON or exceed the maximum allowed size.

Enhancements:
- Add validation that live-readiness evidence artifacts are valid JSON files and below a 1 MiB size limit.

Documentation:
- Document the requirement that live-readiness evidence artifacts be readable, non-empty JSON files under 1 MiB.

Tests:
- Add regression tests covering invalid JSON evidence artifacts and oversized evidence files in the live-readiness manifest guard.