### PR TITLE
Require timestamped live readiness evidence artifacts

### DIFF
--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -12,7 +12,10 @@ evidence paths are resolved from the manifest file's directory. Evidence files
 larger than 1 MiB are rejected by the guard. When a manifest entry includes
 `evidence_metrics`, the evidence artifact must include matching metrics either
 as top-level `evidence_metrics` or as
-`live_readiness.manifest_entry.evidence_metrics`.
+`live_readiness.manifest_entry.evidence_metrics`. Ready entries must include an
+RFC3339 `verified_at` timestamp, and the evidence artifact must carry the same
+timestamp either as top-level `verified_at` or as
+`live_readiness.manifest_entry.verified_at`.
 
 ```json
 {
@@ -70,7 +73,10 @@ as top-level `evidence_metrics` or as
 }
 ```
 
-Required paper-trading metrics:
+Required paper-trading readiness fields:
+
+- `verified_at`: must be an RFC3339 timestamp and must match the referenced
+  evidence artifact timestamp.
 
 - `paper_runtime_probe_passed`: must be true.
 - `lifecycle_storage_verified`: must be true.
@@ -84,7 +90,10 @@ Required paper-trading metrics:
 - `open_positions`: must be 0.
 - `net_pnl` and `avg_net_pnl`: decimal strings greater than 0.
 
-Required trading-strategy metrics:
+Required trading-strategy readiness fields:
+
+- `verified_at`: must be an RFC3339 timestamp and must match the referenced
+  evidence artifact timestamp.
 
 - `closed_trades`: at least 20 for `scalping`; at least 2 for `daily_trading`, `swing_trading`, and `arbitrage` unless arbitrage uses documented no-trade safety.
 - `winning_trades` and `losing_trades`: both must be positive.

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/shopspring/decimal"
 )
@@ -123,7 +124,8 @@ func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) Liv
 			case strings.TrimSpace(status.Evidence) == "":
 				blockers = append(blockers, fmt.Sprintf("%s=missing_evidence", strategy))
 			default:
-				blockers = append(blockers, evidenceArtifactBlockers(strategy, status.Evidence, manifestDir, status.EvidenceMetrics)...)
+				blockers = append(blockers, evidenceArtifactBlockers(strategy, status.Evidence, manifestDir, status.EvidenceMetrics, status.VerifiedAt)...)
+				blockers = append(blockers, readinessVerifiedAtBlockers(strategy, status)...)
 				blockers = append(blockers, strategyReadinessEvidenceBlockers(strategy, status)...)
 			}
 		}
@@ -135,7 +137,13 @@ func ManifestLiveModeGuard(manifestPath string, requiredStrategies []string) Liv
 	}
 }
 
-func evidenceArtifactBlockers(strategy string, evidence string, manifestDir string, expectedMetrics *StrategyReadinessEvidence) []string {
+func evidenceArtifactBlockers(
+	strategy string,
+	evidence string,
+	manifestDir string,
+	expectedMetrics *StrategyReadinessEvidence,
+	expectedVerifiedAt string,
+) []string {
 	evidence = strings.TrimSpace(evidence)
 	evidencePath := evidence
 	if !filepath.IsAbs(evidencePath) {
@@ -168,7 +176,23 @@ func evidenceArtifactBlockers(strategy string, evidence string, manifestDir stri
 		return []string{fmt.Sprintf("%s=evidence_not_json_object_%q", strategy, evidence)}
 	}
 	if expectedMetrics != nil {
-		return evidenceArtifactMetricsBlockers(strategy, evidence, evidenceObject, expectedMetrics)
+		if blockers := evidenceArtifactMetricsBlockers(strategy, evidence, evidenceObject, expectedMetrics); len(blockers) > 0 {
+			return blockers
+		}
+	}
+	if strings.TrimSpace(expectedVerifiedAt) != "" {
+		return evidenceArtifactVerifiedAtBlockers(strategy, evidence, evidenceObject, expectedVerifiedAt)
+	}
+	return nil
+}
+
+func readinessVerifiedAtBlockers(strategy string, status StrategyLiveReadiness) []string {
+	verifiedAt := strings.TrimSpace(status.VerifiedAt)
+	if verifiedAt == "" {
+		return []string{fmt.Sprintf("%s=missing_verified_at", strategy)}
+	}
+	if _, err := time.Parse(time.RFC3339Nano, verifiedAt); err != nil {
+		return []string{fmt.Sprintf("%s=invalid_verified_at_%q", strategy, verifiedAt)}
 	}
 	return nil
 }
@@ -244,6 +268,56 @@ func evidenceArtifactMetrics(evidenceObject map[string]json.RawMessage) (Strateg
 		return StrategyReadinessEvidence{}, false
 	}
 	return *readiness.ManifestEntry.EvidenceMetrics, true
+}
+
+func evidenceArtifactVerifiedAtBlockers(
+	strategy string,
+	evidence string,
+	evidenceObject map[string]json.RawMessage,
+	expectedVerifiedAt string,
+) []string {
+	actualVerifiedAt, ok := evidenceArtifactVerifiedAt(evidenceObject)
+	if !ok {
+		return []string{fmt.Sprintf("%s=evidence_missing_verified_at_%q", strategy, evidence)}
+	}
+	expectedAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(expectedVerifiedAt))
+	if err != nil {
+		return nil
+	}
+	actualAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(actualVerifiedAt))
+	if err != nil {
+		return []string{fmt.Sprintf("%s=evidence_invalid_verified_at_%q", strategy, actualVerifiedAt)}
+	}
+	if !expectedAt.Equal(actualAt) {
+		return []string{fmt.Sprintf("%s=evidence_verified_at_mismatch_%q", strategy, evidence)}
+	}
+	return nil
+}
+
+func evidenceArtifactVerifiedAt(evidenceObject map[string]json.RawMessage) (string, bool) {
+	if raw, ok := evidenceObject["verified_at"]; ok {
+		var verifiedAt string
+		if err := json.Unmarshal(raw, &verifiedAt); err != nil {
+			return "", false
+		}
+		verifiedAt = strings.TrimSpace(verifiedAt)
+		return verifiedAt, verifiedAt != ""
+	}
+
+	var readiness struct {
+		ManifestEntry struct {
+			VerifiedAt string `json:"verified_at"`
+		} `json:"manifest_entry"`
+	}
+	raw, ok := evidenceObject["live_readiness"]
+	if !ok {
+		return "", false
+	}
+	if err := json.Unmarshal(raw, &readiness); err != nil {
+		return "", false
+	}
+	verifiedAt := strings.TrimSpace(readiness.ManifestEntry.VerifiedAt)
+	return verifiedAt, verifiedAt != ""
 }
 
 func normalizeReadinessStrategies(strategies []string) []string {

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testReadinessVerifiedAt = "2026-05-21T00:00:00Z"
+
 func TestOperationalModeService_SQLitePersistence(t *testing.T) {
 	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "trading-mode.db"))
 	require.NoError(t, err)
