### PR TITLE
Harden gateway process matching

### DIFF
--- a/cmd/neuratrade-cli/gateway.go
+++ b/cmd/neuratrade-cli/gateway.go
@@ -50,6 +50,12 @@ type serviceProbeResult struct {
 }
 
 var allowedGatewayServiceBinaries = newAllowedGatewayServiceBinaries()
+var allowedGatewayProcessPatterns = newAllowedGatewayProcessPatterns(allowedGatewayServiceBinaries)
+
+type gatewayProcessInfo struct {
+	pid     string
+	command string
+}
 
 // newAllowedGatewayServiceBinaries returns a set of allowed service binary basenames.
 // By default it includes "neuratrade-server", "telegram-service", and "ccxt-service".
@@ -85,6 +91,15 @@ func newAllowedGatewayServiceBinaries() map[string]struct{} {
 		return defaultSet
 	}
 	return customSet
+}
+
+func newAllowedGatewayProcessPatterns(serviceBinaries map[string]struct{}) map[string]struct{} {
+	patterns := make(map[string]struct{}, len(serviceBinaries)+1)
+	for binary := range serviceBinaries {
+		patterns[binary] = struct{}{}
+	}
+	patterns["bun run index.ts"] = struct{}{}
+	return patterns
 }
 
 const (
@@ -562,7 +577,11 @@ func processMatchesAnyPattern(pid int, expectedPatterns ...string) (bool, error)
 	}
 	command := strings.ToLower(strings.TrimSpace(string(output)))
 	for _, pattern := range expectedPatterns {
-		if strings.Contains(command, strings.ToLower(pattern)) {
+		normalizedPattern, err := normalizeGatewayProcessPattern(pattern)
+		if err != nil {
+			return false, err
+		}
+		if strings.Contains(command, normalizedPattern) {
 			return true, nil
 		}
 	}
@@ -657,66 +676,85 @@ func gatewayStatus(cCtx *cli.Context) error {
 // checkProcess checks if a process is running
 func checkProcess(displayName string, processPatterns ...string) {
 	seen := make(map[string]struct{})
+	processes, err := listGatewayProcesses()
+	if err != nil {
+		fmt.Printf("❌ %s: Not running\n", displayName)
+		return
+	}
 
 	for _, pattern := range processPatterns {
-		cmd := exec.Command("pgrep", "-f", pattern)
-		output, err := cmd.Output()
-		if err != nil || len(output) == 0 {
+		normalizedPattern, err := normalizeGatewayProcessPattern(pattern)
+		if err != nil {
+			fmt.Printf("⚠️  %s: Ignoring invalid process pattern %q: %v\n", displayName, pattern, err)
 			continue
 		}
 
-		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-		for _, line := range lines {
-			pidField := strings.TrimSpace(strings.Fields(line)[0])
-			if pidField == "" {
+		for _, proc := range processes {
+			if _, exists := seen[proc.pid]; exists {
 				continue
 			}
 
-			if _, exists := seen[pidField]; exists {
+			cmdlineLower := strings.ToLower(strings.TrimSpace(proc.command))
+			if cmdlineLower == "" {
 				continue
 			}
-
-			cmdline, readErr := readCommandLineForPID(pidField)
-			if readErr != nil || strings.TrimSpace(cmdline) == "" {
-				continue
-			}
-			cmdlineLower := strings.ToLower(strings.TrimSpace(cmdline))
 			if strings.Contains(cmdlineLower, "pgrep -f") ||
 				strings.Contains(cmdlineLower, "pkill -f") ||
 				strings.Contains(cmdlineLower, "gateway status") {
 				continue
 			}
-			if !strings.Contains(cmdlineLower, strings.ToLower(pattern)) {
+			if !strings.Contains(cmdlineLower, normalizedPattern) {
 				continue
 			}
 
-			seen[pidField] = struct{}{}
-			fmt.Printf("✅ %s: Running (PID: %s)\n", displayName, pidField)
+			seen[proc.pid] = struct{}{}
+			fmt.Printf("✅ %s: Running (PID: %s)\n", displayName, proc.pid)
 			return
 		}
 	}
 	fmt.Printf("❌ %s: Not running\n", displayName)
 }
 
-func readCommandLineForPID(pid string) (string, error) {
-	pid = strings.TrimSpace(pid)
-	if pid == "" {
-		return "", fmt.Errorf("empty pid")
+func normalizeGatewayProcessPattern(pattern string) (string, error) {
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	if _, ok := allowedGatewayProcessPatterns[pattern]; !ok {
+		return "", fmt.Errorf("process pattern %q is not allowlisted", pattern)
 	}
-	// Validate PID is purely numeric to prevent command injection
-	parsedPID, err := strconv.Atoi(pid)
-	if err != nil {
-		return "", fmt.Errorf("invalid pid (non-numeric): %q", pid)
-	}
-	if parsedPID <= 0 {
-		return "", fmt.Errorf("invalid pid (must be positive): %q", pid)
-	}
-	cmd := exec.Command("ps", "-p", pid, "-o", "command=")
+	return pattern, nil
+}
+
+func listGatewayProcesses() ([]gatewayProcessInfo, error) {
+	cmd := exec.Command("ps", "-axo", "pid=,command=")
 	output, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("ps command failed for PID %s: %w", pid, err)
+		return nil, fmt.Errorf("ps process listing failed: %w", err)
 	}
-	return strings.TrimSpace(string(output)), nil
+
+	return parseGatewayProcessList(output), nil
+}
+
+func parseGatewayProcessList(output []byte) []gatewayProcessInfo {
+	processes := make([]gatewayProcessInfo, 0)
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		pid := fields[0]
+		parsedPID, err := strconv.Atoi(pid)
+		if err != nil || parsedPID <= 0 {
+			continue
+		}
+		processes = append(processes, gatewayProcessInfo{
+			pid:     pid,
+			command: strings.TrimSpace(line[len(pid):]),
+		})
+	}
+	return processes
 }
 
 // printServiceStatus prints service health status

--- a/cmd/neuratrade-cli/gateway_test.go
+++ b/cmd/neuratrade-cli/gateway_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -116,23 +115,78 @@ func TestGatewayHealthTimeoutEnvOverride(t *testing.T) {
 	require.Equal(t, 12*time.Second, got)
 }
 
-func TestReadCommandLineForPIDTrimsWhitespace(t *testing.T) {
-	got, err := readCommandLineForPID(" \t" + strconv.Itoa(os.Getpid()) + "\n")
+func TestNormalizeGatewayProcessPatternAllowsKnownPatterns(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "neuratrade-server", want: "neuratrade-server"},
+		{input: " CCXT-SERVICE ", want: "ccxt-service"},
+		{input: "telegram-service", want: "telegram-service"},
+		{input: "BUN RUN INDEX.TS", want: "bun run index.ts"},
+	}
 
-	require.NoError(t, err)
-	require.NotEmpty(t, got)
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := normalizeGatewayProcessPattern(tc.input)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
-func TestReadCommandLineForPIDRejectsInvalidPID(t *testing.T) {
-	tests := []string{"", "abc", "; rm -rf /", "123; malicious", "0", "-1"}
+func TestAllowedGatewayProcessPatternsDerivesFromServiceBinaries(t *testing.T) {
+	patterns := newAllowedGatewayProcessPatterns(map[string]struct{}{
+		"custom-backend": {},
+		"custom-bridge":  {},
+	})
 
-	for _, pid := range tests {
-		t.Run(pid, func(t *testing.T) {
-			_, err := readCommandLineForPID(pid)
+	require.Contains(t, patterns, "custom-backend")
+	require.Contains(t, patterns, "custom-bridge")
+	require.Contains(t, patterns, "bun run index.ts")
+	require.NotContains(t, patterns, "neuratrade-server")
+}
+
+func TestNormalizeGatewayProcessPatternRejectsShellInput(t *testing.T) {
+	tests := []string{
+		"",
+		"neuratrade-server && id",
+		"telegram-service; rm -rf /",
+		"$(touch /tmp/owned)",
+		"../neuratrade-server",
+		"pgrep -f neuratrade-server",
+	}
+
+	for _, pattern := range tests {
+		t.Run(pattern, func(t *testing.T) {
+			_, err := normalizeGatewayProcessPattern(pattern)
 
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestProcessMatchesAnyPatternRejectsUnexpectedPattern(t *testing.T) {
+	matches, err := processMatchesAnyPattern(os.Getpid(), "neuratrade-server && id")
+
+	require.Error(t, err)
+	require.False(t, matches)
+}
+
+func TestParseGatewayProcessListValidatesPositiveNumericPID(t *testing.T) {
+	processes := parseGatewayProcessList([]byte(`
+	    123 /usr/local/bin/neuratrade-server --config config.yml
+	    0 /usr/local/bin/ccxt-service
+	   -10 /usr/local/bin/telegram-service
+	    abc /usr/local/bin/telegram-service
+	    456 bun run index.ts
+	`))
+
+	require.Equal(t, []gatewayProcessInfo{
+		{pid: "123", command: "/usr/local/bin/neuratrade-server --config config.yml"},
+		{pid: "456", command: "bun run index.ts"},
+	}, processes)
 }
 
 func TestShouldSkipTelegramGatewayForPaperOnlyRuntime(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace dynamic `pgrep -f` gateway status checks with fixed-argument `ps` enumeration
- restrict gateway process matching to an allowlisted set of service patterns
- add regression tests for rejecting shell-like process patterns

## Validation
- `go test ./...` from `cmd/neuratrade-cli`
- `git diff --check`
- `make lint`
- `make build`

Tracks `NeuraTrade-jza`.

This PR is stacked on #405 and should not be merged independently until the stack is reviewed.

## Summary by Sourcery

Harden gateway process detection by restricting process pattern matching to an allowlisted set and replacing dynamic `pgrep` usage with fixed-argument `ps` enumeration.

Enhancements:
- Introduce normalized, allowlisted gateway process patterns and centralize process listing via `ps` to avoid dynamic shell-like invocations.
- Tighten gateway status checks to operate only on validated process patterns and ignore unsafe or irrelevant processes.

Tests:
- Add unit tests covering allowed and rejected gateway process patterns, including shell-like and unexpected inputs, and verify that pattern validation errors are surfaced by process matching.