### PR TITLE
Guard collector startup exchange priority query

### DIFF
--- a/services/backend-api/internal/services/collector_service.go
+++ b/services/backend-api/internal/services/collector_service.go
@@ -286,6 +286,11 @@ func (c *CollectorService) getPrioritizedExchanges() []string {
 		}
 	}
 
+	if len(allExchanges) == 0 {
+		c.logger.Warn("No exchanges available from CCXT, skipping priority query")
+		return allExchanges
+	}
+
 	if isNilDBPool(c.db) {
 		c.logger.Warn("Database not available, returning filtered exchanges")
 		return allExchanges

--- a/services/backend-api/internal/services/collector_validation_test.go
+++ b/services/backend-api/internal/services/collector_validation_test.go
@@ -96,6 +96,45 @@ func TestCollectorServiceSaveBulkTickerDataReusesCachedExchangeWithMixedCaseName
 	assertSQLiteScalar(t, db, "SELECT COUNT(*) FROM market_data WHERE exchange_id = 1", 1)
 }
 
+func TestCollectorServiceGetPrioritizedExchangesUsesSQLiteInClause(t *testing.T) {
+	db, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "collector-priority.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	createCollectorSQLiteSchema(t, db)
+
+	ctx := context.Background()
+	_, err = db.Exec(ctx, `
+		INSERT INTO exchanges (name, display_name, ccxt_id, is_active, priority)
+		VALUES
+			('binance', 'Binance', 'binance', 1, 20),
+			('bybit', 'Bybit', 'bybit', 1, 10),
+			('kraken', 'Kraken', 'kraken', 0, 1)
+	`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO ccxt_exchanges (exchange_id, ccxt_id)
+		SELECT id, 'bybit-linear' FROM exchanges WHERE name = 'bybit'
+	`)
+	require.NoError(t, err)
+
+	mockCCXT := &testmocks.MockCCXTService{}
+	mockCCXT.On("GetSupportedExchanges").Return([]string{"binance", "kraken", "bybit"}).Once()
+
+	collector := NewCollectorService(
+		db,
+		mockCCXT,
+		&config.Config{Database: config.DatabaseConfig{Driver: "sqlite"}},
+		nil,
+		cache.NewInMemoryBlacklistCache(),
+	)
+	defer collector.Stop()
+
+	got := collector.getPrioritizedExchanges()
+	require.Equal(t, []string{"bybit-linear", "binance"}, got)
+	mockCCXT.AssertExpectations(t)
+}
+
 func newCollectorWithSQLiteAndRedis(t *testing.T) (*CollectorService, *database.SQLiteDB, *redis.Client) {
 	t.Helper()
 
@@ -141,6 +180,14 @@ func createCollectorSQLiteSchema(t *testing.T, db *database.SQLiteDB) {
 			last_ping DATETIME,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE TABLE ccxt_exchanges (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			exchange_id INTEGER NOT NULL,
+			ccxt_id TEXT NOT NULL UNIQUE,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (exchange_id) REFERENCES exchanges(id) ON DELETE CASCADE
 		)`,
 		`CREATE TABLE trading_pairs (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- add a collector startup guard for an empty CCXT-supported exchange list before priority querying
- add SQLite regression coverage that verifies prioritized exchanges use the SQLite IN-clause path and exclude inactive exchanges
- extend the collector SQLite test schema with the ccxt_exchanges table used by the priority query

Refs neura-v7e6.

## Validation
- go test ./internal/services -run 'TestCollectorService(GetPrioritizedExchangesUsesSQLiteInClause|_Start|_WaitForFirstData)|TestCollectorServiceSaveBulkTickerData'\n- go test ./internal/services\n- git diff --check\n- go test ./...\n- make lint\n- make build\n\nNote: this PR is stacked on #407 / fix/secret-generation-hardening and should not be merged independently of the stack.

## Summary by Sourcery

Guard collector prioritized exchange lookup when no CCXT-supported exchanges are available and extend SQLite-based validation around prioritized exchange selection.

Bug Fixes:
- Prevent prioritized exchange lookup from querying the database when CCXT returns an empty exchange list, avoiding unnecessary work and potential issues during collector startup.

Enhancements:
- Extend the collector SQLite test schema with a ccxt_exchanges table to support priority-based exchange queries.

Tests:
- Add a regression test to verify prioritized exchanges use the SQLite IN-clause path and exclude inactive exchanges when determining the exchange order.