### PR TITLE
Rollback bootstrap risk actor on build failure

### DIFF
--- a/services/backend-api/internal/app/bootstrap/bootstrap.go
+++ b/services/backend-api/internal/app/bootstrap/bootstrap.go
@@ -194,8 +194,8 @@ func (b *Builder) WithStrategy(actor *strategy.StrategyActor) *Builder {
 }
 
 // Build builds the Application.
-func (b *Builder) Build() (*Application, error) {
-	app := &Application{
+func (b *Builder) Build() (app *Application, err error) {
+	app = &Application{
 		Config:      b.config,
 		Supervisor:  supervisor.New(),
 		ActorSystem: actor.NewSystem(b.config.Actor),
@@ -206,17 +206,44 @@ func (b *Builder) Build() (*Application, error) {
 		State:       b.state,
 		Notifier:    b.notifier,
 	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		app.rollbackPartialBuild()
+		app = nil
+	}()
 
 	// Build risk components if not provided
-	if err := app.buildRiskComponents(b); err != nil {
-		return nil, fmt.Errorf("build risk components: %w", err)
+	if err = app.buildRiskComponents(b); err != nil {
+		return app, fmt.Errorf("build risk components: %w", err)
 	}
 
-	if err := app.buildStrategyComponents(b); err != nil {
-		return nil, fmt.Errorf("build strategy components: %w", err)
+	if err = app.buildStrategyComponents(b); err != nil {
+		return app, fmt.Errorf("build strategy components: %w", err)
 	}
 
 	return app, nil
+}
+
+func (a *Application) rollbackPartialBuild() {
+	if a == nil {
+		return
+	}
+	if a.ActorSystem != nil {
+		a.ActorSystem.StopAll()
+	}
+	if a.EventBus != nil {
+		a.EventBus.Stop()
+	}
+	a.ActorSystem = nil
+	a.EventBus = nil
+	a.RiskRef = nil
+	a.RiskActor = nil
+	a.StrategyActorRef = nil
+	a.StrategyActor = nil
+	a.CollectorActorRef = nil
+	a.CollectorActor = nil
 }
 
 // buildRiskComponents builds the risk system components.

--- a/services/backend-api/internal/app/bootstrap/bootstrap_test.go
+++ b/services/backend-api/internal/app/bootstrap/bootstrap_test.go
@@ -1,0 +1,90 @@
+package bootstrap
+
+import (
+	"testing"
+
+	appstrategy "github.com/irfndi/neuratrade/internal/app/strategy"
+	"github.com/irfndi/neuratrade/internal/platform/actor"
+	"github.com/irfndi/neuratrade/internal/platform/eventbus"
+	"github.com/irfndi/neuratrade/internal/platform/retry"
+	"github.com/irfndi/neuratrade/internal/platform/supervisor"
+	"go.uber.org/goleak"
+)
+
+func TestBootstrapRollbackScenarios(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "build returns nil app when strategy build fails after risk startup",
+			run: func(t *testing.T) {
+				defer goleak.VerifyNone(t)
+
+				cfg := DefaultConfig()
+				cfg.RiskActorID = "duplicate-risk-strategy-actor"
+				strategyCfg := appstrategy.DefaultConfig()
+				strategyCfg.ActorID = cfg.RiskActorID
+
+				app, err := NewBuilder().
+					WithConfig(cfg).
+					WithStrategy(appstrategy.NewStrategyActor(strategyCfg, nil, nil)).
+					Build()
+
+				if err == nil {
+					t.Fatal("expected duplicate actor id to fail strategy component build")
+				}
+				if app != nil {
+					t.Fatalf("expected failed build to return nil app, got %#v", app)
+				}
+			},
+		},
+		{
+			name: "rollbackPartialBuild stops and clears started risk actor",
+			run: func(t *testing.T) {
+				cfg := DefaultConfig()
+				app := &Application{
+					Config:      cfg,
+					Supervisor:  supervisor.New(),
+					ActorSystem: actor.NewSystem(cfg.Actor),
+					EventBus:    eventbus.New(cfg.EventBus),
+					Timeout:     &cfg.Timeout,
+					Retry:       retry.NewPolicy(cfg.Retry),
+				}
+
+				if err := app.buildRiskComponents(NewBuilder().WithConfig(cfg)); err != nil {
+					t.Fatalf("build risk components: %v", err)
+				}
+
+				ref, ok := app.ActorSystem.Get(riskActorID(cfg.RiskActorID))
+				if !ok {
+					t.Fatal("expected risk actor to be registered")
+				}
+				if !ref.IsRunning() {
+					t.Fatal("expected risk actor to be running before rollback")
+				}
+
+				actorSystem := app.ActorSystem
+				app.rollbackPartialBuild()
+
+				if ref.IsRunning() {
+					t.Fatal("expected risk actor to stop after rollback")
+				}
+				if _, ok := actorSystem.Get(riskActorID(cfg.RiskActorID)); ok {
+					t.Fatal("expected risk actor to be removed from actor system after rollback")
+				}
+				if app.ActorSystem != nil || app.EventBus != nil {
+					t.Fatalf("expected stopped runtime subsystems to be cleared, got ActorSystem=%#v EventBus=%#v", app.ActorSystem, app.EventBus)
+				}
+				if app.RiskRef != nil || app.RiskActor != nil || app.StrategyActorRef != nil || app.StrategyActor != nil ||
+					app.CollectorActorRef != nil || app.CollectorActor != nil {
+					t.Fatalf("expected actor references to be cleared, got app=%#v", app)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}

--- a/services/backend-api/internal/platform/actor/actor.go
+++ b/services/backend-api/internal/platform/actor/actor.go
@@ -162,6 +162,7 @@ type Mailbox struct {
 	messages   chan Envelope
 	deadLetter func(Message)
 	stopped    atomic.Bool
+	stopOnce   sync.Once
 }
 
 // NewMailbox creates a new bounded mailbox.
@@ -242,8 +243,10 @@ func (m *Mailbox) Receive() <-chan Envelope {
 
 // Stop closes the mailbox and prevents further sends.
 func (m *Mailbox) Stop() {
-	m.stopped.Store(true)
-	close(m.messages)
+	m.stopOnce.Do(func() {
+		m.stopped.Store(true)
+		close(m.messages)
+	})
 }
 
 // Ref represents a reference to a running actor.

--- a/services/backend-api/internal/platform/actor/actor_test.go
+++ b/services/backend-api/internal/platform/actor/actor_test.go
@@ -158,6 +158,7 @@ func TestMailboxExpiredMessage(t *testing.T) {
 func TestMailboxStop(t *testing.T) {
 	m := NewMailbox(DefaultConfig())
 	m.Stop()
+	m.Stop()
 
 	if !m.stopped.Load() {
 		t.Error("mailbox should be stopped")
@@ -166,6 +167,31 @@ func TestMailboxStop(t *testing.T) {
 	err := m.Send(context.Background(), Envelope{Message: testMessage{}})
 	if err != ErrActorStopped {
 		t.Errorf("expected ErrActorStopped, got %v", err)
+	}
+}
+
+func TestRefStopIsIdempotent(t *testing.T) {
+	actor := ActorFunc(func(ctx context.Context, env Envelope) error {
+		return nil
+	})
+
+	ref := NewRef(actor, DefaultConfig())
+	ctx := context.Background()
+
+	go ref.Run(ctx)
+
+	for i := 0; i < 100; i++ {
+		if ref.IsRunning() {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	ref.Stop()
+	ref.Stop()
+
+	if ref.IsRunning() {
+		t.Error("actor should not be running after repeated Stop")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add partial-bootstrap rollback when a later component build fails
- stop any started actors directly instead of using supervisor shutdown before the supervisor is running
- add regression coverage for strategy build failure after risk actor startup

## Validation
- git diff --check
- go test ./internal/app/bootstrap
- go test ./internal/app/...
- make lint
- make build

## Summary by Sourcery

Ensure application bootstrap rolls back partially built components when later build steps fail to prevent leaking running actors or resources.

Bug Fixes:
- Rollback partially built application state, including running actors and event bus, when strategy component construction fails during bootstrap.

Enhancements:
- Add a rollback helper on Application to stop started subsystems and clear actor references on bootstrap failure.

Tests:
- Add regression tests verifying failed strategy build returns a nil application and that rollback stops and unregisters the started risk actor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during application initialization with automatic rollback of partially initialized components when failures occur, ensuring proper resource cleanup and preventing resource leaks.

* **Tests**
  * Added unit tests to verify rollback behavior and resource cleanup during failed initialization scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->