### PR TITLE
Match live readiness artifact metrics to manifest

### DIFF
--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -9,7 +9,10 @@ strategy. Required entries also require structured `evidence_metrics`; a
 non-empty evidence path alone is not enough to permit live mode.
 Evidence paths must resolve to readable, non-empty JSON object files. Relative
 evidence paths are resolved from the manifest file's directory. Evidence files
-larger than 1 MiB are rejected by the guard.
+larger than 1 MiB are rejected by the guard. When a manifest entry includes
+`evidence_metrics`, the evidence artifact must include matching metrics either
+as top-level `evidence_metrics` or as
+`live_readiness.manifest_entry.evidence_metrics`.
 
 ```json
 {

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -123,7 +123,7 @@ func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) Liv
 			case strings.TrimSpace(status.Evidence) == "":
 				blockers = append(blockers, fmt.Sprintf("%s=missing_evidence", strategy))
 			default:
-				blockers = append(blockers, evidenceArtifactBlockers(strategy, status.Evidence, manifestDir)...)
+				blockers = append(blockers, evidenceArtifactBlockers(strategy, status.Evidence, manifestDir, status.EvidenceMetrics)...)
 				blockers = append(blockers, strategyReadinessEvidenceBlockers(strategy, status)...)
 			}
 		}
@@ -135,7 +135,7 @@ func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) Liv
 	}
 }
 
-func evidenceArtifactBlockers(strategy string, evidence string, manifestDir string) []string {
+func evidenceArtifactBlockers(strategy string, evidence string, manifestDir string, expectedMetrics *StrategyReadinessEvidence) []string {
 	evidence = strings.TrimSpace(evidence)
 	evidencePath := evidence
 	if !filepath.IsAbs(evidencePath) {
@@ -167,7 +167,83 @@ func evidenceArtifactBlockers(strategy string, evidence string, manifestDir stri
 	if err := json.Unmarshal(raw, &evidenceObject); err != nil || evidenceObject == nil {
 		return []string{fmt.Sprintf("%s=evidence_not_json_object_%q", strategy, evidence)}
 	}
+	if expectedMetrics != nil {
+		return evidenceArtifactMetricsBlockers(strategy, evidence, evidenceObject, expectedMetrics)
+	}
 	return nil
+}
+
+func evidenceArtifactMetricsBlockers(
+	strategy string,
+	evidence string,
+	evidenceObject map[string]json.RawMessage,
+	expectedMetrics *StrategyReadinessEvidence,
+) []string {
+	actualMetrics, ok := evidenceArtifactMetrics(evidenceObject)
+	if !ok {
+		return []string{fmt.Sprintf("%s=evidence_missing_metrics_%q", strategy, evidence)}
+	}
+	if !readinessEvidenceMatches(*expectedMetrics, actualMetrics) {
+		return []string{fmt.Sprintf("%s=evidence_metrics_mismatch_%q", strategy, evidence)}
+	}
+	return nil
+}
+
+func readinessEvidenceMatches(expected StrategyReadinessEvidence, actual StrategyReadinessEvidence) bool {
+	if !matchingDecimalString(expected.NetPnL, actual.NetPnL) {
+		return false
+	}
+	if !matchingDecimalString(expected.AvgNetPnL, actual.AvgNetPnL) {
+		return false
+	}
+	if !matchingDecimalString(expected.MaxDrawdownPct, actual.MaxDrawdownPct) {
+		return false
+	}
+	expected.NetPnL = ""
+	actual.NetPnL = ""
+	expected.AvgNetPnL = ""
+	actual.AvgNetPnL = ""
+	expected.MaxDrawdownPct = ""
+	actual.MaxDrawdownPct = ""
+	return expected == actual
+}
+
+func matchingDecimalString(expected string, actual string) bool {
+	expected = strings.TrimSpace(expected)
+	actual = strings.TrimSpace(actual)
+	if expected == "" || actual == "" {
+		return expected == actual
+	}
+	expectedDecimal, expectedErr := decimal.NewFromString(expected)
+	actualDecimal, actualErr := decimal.NewFromString(actual)
+	if expectedErr != nil || actualErr != nil {
+		return expected == actual
+	}
+	return expectedDecimal.Equal(actualDecimal)
+}
+
+func evidenceArtifactMetrics(evidenceObject map[string]json.RawMessage) (StrategyReadinessEvidence, bool) {
+	if raw, ok := evidenceObject["evidence_metrics"]; ok {
+		var metrics StrategyReadinessEvidence
+		if err := json.Unmarshal(raw, &metrics); err == nil {
+			return metrics, true
+		}
+		return StrategyReadinessEvidence{}, false
+	}
+
+	var readiness struct {
+		ManifestEntry struct {
+			EvidenceMetrics *StrategyReadinessEvidence `json:"evidence_metrics"`
+		} `json:"manifest_entry"`
+	}
+	raw, ok := evidenceObject["live_readiness"]
+	if !ok {
+		return StrategyReadinessEvidence{}, false
+	}
+	if err := json.Unmarshal(raw, &readiness); err != nil || readiness.ManifestEntry.EvidenceMetrics == nil {
+		return StrategyReadinessEvidence{}, false
+	}
+	return *readiness.ManifestEntry.EvidenceMetrics, true
 }
 
 func normalizeReadinessStrategies(strategies []string) []string {

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -137,15 +137,18 @@ func TestManifestLiveModeGuardQuotesManifestPathErrors(t *testing.T) {
 
 func TestManifestLiveModeGuardAllowsVerifiedStrategies(t *testing.T) {
 	manifestDir := t.TempDir()
-	writeReadinessEvidenceArtifact(t, manifestDir, "paper-readiness.json")
-	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/daily.json")
-	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/swing.json")
+	paperMetrics := passingPaperReadinessEvidence()
+	dailyMetrics := passingReadinessEvidence(2)
+	swingMetrics := passingReadinessEvidence(2)
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-readiness.json", paperMetrics)
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/daily.json", dailyMetrics)
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-soak/swing.json", swingMetrics)
 	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
-			"paper_trading": {Ready: true, Evidence: "paper-readiness.json", EvidenceMetrics: passingPaperReadinessEvidence()},
-			"daily_trading": {Ready: true, Evidence: "paper-soak/daily.json", EvidenceMetrics: passingReadinessEvidence(2)},
-			"swing_trading": {Ready: true, Evidence: "paper-soak/swing.json", EvidenceMetrics: passingReadinessEvidence(2)},
+			"paper_trading": {Ready: true, Evidence: "paper-readiness.json", EvidenceMetrics: paperMetrics},
+			"daily_trading": {Ready: true, Evidence: "paper-soak/daily.json", EvidenceMetrics: dailyMetrics},
+			"swing_trading": {Ready: true, Evidence: "paper-soak/swing.json", EvidenceMetrics: swingMetrics},
 		},
 	}
 	raw, err := json.Marshal(manifest)
@@ -209,6 +212,95 @@ func TestManifestLiveModeGuardRequiresObjectEvidenceArtifact(t *testing.T) {
 	err = guard(context.Background(), "chat-1", "tester")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `daily_trading=evidence_not_json_object_"daily.json"`)
+}
+
+func TestManifestLiveModeGuardRequiresEvidenceArtifactMetrics(t *testing.T) {
+	manifestDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(manifestDir, "daily.json"), []byte(`{"verified":true}`), 0o600))
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: passingReadinessEvidence(2)},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=evidence_missing_metrics_"daily.json"`)
+}
+
+func TestManifestLiveModeGuardRequiresEvidenceArtifactMetricsToMatchManifest(t *testing.T) {
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "daily.json", passingReadinessEvidence(3))
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: passingReadinessEvidence(2)},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=evidence_metrics_mismatch_"daily.json"`)
+}
+
+func TestManifestLiveModeGuardMatchesEvidenceArtifactDecimalMetricsByValue(t *testing.T) {
+	manifestDir := t.TempDir()
+	manifestMetrics := passingReadinessEvidence(2)
+	artifactMetrics := *manifestMetrics
+	artifactMetrics.NetPnL = " 1.250 "
+	artifactMetrics.AvgNetPnL = "0.100"
+	artifactMetrics.MaxDrawdownPct = "0.0500"
+	writeReadinessEvidenceArtifact(t, manifestDir, "daily.json", &artifactMetrics)
+
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: manifestMetrics},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	require.NoError(t, guard(context.Background(), "chat-1", "tester"))
+}
+
+func TestManifestLiveModeGuardAllowsWrappedManifestEntryEvidenceMetrics(t *testing.T) {
+	manifestDir := t.TempDir()
+	metrics := passingReadinessEvidence(2)
+	evidencePath := filepath.Join(manifestDir, "daily.json")
+	rawEvidence, err := json.Marshal(map[string]interface{}{
+		"live_readiness": map[string]interface{}{
+			"manifest_entry": map[string]interface{}{
+				"evidence_metrics": metrics,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(evidencePath, rawEvidence, 0o600))
+
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: metrics},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	require.NoError(t, guard(context.Background(), "chat-1", "tester"))
 }
 
 func TestManifestLiveModeGuardRejectsOversizedEvidenceArtifact(t *testing.T) {
@@ -436,20 +528,21 @@ func TestManifestLiveModeGuardRequiresScalpingMinimumTradeProof(t *testing.T) {
 
 func TestManifestLiveModeGuardAllowsArbitrageNoTradeSafetyEvidence(t *testing.T) {
 	manifestDir := t.TempDir()
-	writeReadinessEvidenceArtifact(t, manifestDir, "paper-safety/arbitrage.json")
+	metrics := &StrategyReadinessEvidence{
+		NoTradeSafety:          true,
+		NoTradeReason:          "no executable spreads after fees across observed window",
+		MarketDataVerified:     true,
+		CostAccountingVerified: true,
+		ExposureSafetyVerified: true,
+	}
+	writeReadinessEvidenceArtifact(t, manifestDir, "paper-safety/arbitrage.json", metrics)
 	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
 			"arbitrage": {
-				Ready:    true,
-				Evidence: "paper-safety/arbitrage.json",
-				EvidenceMetrics: &StrategyReadinessEvidence{
-					NoTradeSafety:          true,
-					NoTradeReason:          "no executable spreads after fees across observed window",
-					MarketDataVerified:     true,
-					CostAccountingVerified: true,
-					ExposureSafetyVerified: true,
-				},
+				Ready:           true,
+				Evidence:        "paper-safety/arbitrage.json",
+				EvidenceMetrics: metrics,
 			},
 		},
 	}
@@ -491,14 +584,20 @@ func TestManifestLiveModeGuardQuotesArbitrageNoTradeSafetyBlockers(t *testing.T)
 	assert.Contains(t, err.Error(), "arbitrage=exposure_safety_not_verified")
 }
 
-func writeReadinessEvidenceArtifact(t *testing.T, manifestDir string, evidence string) {
+func writeReadinessEvidenceArtifact(t *testing.T, manifestDir string, evidence string, metrics ...*StrategyReadinessEvidence) {
 	t.Helper()
 	path := strings.TrimSpace(evidence)
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(manifestDir, path)
 	}
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
-	require.NoError(t, os.WriteFile(path, []byte(`{"verified":true}`), 0o600))
+	payload := map[string]interface{}{"verified": true}
+	if len(metrics) > 0 && metrics[0] != nil {
+		payload["evidence_metrics"] = metrics[0]
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
 }
 
 func passingReadinessEvidence(closedTrades int) *StrategyReadinessEvidence {


### PR DESCRIPTION
## Summary
- require evidence artifacts to include metrics matching manifest evidence_metrics whenever a manifest entry claims readiness metrics
- accept metrics from either top-level evidence_metrics or live_readiness.manifest_entry.evidence_metrics wrapper artifacts
- add regressions for missing, mismatched, and wrapped artifact metrics
- document the artifact metric consistency requirement

## Validation
- git diff --check
- go test ./internal/services -run TestManifestLiveModeGuard
- go test ./internal/services
- make lint
- make build

Stacked on #400. Draft until the readiness stack is ready to land.

## Summary by Sourcery

Enforce consistency between live readiness manifest evidence metrics and their corresponding evidence artifacts, and expand tests and documentation to cover the new constraints.

New Features:
- Validate that evidence artifacts contain metrics matching manifest evidence_metrics, accepting both top-level and wrapped metric locations.

Enhancements:
- Add comparison logic that treats decimal metric strings as equal when they represent the same numeric value regardless of formatting.

Documentation:
- Document the requirement that evidence artifacts must embed metrics matching manifest evidence_metrics, including supported locations for those metrics.

Tests:
- Extend ManifestLiveModeGuard tests to cover presence, matching, numeric equivalence, and wrapped locations of evidence metrics in readiness artifacts.