### PR TITLE
Unify agent risk controls with scalping gate

### DIFF
--- a/services/backend-api/cmd/server/main.go
+++ b/services/backend-api/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	sentrygin "github.com/getsentry/sentry-go/gin"
 	"github.com/gin-gonic/gin"
 	"github.com/irfndi/neuratrade/internal/api"
+	apprisk "github.com/irfndi/neuratrade/internal/app/risk"
 	"github.com/irfndi/neuratrade/internal/cache"
 	"github.com/irfndi/neuratrade/internal/ccxt"
 	"github.com/irfndi/neuratrade/internal/config"
@@ -473,9 +474,32 @@ func run() error {
 
 	// Create operational mode service
 	opModeService := services.NewOperationalModeService(db, services.DefaultOperationalModeConfig(), logger.WithComponent("operational_mode"))
+	runtimeKillSwitch := apprisk.NewKillSwitch()
+	runtimeSafeMode := apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
 
 	// Setup routes and get cleanup function
-	cleanupRoutes := api.SetupRoutes(router, db, redisClient, ccxtService, collectorService, cleanupService, cacheAnalyticsService, signalAggregator, analyticsService, &cfg.Telegram, &cfg.AI, &cfg.Features, authMiddleware, walletValidator, opModeService, technicalAnalysisService)
+	cleanupRoutes := api.SetupRoutesWithOptions(
+		router,
+		db,
+		redisClient,
+		ccxtService,
+		collectorService,
+		cleanupService,
+		cacheAnalyticsService,
+		signalAggregator,
+		analyticsService,
+		&cfg.Telegram,
+		&cfg.AI,
+		&cfg.Features,
+		authMiddleware,
+		walletValidator,
+		opModeService,
+		technicalAnalysisService,
+		api.RouteOptions{
+			KillSwitch: runtimeKillSwitch,
+			SafeMode:   runtimeSafeMode,
+		},
+	)
 	defer cleanupRoutes()
 	// Create HTTP server with security timeouts
 	srv := &http.Server{

--- a/services/backend-api/internal/api/handlers/agent_control_adapters.go
+++ b/services/backend-api/internal/api/handlers/agent_control_adapters.go
@@ -62,3 +62,40 @@ func (a *riskAdapter) EngageKillSwitch(ctx context.Context, reason string) error
 func (a *riskAdapter) DisengageKillSwitch(ctx context.Context) error {
 	return a.killSwitch.Disengage(ctx)
 }
+
+type riskStateAdapter struct {
+	killSwitch *risk.KillSwitchImpl
+	safeMode   *risk.SafeModeImpl
+}
+
+type staticRiskStateProvider struct {
+	state services.ScalpingRiskControlState
+}
+
+// NewScalpingRiskControlStateProvider exposes shared app risk controls to the
+// scalping live gate.
+func NewScalpingRiskControlStateProvider(killSwitch *risk.KillSwitchImpl, safeMode *risk.SafeModeImpl) services.ScalpingRiskControlStateProvider {
+	if killSwitch == nil || safeMode == nil {
+		return staticRiskStateProvider{state: services.ScalpingRiskControlState{
+			SafeModeEnabled:   true,
+			KillSwitchEngaged: true,
+		}}
+	}
+	return &riskStateAdapter{
+		killSwitch: killSwitch,
+		safeMode:   safeMode,
+	}
+}
+
+func (a staticRiskStateProvider) ScalpingRiskControlState(ctx context.Context) services.ScalpingRiskControlState {
+	_ = ctx
+	return a.state
+}
+
+func (a *riskStateAdapter) ScalpingRiskControlState(ctx context.Context) services.ScalpingRiskControlState {
+	_ = ctx
+	return services.ScalpingRiskControlState{
+		SafeModeEnabled:   a.safeMode.IsEnabled(),
+		KillSwitchEngaged: a.killSwitch.IsEngaged(),
+	}
+}

--- a/services/backend-api/internal/api/handlers/agent_control_test.go
+++ b/services/backend-api/internal/api/handlers/agent_control_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	apprisk "github.com/irfndi/neuratrade/internal/app/risk"
 	"github.com/irfndi/neuratrade/internal/database"
 	"github.com/irfndi/neuratrade/internal/services"
 	"github.com/stretchr/testify/assert"
@@ -173,6 +174,34 @@ func decodeResponseBody(t *testing.T, body []byte) map[string]interface{} {
 	var response map[string]interface{}
 	require.NoError(t, json.Unmarshal(body, &response))
 	return response
+}
+
+func TestScalpingRiskControlStateProviderReflectsSharedControls(t *testing.T) {
+	ctx := context.Background()
+	killSwitch := apprisk.NewKillSwitch()
+	safeMode := apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
+	provider := NewScalpingRiskControlStateProvider(killSwitch, safeMode)
+	require.NotNil(t, provider)
+
+	state := provider.ScalpingRiskControlState(ctx)
+	require.False(t, state.SafeModeEnabled)
+	require.False(t, state.KillSwitchEngaged)
+
+	require.NoError(t, safeMode.EnableWithReason(ctx, "operator request"))
+	require.NoError(t, killSwitch.Engage(ctx, "operator request"))
+
+	state = provider.ScalpingRiskControlState(ctx)
+	require.True(t, state.SafeModeEnabled)
+	require.True(t, state.KillSwitchEngaged)
+}
+
+func TestScalpingRiskControlStateProviderFailsClosedWithoutSharedControls(t *testing.T) {
+	provider := NewScalpingRiskControlStateProvider(nil, nil)
+	require.NotNil(t, provider)
+
+	state := provider.ScalpingRiskControlState(context.Background())
+	require.True(t, state.SafeModeEnabled)
+	require.True(t, state.KillSwitchEngaged)
 }
 
 func TestAgentControlHandler_PauseExchange_Success(t *testing.T) {

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -57,6 +57,25 @@ type routeDB interface {
 	HealthCheck(ctx context.Context) error
 }
 
+// RouteOptions supplies runtime-owned dependencies that must be shared between
+// route handlers and trading gates.
+type RouteOptions struct {
+	KillSwitch *apprisk.KillSwitchImpl
+	SafeMode   *apprisk.SafeModeImpl
+}
+
+func (o RouteOptions) riskControls() (*apprisk.KillSwitchImpl, *apprisk.SafeModeImpl) {
+	killSwitch := o.KillSwitch
+	if killSwitch == nil {
+		killSwitch = apprisk.NewKillSwitch()
+	}
+	safeMode := o.SafeMode
+	if safeMode == nil {
+		safeMode = apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
+	}
+	return killSwitch, safeMode
+}
+
 func diagnosticFloat(metrics map[string]interface{}, key string) (float64, bool) {
 	value, ok := metrics[key]
 	if !ok {
@@ -404,6 +423,13 @@ func riskLockSourcePriority(source string) int {
 //
 //nolint:staticcheck // SA1019: SignalAggregator and TechnicalAnalysisService are deprecated but required for backward compatibility until scalping composer migration completes.
 func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, ccxtService ccxt.CCXTService, collectorService *services.CollectorService, cleanupService *services.CleanupService, cacheAnalyticsService *services.CacheAnalyticsService, signalAggregator *services.SignalAggregator, analyticsService *services.AnalyticsService, telegramConfig *config.TelegramConfig, aiConfig *config.AIConfig, featuresConfig *config.FeaturesConfig, authMiddleware *middleware.AuthMiddleware, walletValidator *services.WalletValidator, opModeService *services.OperationalModeService, technicalAnalysisService *services.TechnicalAnalysisService) func() {
+	return SetupRoutesWithOptions(router, db, redis, ccxtService, collectorService, cleanupService, cacheAnalyticsService, signalAggregator, analyticsService, telegramConfig, aiConfig, featuresConfig, authMiddleware, walletValidator, opModeService, technicalAnalysisService, RouteOptions{})
+}
+
+// SetupRoutesWithOptions configures routes with explicit runtime controls supplied by the server startup path.
+//
+//nolint:staticcheck // SA1019: SignalAggregator and TechnicalAnalysisService are deprecated but required for backward compatibility until scalping composer migration completes.
+func SetupRoutesWithOptions(router *gin.Engine, db routeDB, redis *database.RedisClient, ccxtService ccxt.CCXTService, collectorService *services.CollectorService, cleanupService *services.CleanupService, cacheAnalyticsService *services.CacheAnalyticsService, signalAggregator *services.SignalAggregator, analyticsService *services.AnalyticsService, telegramConfig *config.TelegramConfig, aiConfig *config.AIConfig, featuresConfig *config.FeaturesConfig, authMiddleware *middleware.AuthMiddleware, walletValidator *services.WalletValidator, opModeService *services.OperationalModeService, technicalAnalysisService *services.TechnicalAnalysisService, options RouteOptions) func() {
 	configureLiveReadinessGuard(opModeService)
 
 	// Initialize admin middleware
@@ -717,6 +743,8 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		log.Printf("Warning: Unknown database type, AI learning disabled")
 	}
 
+	routeKillSwitch, routeSafeMode := options.riskControls()
+	riskStateProvider := handlers.NewScalpingRiskControlStateProvider(routeKillSwitch, routeSafeMode)
 	runtimeDeps := autonomyruntime.Dependencies{
 		TechnicalAnalysis:   technicalAnalysisService,
 		CCXTService:         ccxtService,
@@ -725,6 +753,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		NotificationService: notificationService,
 		MonitoringService:   autonomousMonitoring,
 		SQLDB:               sqlDB,
+		RiskControls:        riskStateProvider,
 	}
 
 	// Create integrated quest runtime handlers through app/autonomy module.
@@ -1125,13 +1154,10 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		log.Printf("WARNING: OperationalModeService is nil, trading mode endpoints disabled")
 	}
 
-	sharedKillSwitch := apprisk.NewKillSwitch()
-	sharedSafeMode := apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
-
 	agentControlHandler := handlers.NewAgentControlHandler(handlers.AgentControlDeps{
 		Autonomy:  integratedHandlers.AutonomyCoordinator(),
 		Collector: handlers.NewCollectorController(collectorService),
-		Risk:      handlers.NewRiskControllerAdapter(sharedKillSwitch, sharedSafeMode),
+		Risk:      handlers.NewRiskControllerAdapter(routeKillSwitch, routeSafeMode),
 		Orders:    handlers.NewCCXTOrderCanceller(ccxtService),
 	})
 	shadowHandler := handlers.NewShadowHandler(integratedHandlers.ShadowEvaluationCoordinator())

--- a/services/backend-api/internal/api/routes_test.go
+++ b/services/backend-api/internal/api/routes_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/irfndi/neuratrade/internal/api/handlers/testmocks"
+	apprisk "github.com/irfndi/neuratrade/internal/app/risk"
 	"github.com/irfndi/neuratrade/internal/config"
 	"github.com/irfndi/neuratrade/internal/database"
 	"github.com/irfndi/neuratrade/internal/middleware"
@@ -112,6 +114,89 @@ func restoreEnv(t *testing.T, key, value string, existed bool) {
 		return
 	}
 	mustUnsetEnv(t, key)
+}
+
+func TestSetupRoutesWithOptions_AgentRiskControlsUseProvidedInstances(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const adminKey = "test-admin-key-that-is-at-least-32-chars"
+	oldAdminKey, adminKeyExists := os.LookupEnv("ADMIN_API_KEY")
+	defer restoreEnv(t, "ADMIN_API_KEY", oldAdminKey, adminKeyExists)
+	mustSetEnv(t, "ADMIN_API_KEY", adminKey)
+
+	mockCCXT := &testmocks.MockCCXTService{}
+	mockCCXT.On("GetServiceURL").Return("test-url")
+	mockCCXT.On("GetSupportedExchanges").Return([]string{"binance"})
+
+	router := gin.New()
+	killSwitch := apprisk.NewKillSwitch()
+	safeMode := apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
+	mockAuthMiddleware := middleware.NewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
+
+	teardown := SetupRoutesWithOptions(
+		router,
+		setupMockDB(t),
+		nil,
+		mockCCXT,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		&config.TelegramConfig{},
+		nil,
+		nil,
+		mockAuthMiddleware,
+		nil,
+		nil,
+		nil,
+		RouteOptions{
+			KillSwitch: killSwitch,
+			SafeMode:   safeMode,
+		},
+	)
+	defer teardown()
+
+	require.False(t, safeMode.IsEnabled())
+	require.False(t, killSwitch.IsEngaged())
+
+	tests := []struct {
+		name   string
+		path   string
+		body   string
+		assert func(t *testing.T)
+	}{
+		{
+			name: "enable safe mode",
+			path: "/api/v1/agent/enable-safe-mode",
+			body: `{}`,
+			assert: func(t *testing.T) {
+				t.Helper()
+				require.True(t, safeMode.IsEnabled(), "agent safe-mode endpoint must toggle the provided runtime safe mode")
+			},
+		},
+		{
+			name: "engage kill switch",
+			path: "/api/v1/agent/kill-switch",
+			body: `{"engage":true}`,
+			assert: func(t *testing.T) {
+				t.Helper()
+				require.True(t, killSwitch.IsEngaged(), "agent kill-switch endpoint must toggle the provided runtime kill switch")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, tt.path, bytes.NewBufferString(tt.body))
+			req.Header.Set("X-API-Key", adminKey)
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(recorder, req)
+			require.Equal(t, http.StatusOK, recorder.Code)
+			tt.assert(t)
+		})
+	}
 }
 
 // Test HealthResponse struct

--- a/services/backend-api/internal/app/autonomy/runtime/runtime.go
+++ b/services/backend-api/internal/app/autonomy/runtime/runtime.go
@@ -18,16 +18,18 @@ type Dependencies struct {
 	NotificationService *services.NotificationService
 	MonitoringService   *services.AutonomousMonitorManager
 	SQLDB               *sql.DB
+	RiskControls        services.ScalpingRiskControlStateProvider
 }
 
 func BuildLocalIntegratedHandlers(deps Dependencies) *services.IntegratedQuestHandlers {
-	handlers := services.NewIntegratedQuestHandlers(
+	handlers := services.NewIntegratedQuestHandlersWithRiskControls(
 		deps.TechnicalAnalysis,
 		deps.CCXTService,
 		deps.ArbitrageService,
 		deps.FuturesArbService,
 		deps.NotificationService,
 		deps.MonitoringService,
+		deps.RiskControls,
 	)
 	handlers.SetDB(deps.SQLDB)
 	return handlers
@@ -44,7 +46,7 @@ func BuildIntegratedHandlers(deps Dependencies) (*services.IntegratedQuestHandle
 		return nil, fmt.Errorf("build integrated autonomy handlers: ensure autonomy schema: %w", err)
 	}
 
-	handlers, err := services.NewIntegratedQuestHandlersWithAutonomyStore(
+	handlers, err := services.NewIntegratedQuestHandlersWithAutonomyStoreAndRiskControls(
 		deps.TechnicalAnalysis,
 		deps.CCXTService,
 		deps.ArbitrageService,
@@ -53,6 +55,7 @@ func BuildIntegratedHandlers(deps Dependencies) (*services.IntegratedQuestHandle
 		deps.MonitoringService,
 		deps.SQLDB,
 		nil,
+		deps.RiskControls,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build integrated autonomy handlers: %w", err)

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -50,6 +50,7 @@ type IntegratedQuestHandlers struct {
 	protectionManager    *DynamicProtectionManager
 	db                   *sql.DB // Database for user settings
 	opModeService        *OperationalModeService
+	riskControls         ScalpingRiskControlStateProvider
 	autonomyStore        *AutonomousRolloutStore
 	autonomyStoreMu      sync.RWMutex
 	autonomyCoordinator  *ScalpingAutonomyCoordinator
@@ -98,6 +99,20 @@ func NewIntegratedQuestHandlers(
 	notif *NotificationService,
 	monitoring *AutonomousMonitorManager,
 ) *IntegratedQuestHandlers {
+	return NewIntegratedQuestHandlersWithRiskControls(ta, ccxt, arb, futuresArb, notif, monitoring, nil)
+}
+
+// NewIntegratedQuestHandlersWithRiskControls creates integrated quest handlers
+// with startup-owned scalping risk controls already wired.
+func NewIntegratedQuestHandlersWithRiskControls(
+	ta *TechnicalAnalysisService,
+	ccxt interface{},
+	arb interface{},
+	futuresArb interface{},
+	notif *NotificationService,
+	monitoring *AutonomousMonitorManager,
+	riskControls ScalpingRiskControlStateProvider,
+) *IntegratedQuestHandlers {
 	return &IntegratedQuestHandlers{
 		technicalAnalysis:   ta,
 		ccxtService:         ccxt,
@@ -105,7 +120,19 @@ func NewIntegratedQuestHandlers(
 		futuresArbService:   futuresArb,
 		notificationService: notif,
 		monitoring:          monitoring,
+		riskControls:        riskControls,
 	}
+}
+
+func (h *IntegratedQuestHandlers) scalpingRiskControlState(ctx context.Context) ScalpingRiskControlState {
+	if h == nil {
+		return ScalpingRiskControlState{}
+	}
+	provider := h.riskControls
+	if provider == nil {
+		return ScalpingRiskControlState{}
+	}
+	return provider.ScalpingRiskControlState(ctx)
 }
 
 // NewIntegratedQuestHandlersWithAutonomyStore creates handlers with deterministic autonomy wiring.
@@ -119,7 +146,24 @@ func NewIntegratedQuestHandlersWithAutonomyStore(
 	db *sql.DB,
 	store *AutonomousRolloutStore,
 ) (*IntegratedQuestHandlers, error) {
-	handlers := NewIntegratedQuestHandlers(ta, ccxt, arb, futuresArb, notif, monitoring)
+	return NewIntegratedQuestHandlersWithAutonomyStoreAndRiskControls(ta, ccxt, arb, futuresArb, notif, monitoring, db, store, nil)
+}
+
+// NewIntegratedQuestHandlersWithAutonomyStoreAndRiskControls creates
+// integrated quest handlers with deterministic autonomy storage and
+// startup-owned scalping risk controls.
+func NewIntegratedQuestHandlersWithAutonomyStoreAndRiskControls(
+	ta *TechnicalAnalysisService,
+	ccxt interface{},
+	arb interface{},
+	futuresArb interface{},
+	notif *NotificationService,
+	monitoring *AutonomousMonitorManager,
+	db *sql.DB,
+	store *AutonomousRolloutStore,
+	riskControls ScalpingRiskControlStateProvider,
+) (*IntegratedQuestHandlers, error) {
+	handlers := NewIntegratedQuestHandlersWithRiskControls(ta, ccxt, arb, futuresArb, notif, monitoring, riskControls)
 	handlers.SetDB(db)
 	if err := handlers.setAutonomyStoreWithInit(context.Background(), store); err != nil {
 		return nil, fmt.Errorf("failed to set autonomy store in NewIntegratedQuestHandlersWithAutonomyStore: %w", err)
@@ -1956,6 +2000,9 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 	} else if envKillSwitch, ok := getEnvBool("NEURATRADE_KILL_SWITCH"); ok {
 		killSwitchEngaged = envKillSwitch
 	}
+	riskControls := h.scalpingRiskControlState(ctx)
+	safeMode = safeMode || riskControls.SafeModeEnabled
+	killSwitchEngaged = killSwitchEngaged || riskControls.KillSwitchEngaged
 	strategyID := ScalpingStrategyID(chatID)
 	cycleCtx := WithScalpingAutonomyScope(ctx, ScalpingAutonomyScope{
 		ChatID:            chatID,

--- a/services/backend-api/internal/services/scalping_autonomy.go
+++ b/services/backend-api/internal/services/scalping_autonomy.go
@@ -30,6 +30,19 @@ type ScalpingAutonomyScope struct {
 	ConnectionChecked bool
 }
 
+// ScalpingRiskControlState reflects operator risk controls that must gate
+// autonomous scalping before any real order can be submitted.
+type ScalpingRiskControlState struct {
+	SafeModeEnabled   bool
+	KillSwitchEngaged bool
+}
+
+// ScalpingRiskControlStateProvider returns the current operator risk-control
+// state for autonomous scalping gate evaluation.
+type ScalpingRiskControlStateProvider interface {
+	ScalpingRiskControlState(ctx context.Context) ScalpingRiskControlState
+}
+
 type scalpingAutonomyEvalInput struct {
 	SafeModeEnabled   bool
 	KillSwitchEngaged bool

--- a/services/backend-api/internal/services/scalping_autonomy_test.go
+++ b/services/backend-api/internal/services/scalping_autonomy_test.go
@@ -11,6 +11,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type staticScalpingRiskControls struct {
+	state ScalpingRiskControlState
+}
+
+func (s staticScalpingRiskControls) ScalpingRiskControlState(context.Context) ScalpingRiskControlState {
+	return s.state
+}
+
+func TestIntegratedQuestHandlers_ScalpingRiskControlStateUsesInjectedProvider(t *testing.T) {
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+
+	assert.Equal(t, ScalpingRiskControlState{}, handlers.scalpingRiskControlState(context.Background()))
+
+	handlers = NewIntegratedQuestHandlersWithRiskControls(nil, nil, nil, nil, nil, nil, staticScalpingRiskControls{
+		state: ScalpingRiskControlState{
+			SafeModeEnabled:   true,
+			KillSwitchEngaged: true,
+		},
+	})
+
+	assert.Equal(t, ScalpingRiskControlState{
+		SafeModeEnabled:   true,
+		KillSwitchEngaged: true,
+	}, handlers.scalpingRiskControlState(context.Background()))
+}
+
 func TestScalpingAutonomyCoordinator_SetStrategyMode_IgnoresInitialStageOverrideForNewShadowStrategy(t *testing.T) {
 	t.Setenv("NEURATRADE_AUTONOMY_INITIAL_STAGE", "live")
 


### PR DESCRIPTION
## Summary
- add route options for startup-owned kill-switch and safe-mode controls
- wire agent control endpoints and scalping live-gate evaluation to the same risk-control instances
- pass runtime-owned controls from server startup instead of creating route-local safety state

## Validation
- git diff --check
- go test ./internal/api -run TestSetupRoutesWithOptions_AgentRiskControlsUseProvidedInstances
- go test ./internal/api/handlers -run TestScalpingRiskControlStateProviderReflectsSharedControls
- go test ./internal/services -run TestIntegratedQuestHandlers_ScalpingRiskControlStateUsesInjectedProvider
- go test ./internal/api/...
- go test ./internal/services -run 'TestIntegratedQuestHandlers_ScalpingRiskControlStateUsesInjectedProvider|TestScalpingAutonomyCoordinator'
- go test ./cmd/server
- go test ./internal/services
- make lint
- make build

## Summary by Sourcery

Unify runtime risk controls for agent management endpoints and scalping autonomy so both flows share the same kill-switch and safe-mode state.

New Features:
- Allow HTTP route setup to accept shared runtime-owned kill-switch and safe-mode control instances.
- Expose a risk-control state provider interface for scalping autonomy to consume shared operator risk controls.

Enhancements:
- Wire integrated scalping handlers to use injectable risk-control state instead of local environment-only checks.
- Propagate shared risk-control instances from server startup into route and scalping evaluation wiring.
- Adapt agent control handlers to expose shared risk controls to the scalping live gate via an adapter.

Tests:
- Add tests to verify routes use provided risk-control instances for agent endpoints.
- Add tests to confirm the scalping risk-control provider reflects shared kill-switch and safe-mode state.
- Add tests ensuring integrated quest handlers consume the injected scalping risk-control provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime Kill Switch and Safe Mode controls added and can be toggled without restarting the server
  * These runtime safety controls are applied to autonomous scalping/trading flows to alter behavior at runtime
  * Routes and handlers can be initialized with provided risk-control instances so operational tooling can supply shared controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->