### PR TITLE
Require object live readiness evidence artifacts

### DIFF
--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -7,7 +7,7 @@ The manifest is intentionally a final gate, not proof by itself. Each entry must
 point to evidence produced by the relevant paper/live-market verifier for that
 strategy. Required entries also require structured `evidence_metrics`; a
 non-empty evidence path alone is not enough to permit live mode.
-Evidence paths must resolve to readable, non-empty JSON files. Relative
+Evidence paths must resolve to readable, non-empty JSON object files. Relative
 evidence paths are resolved from the manifest file's directory. Evidence files
 larger than 1 MiB are rejected by the guard.
 

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -163,6 +163,10 @@ func evidenceArtifactBlockers(strategy string, evidence string, manifestDir stri
 	if !json.Valid(raw) {
 		return []string{fmt.Sprintf("%s=evidence_invalid_json_%q", strategy, evidence)}
 	}
+	var evidenceObject map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &evidenceObject); err != nil || evidenceObject == nil {
+		return []string{fmt.Sprintf("%s=evidence_not_json_object_%q", strategy, evidence)}
+	}
 	return nil
 }
 

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -192,6 +192,25 @@ func TestManifestLiveModeGuardRequiresJSONEvidenceArtifact(t *testing.T) {
 	assert.Contains(t, err.Error(), `daily_trading=evidence_invalid_json_"daily.txt"`)
 }
 
+func TestManifestLiveModeGuardRequiresObjectEvidenceArtifact(t *testing.T) {
+	manifestDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(manifestDir, "daily.json"), []byte(`"verified"`), 0o600))
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: passingReadinessEvidence(2)},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=evidence_not_json_object_"daily.json"`)
+}
+
 func TestManifestLiveModeGuardRejectsOversizedEvidenceArtifact(t *testing.T) {
 	manifestDir := t.TempDir()
 	require.NoError(t, os.WriteFile(


### PR DESCRIPTION
## Summary
- require live-readiness evidence artifacts to be top-level JSON objects after JSON validity and size checks
- add a manifest guard regression for valid JSON scalar evidence placeholders
- document that evidence files must be non-empty JSON object files

## Validation
- git diff --check
- go test ./internal/services -run TestManifestLiveModeGuard
- go test ./internal/services
- make lint
- make build

Stacked on #399. Draft until the readiness stack is ready to land.

## Summary by Sourcery

Enforce that live-readiness evidence artifacts are valid, non-empty JSON objects and update tests and documentation accordingly.

Bug Fixes:
- Prevent acceptance of live-readiness evidence artifacts that are valid JSON but not top-level objects (e.g., scalars or arrays).

Enhancements:
- Extend the live readiness guard to validate that evidence artifacts deserialize into JSON objects after basic validity checks.

Documentation:
- Clarify in the live readiness manifest documentation that evidence files must be non-empty JSON object files.

Tests:
- Add a regression test ensuring scalar JSON evidence artifacts are rejected as non-object evidence.