### PR TITLE
Require live readiness evidence strategy identity

### DIFF
--- a/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
+++ b/services/backend-api/docs/LIVE_READINESS_MANIFEST.md
@@ -15,7 +15,9 @@ as top-level `evidence_metrics` or as
 `live_readiness.manifest_entry.evidence_metrics`. Ready entries must include an
 RFC3339 `verified_at` timestamp, and the evidence artifact must carry the same
 timestamp either as top-level `verified_at` or as
-`live_readiness.manifest_entry.verified_at`.
+`live_readiness.manifest_entry.verified_at`. The evidence artifact must also
+identify the same strategy as the manifest entry, either as top-level `strategy`
+or as `live_readiness.strategy`.
 
 ```json
 {
@@ -77,6 +79,7 @@ Required paper-trading readiness fields:
 
 - `verified_at`: must be an RFC3339 timestamp and must match the referenced
   evidence artifact timestamp.
+- `strategy`: the referenced evidence artifact must identify `paper_trading`.
 
 - `paper_runtime_probe_passed`: must be true.
 - `lifecycle_storage_verified`: must be true.
@@ -94,6 +97,8 @@ Required trading-strategy readiness fields:
 
 - `verified_at`: must be an RFC3339 timestamp and must match the referenced
   evidence artifact timestamp.
+- `strategy`: the referenced evidence artifact must identify the same strategy
+  key as the manifest entry.
 
 - `closed_trades`: at least 20 for `scalping`; at least 2 for `daily_trading`, `swing_trading`, and `arbitrage` unless arbitrage uses documented no-trade safety.
 - `winning_trades` and `losing_trades`: both must be positive.

--- a/services/backend-api/internal/services/live_readiness_guard.go
+++ b/services/backend-api/internal/services/live_readiness_guard.go
@@ -181,9 +181,11 @@ func evidenceArtifactBlockers(
 		}
 	}
 	if strings.TrimSpace(expectedVerifiedAt) != "" {
-		return evidenceArtifactVerifiedAtBlockers(strategy, evidence, evidenceObject, expectedVerifiedAt)
+		if blockers := evidenceArtifactVerifiedAtBlockers(strategy, evidence, evidenceObject, expectedVerifiedAt); len(blockers) > 0 {
+			return blockers
+		}
 	}
-	return nil
+	return evidenceArtifactStrategyBlockers(strategy, evidence, evidenceObject)
 }
 
 func readinessVerifiedAtBlockers(strategy string, status StrategyLiveReadiness) []string {
@@ -318,6 +320,46 @@ func evidenceArtifactVerifiedAt(evidenceObject map[string]json.RawMessage) (stri
 	}
 	verifiedAt := strings.TrimSpace(readiness.ManifestEntry.VerifiedAt)
 	return verifiedAt, verifiedAt != ""
+}
+
+func evidenceArtifactStrategyBlockers(
+	strategy string,
+	evidence string,
+	evidenceObject map[string]json.RawMessage,
+) []string {
+	actualStrategy, ok := evidenceArtifactStrategy(evidenceObject)
+	if !ok {
+		return []string{fmt.Sprintf("%s=evidence_missing_strategy_%q", strategy, evidence)}
+	}
+	actualStrategy = strings.ToLower(strings.TrimSpace(actualStrategy))
+	if actualStrategy != strategy {
+		return []string{fmt.Sprintf("%s=evidence_strategy_mismatch_%q_%q", strategy, actualStrategy, evidence)}
+	}
+	return nil
+}
+
+func evidenceArtifactStrategy(evidenceObject map[string]json.RawMessage) (string, bool) {
+	if raw, ok := evidenceObject["strategy"]; ok {
+		var strategy string
+		if err := json.Unmarshal(raw, &strategy); err != nil {
+			return "", false
+		}
+		strategy = strings.TrimSpace(strategy)
+		return strategy, strategy != ""
+	}
+
+	var readiness struct {
+		Strategy string `json:"strategy"`
+	}
+	raw, ok := evidenceObject["live_readiness"]
+	if !ok {
+		return "", false
+	}
+	if err := json.Unmarshal(raw, &readiness); err != nil {
+		return "", false
+	}
+	strategy := strings.TrimSpace(readiness.Strategy)
+	return strategy, strategy != ""
 }
 
 func normalizeReadinessStrategies(strategies []string) []string {

--- a/services/backend-api/internal/services/trading_mode_test.go
+++ b/services/backend-api/internal/services/trading_mode_test.go
@@ -386,6 +386,7 @@ func TestManifestLiveModeGuardMatchesFractionalVerifiedAtByInstant(t *testing.T)
 	manifestDir := t.TempDir()
 	evidencePath := filepath.Join(manifestDir, "daily.json")
 	rawEvidence, err := json.Marshal(map[string]interface{}{
+		"strategy":         "daily_trading",
 		"verified_at":      "2026-05-21T00:00:00.000Z",
 		"evidence_metrics": passingReadinessEvidence(2),
 	})
@@ -411,12 +412,76 @@ func TestManifestLiveModeGuardMatchesFractionalVerifiedAtByInstant(t *testing.T)
 	require.NoError(t, guard(context.Background(), "chat-1", "tester"))
 }
 
+func TestManifestLiveModeGuardRequiresEvidenceArtifactStrategy(t *testing.T) {
+	manifestDir := t.TempDir()
+	evidencePath := filepath.Join(manifestDir, "daily.json")
+	rawEvidence, err := json.Marshal(map[string]interface{}{
+		"verified_at":      testReadinessVerifiedAt,
+		"evidence_metrics": passingReadinessEvidence(2),
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(evidencePath, rawEvidence, 0o600))
+
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {
+				Ready:           true,
+				Evidence:        "daily.json",
+				EvidenceMetrics: passingReadinessEvidence(2),
+				VerifiedAt:      testReadinessVerifiedAt,
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=evidence_missing_strategy_"daily.json"`)
+}
+
+func TestManifestLiveModeGuardRequiresEvidenceArtifactStrategyToMatch(t *testing.T) {
+	manifestDir := t.TempDir()
+	evidencePath := filepath.Join(manifestDir, "daily.json")
+	rawEvidence, err := json.Marshal(map[string]interface{}{
+		"strategy":         "swing_trading",
+		"verified_at":      testReadinessVerifiedAt,
+		"evidence_metrics": passingReadinessEvidence(2),
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(evidencePath, rawEvidence, 0o600))
+
+	manifestPath := filepath.Join(manifestDir, "live-readiness.json")
+	manifest := LiveReadinessManifest{
+		Strategies: map[string]StrategyLiveReadiness{
+			"daily_trading": {
+				Ready:           true,
+				Evidence:        "daily.json",
+				EvidenceMetrics: passingReadinessEvidence(2),
+				VerifiedAt:      testReadinessVerifiedAt,
+			},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, raw, 0o600))
+
+	guard := ManifestLiveModeGuard(manifestPath, []string{"daily_trading"})
+	err = guard(context.Background(), "chat-1", "tester")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daily_trading=evidence_strategy_mismatch_"swing_trading"_"daily.json"`)
+}
+
 func TestManifestLiveModeGuardAllowsWrappedManifestEntryEvidenceMetrics(t *testing.T) {
 	manifestDir := t.TempDir()
 	metrics := passingReadinessEvidence(2)
 	evidencePath := filepath.Join(manifestDir, "daily.json")
 	rawEvidence, err := json.Marshal(map[string]interface{}{
 		"live_readiness": map[string]interface{}{
+			"strategy": "daily_trading",
 			"manifest_entry": map[string]interface{}{
 				"evidence_metrics": metrics,
 				"verified_at":      testReadinessVerifiedAt,
@@ -732,6 +797,7 @@ func writeReadinessEvidenceArtifact(t *testing.T, manifestDir string, evidence s
 	payload := map[string]interface{}{
 		"verified":    true,
 		"verified_at": testReadinessVerifiedAt,
+		"strategy":    readinessEvidenceStrategy(evidence),
 	}
 	if len(metrics) > 0 && metrics[0] != nil {
 		payload["evidence_metrics"] = metrics[0]
@@ -739,6 +805,24 @@ func writeReadinessEvidenceArtifact(t *testing.T, manifestDir string, evidence s
 	raw, err := json.Marshal(payload)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path, raw, 0o600))
+}
+
+func readinessEvidenceStrategy(evidence string) string {
+	evidence = strings.ToLower(strings.TrimSpace(evidence))
+	switch {
+	case strings.Contains(evidence, "paper-readiness"):
+		return "paper_trading"
+	case strings.Contains(evidence, "scalping"):
+		return "scalping"
+	case strings.Contains(evidence, "daily"):
+		return "daily_trading"
+	case strings.Contains(evidence, "swing"):
+		return "swing_trading"
+	case strings.Contains(evidence, "arbitrage"):
+		return "arbitrage"
+	default:
+		return "daily_trading"
+	}
 }
 
 func passingReadinessEvidence(closedTrades int) *StrategyReadinessEvidence {


### PR DESCRIPTION
## Summary
- require live-readiness evidence artifacts to identify the same strategy as the manifest entry
- accept strategy identity from top-level strategy or live_readiness.strategy
- add regressions for missing and mismatched evidence artifact strategy identity
- document the strategy identity requirement in the live readiness manifest contract

## Validation
- git diff --check
- go test ./internal/services -run TestManifestLiveModeGuard
- go test ./internal/services
- make lint
- make build

Stacked on #402. Draft until the readiness stack is ready to land.

## Summary by Sourcery

Enforce that live-readiness evidence artifacts explicitly identify the same strategy as their corresponding manifest entries and update tests and documentation to reflect this requirement.

Enhancements:
- Validate strategy identity in live-readiness evidence artifacts against the manifest entry strategy key.
- Derive a default strategy identifier for generated readiness evidence artifacts based on the evidence filename pattern.

Documentation:
- Document the requirement that live-readiness evidence artifacts must declare a strategy matching the manifest entry strategy, including examples for paper-trading and strategy readiness fields.

Tests:
- Add regression tests covering missing strategy identity and mismatched strategy values in live-readiness evidence artifacts, and update existing tests to include strategy fields in evidence payloads.