@@ -146,9 +148,9 @@ func TestManifestLiveModeGuardAllowsVerifiedStrategies(t *testing.T) {
 	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
-			"paper_trading": {Ready: true, Evidence: "paper-readiness.json", EvidenceMetrics: paperMetrics},
-			"daily_trading": {Ready: true, Evidence: "paper-soak/daily.json", EvidenceMetrics: dailyMetrics},
-			"swing_trading": {Ready: true, Evidence: "paper-soak/swing.json", EvidenceMetrics: swingMetrics},
+			"paper_trading": {Ready: true, Evidence: "paper-readiness.json", EvidenceMetrics: paperMetrics, VerifiedAt: testReadinessVerifiedAt},
+			"daily_trading": {Ready: true, Evidence: "paper-soak/daily.json", EvidenceMetrics: dailyMetrics, VerifiedAt: testReadinessVerifiedAt},
+			"swing_trading": {Ready: true, Evidence: "paper-soak/swing.json", EvidenceMetrics: swingMetrics, VerifiedAt: testReadinessVerifiedAt},
 		},
 	}
 	raw, err := json.Marshal(manifest)
@@ -264,7 +266,141 @@ func TestManifestLiveModeGuardMatchesEvidenceArtifactDecimalMetricsByValue(t *te
 	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
-			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: manifestMetrics},
+			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: manifestMetrics, VerifiedAt: testReadinessVerifiedAt},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	require.NoError(t, guard(context.Background(), "chat-1", "tester"))
+}
+
+func TestManifestLiveModeGuardRequiresVerifiedAt(t *testing.T) {
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "daily.json", passingReadinessEvidence(2))
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: passingReadinessEvidence(2)},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daily_trading=missing_verified_at")
+}
+
+func TestManifestLiveModeGuardRequiresValidVerifiedAt(t *testing.T) {
+	manifestDir := t.TempDir()
+	writeReadinessEvidenceArtifact(t, manifestDir, "daily.json", passingReadinessEvidence(2))
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {
+				Ready:           true,
+				Evidence:        "daily.json",
+				EvidenceMetrics: passingReadinessEvidence(2),
+				VerifiedAt:      "not a timestamp",
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=invalid_verified_at_"not a timestamp"`)
+}
+
+func TestManifestLiveModeGuardRequiresEvidenceArtifactVerifiedAt(t *testing.T) {
+	manifestDir := t.TempDir()
+	evidencePath := filepath.Join(manifestDir, "daily.json")
+	rawEvidence, err := json.Marshal(map[string]interface{}{
+		"verified":         true,
+		"evidence_metrics": passingReadinessEvidence(2),
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(evidencePath, rawEvidence, 0o600))
+
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {
+				Ready:           true,
+				Evidence:        "daily.json",
+				EvidenceMetrics: passingReadinessEvidence(2),
+				VerifiedAt:      testReadinessVerifiedAt,
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=evidence_missing_verified_at_"daily.json"`)
+}
+
+func TestManifestLiveModeGuardRequiresEvidenceArtifactVerifiedAtToMatch(t *testing.T) {
+	manifestDir := t.TempDir()
+	evidencePath := filepath.Join(manifestDir, "daily.json")
+	rawEvidence, err := json.Marshal(map[string]interface{}{
+		"verified_at":      "2026-05-20T00:00:00Z",
+		"evidence_metrics": passingReadinessEvidence(2),
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(evidencePath, rawEvidence, 0o600))
+
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {
+				Ready:           true,
+				Evidence:        "daily.json",
+				EvidenceMetrics: passingReadinessEvidence(2),
+				VerifiedAt:      testReadinessVerifiedAt,
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=evidence_verified_at_mismatch_"daily.json"`)
+}
+
+func TestManifestLiveModeGuardMatchesFractionalVerifiedAtByInstant(t *testing.T) {
+	manifestDir := t.TempDir()
+	evidencePath := filepath.Join(manifestDir, "daily.json")
+	rawEvidence, err := json.Marshal(map[string]interface{}{
+		"verified_at":      "2026-05-21T00:00:00.000Z",
+		"evidence_metrics": passingReadinessEvidence(2),
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(evidencePath, rawEvidence, 0o600))
+
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {
+				Ready:           true,
+				Evidence:        "daily.json",
+				EvidenceMetrics: passingReadinessEvidence(2),
+				VerifiedAt:      " 2026-05-21T00:00:00Z ",
+			},
 		},
 	}
 	raw, err := json.Marshal(manifest)
@@ -283,6 +419,7 @@ func TestManifestLiveModeGuardAllowsWrappedManifestEntryEvidenceMetrics(t *testi
 		"live_readiness": map[string]interface{}{
 			"manifest_entry": map[string]interface{}{
 				"evidence_metrics": metrics,
+				"verified_at":      testReadinessVerifiedAt,
 			},
 		},
 	})
@@ -292,7 +429,7 @@ func TestManifestLiveModeGuardAllowsWrappedManifestEntryEvidenceMetrics(t *testi
 	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
 	manifest := LiveReadinessManifest{
 		Strategies: map[string]StrategyLiveReadiness{
-			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: metrics},
+			"daily_trading": {Ready: true, Evidence: "daily.json", EvidenceMetrics: metrics, VerifiedAt: testReadinessVerifiedAt},
 		},
 	}
 	raw, err := json.Marshal(manifest)
@@ -543,6 +680,7 @@ func TestManifestLiveModeGuardAllowsArbitrageNoTradeSafetyEvidence(t *testing.T)
 				Ready:           true,
 				Evidence:        "paper-safety/arbitrage.json",
 				EvidenceMetrics: metrics,
+				VerifiedAt:      testReadinessVerifiedAt,
 			},
 		},
 	}
@@ -591,7 +729,10 @@ func writeReadinessEvidenceArtifact(t *testing.T, manifestDir string, evidence s
 		path = filepath.Join(manifestDir, path)
 	}
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
-	payload := map[string]interface{}{"verified": true}
+	payload := map[string]interface{}{
+		"verified":    true,
+		"verified_at": testReadinessVerifiedAt,
+	}
 	if len(metrics) > 0 && metrics[0] != nil {
 		payload["evidence_metrics"] = metrics[0]
 	}


### PR DESCRIPTION
## Summary
- require ready live-readiness manifest entries to include RFC3339 verified_at timestamps
- require referenced evidence artifacts to carry the same timestamp at top-level verified_at or live_readiness.manifest_entry.verified_at
- add regressions for missing, invalid, and mismatched verified_at values
- document timestamp binding in the live readiness manifest contract

## Validation
- git diff --check
- go test ./internal/services -run TestManifestLiveModeGuard
- go test ./internal/services
- make lint
- make build

Stacked on #401. Draft until the readiness stack is ready to land.

## Summary by Sourcery

Enforce timestamp binding between live readiness manifest entries and their evidence artifacts, and document the updated contract.

Bug Fixes:
- Prevent live readiness guard from accepting ready strategies without a verified_at timestamp or with malformed timestamps.
- Prevent live readiness guard from accepting evidence artifacts that are missing verified_at, have invalid timestamps, or whose verified_at does not match the manifest entry.

Enhancements:
- Extend live readiness guard logic to validate RFC3339/RFC3339Nano verified_at timestamps and compare instants across manifest entries and evidence artifacts, including wrapped manifest_entry evidence.
- Update readiness test helpers and existing guard tests to include verified_at on manifest entries and evidence artifacts and to cover fractional timestamps.

Documentation:
- Document the requirement for RFC3339 verified_at timestamps in live readiness manifest entries and their evidence artifacts, and list verified_at as a required readiness field for paper-trading and strategy entries.

Tests:
- Add regression tests covering missing, invalid, and mismatched verified_at values on manifest entries and evidence artifacts, including fractional timestamp normalization.