### PR TITLE
Use decimal expectancy in pretrade gate

### DIFF
--- a/services/backend-api/internal/services/ai_memory.go
+++ b/services/backend-api/internal/services/ai_memory.go
@@ -65,7 +65,7 @@ type TradeExpectancyStats struct {
 	SampleSize    int
 	Wins          int
 	Losses        int
-	NetExpectancy float64
+	NetExpectancy decimal.Decimal
 }
 
 func NewTradeMemory(db *sql.DB) (*TradeMemory, error) {
@@ -657,8 +657,8 @@ func (tm *TradeMemory) GetScopedExpectancyStats(
 	stats.NetExpectancy = calculateNetExpectancy(
 		stats.Wins,
 		stats.Losses,
-		sumWin.InexactFloat64(),
-		sumLoss.InexactFloat64(),
+		sumWin,
+		sumLoss,
 	)
 	return stats, true, nil
 }

--- a/services/backend-api/internal/services/ai_memory_test.go
+++ b/services/backend-api/internal/services/ai_memory_test.go
@@ -406,7 +406,7 @@ func TestTradeMemory_GetScopedExpectancyStats(t *testing.T) {
 		assert.Equal(t, 3, stats.SampleSize)
 		assert.Equal(t, 2, stats.Wins)
 		assert.Equal(t, 1, stats.Losses)
-		assert.InDelta(t, 1.3333333, stats.NetExpectancy, 0.0001)
+		assert.InDelta(t, 1.3333333, stats.NetExpectancy.InexactFloat64(), 0.0001)
 	})
 
 	t.Run("scoped_no_match_returns_false", func(t *testing.T) {
@@ -440,7 +440,7 @@ func TestTradeMemory_GetScopedExpectancyStats(t *testing.T) {
 		assert.Zero(t, stats.SampleSize)
 		assert.Zero(t, stats.Wins)
 		assert.Zero(t, stats.Losses)
-		assert.Zero(t, stats.NetExpectancy)
+		assert.True(t, stats.NetExpectancy.IsZero())
 	})
 }
 
@@ -470,7 +470,7 @@ func TestTradeMemory_GetScopedExpectancyStats_BitgetExchangeReconciliationSubtra
 	assert.Equal(t, 2, stats.SampleSize)
 	assert.Equal(t, 1, stats.Wins)
 	assert.Equal(t, 1, stats.Losses)
-	assert.InDelta(t, 0.75, stats.NetExpectancy, 0.0001)
+	assert.InDelta(t, 0.75, stats.NetExpectancy.InexactFloat64(), 0.0001)
 }
 
 func TestTradeMemory_GetScopedExpectancyStats_ExcludesSyntheticLifecycleCloses(t *testing.T) {
@@ -499,7 +499,7 @@ func TestTradeMemory_GetScopedExpectancyStats_ExcludesSyntheticLifecycleCloses(t
 	assert.Equal(t, 1, stats.SampleSize)
 	assert.Equal(t, 1, stats.Wins)
 	assert.Zero(t, stats.Losses)
-	assert.InDelta(t, 5.0, stats.NetExpectancy, 0.0001)
+	assert.InDelta(t, 5.0, stats.NetExpectancy.InexactFloat64(), 0.0001)
 }
 
 func TestTradeMemory_GetScopedExpectancyStats_MissingTableReturnsNoData(t *testing.T) {
@@ -621,7 +621,7 @@ func TestTradeMemory_GetScopedExpectancyStats_UsesConfiguredDefaultsAndDetermini
 	assert.Equal(t, 1, stats.SampleSize)
 	assert.Equal(t, 1, stats.Wins)
 	assert.Zero(t, stats.Losses)
-	assert.InDelta(t, 3.0, stats.NetExpectancy, 0.0001)
+	assert.InDelta(t, 3.0, stats.NetExpectancy.InexactFloat64(), 0.0001)
 }
 
 func TestTradeMemory_RecordLesson(t *testing.T) {

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -887,6 +887,13 @@ func decimalFromBalanceFloat(value float64) decimal.Decimal {
 	if value <= 0 {
 		return decimal.Zero
 	}
+	return decimalFromConfigFloat(value)
+}
+
+func decimalFromConfigFloat(value float64) decimal.Decimal {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return decimal.Zero
+	}
 	parsed, err := decimal.NewFromString(strconv.FormatFloat(value, 'f', -1, 64))
 	if err != nil {
 		return decimal.Zero
@@ -1281,7 +1288,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 			attemptedAction,
 			decision.Symbol,
 			gate.Regime,
-			gate.NetExpectancy,
+			gate.NetExpectancy.InexactFloat64(),
 			gate.SampleSize,
 			gate.Reason,
 		)
@@ -1291,7 +1298,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 			BlockCode:   classifyPreTradeBlockCode(gate.Reason),
 		}
 		decision.PreTradeRegime = gate.Regime
-		decision.PreTradeExpectancy = gate.NetExpectancy
+		decision.PreTradeExpectancy = gate.NetExpectancy.InexactFloat64()
 		decision.PreTradeExpectancySampleSize = gate.SampleSize
 		return decision, nil
 	}
@@ -1302,14 +1309,14 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 		}
 	}
 	decision.PreTradeRegime = gate.Regime
-	decision.PreTradeExpectancy = gate.NetExpectancy
+	decision.PreTradeExpectancy = gate.NetExpectancy.InexactFloat64()
 	decision.PreTradeExpectancySampleSize = gate.SampleSize
 	log.Printf(
 		"[AI-SCALPING] Dynamic thresholds: min_confidence=%.2f max_capital_pct=%.2f regime=%s expectancy=%.4f expectancy_n=%d phase=%s risk_drawdown=%.4f",
 		effectiveMinConfidence,
 		effectiveMaxCapital,
 		gate.Regime,
-		gate.NetExpectancy,
+		gate.NetExpectancy.InexactFloat64(),
 		gate.SampleSize,
 		portfolio.StrategyPhase,
 		portfolio.RiskDrawdown,
@@ -2244,7 +2251,7 @@ const (
 type preTradeGateResult struct {
 	Allowed           bool
 	Regime            string
-	NetExpectancy     float64
+	NetExpectancy     decimal.Decimal
 	SampleSize        int
 	CapitalMultiplier float64
 	Reason            string
@@ -2287,12 +2294,13 @@ func (s *AIScalpingService) evaluatePreTradeGate(ctx context.Context, decision *
 	expectancy, sample, hasExpectancy := s.estimateNetExpectancy(ctx, signal.Symbol, decision.Action)
 	result.NetExpectancy = expectancy
 	result.SampleSize = sample
-	if hasExpectancy && sample >= s.config.MinExpectancyN && expectancy < s.config.MinExpectancyEdge {
+	minExpectancyEdge := decimalFromConfigFloat(s.config.MinExpectancyEdge)
+	if hasExpectancy && sample >= s.config.MinExpectancyN && expectancy.LessThan(minExpectancyEdge) {
 		result.Allowed = false
 		result.Reason = fmt.Sprintf(
 			"pre-trade expectancy gate blocked %s: net expectancy %.4f below minimum %.4f (%d samples)",
 			signal.Symbol,
-			expectancy,
+			expectancy.InexactFloat64(),
 			s.config.MinExpectancyEdge,
 			sample,
 		)
@@ -2300,7 +2308,7 @@ func (s *AIScalpingService) evaluatePreTradeGate(ctx context.Context, decision *
 	}
 
 	// In choppy/non-directional conditions require either strong confidence or proven edge.
-	if regime == "chop" && decision.Confidence < 0.65 && (!hasExpectancy || expectancy <= s.config.MinExpectancyEdge) {
+	if regime == "chop" && decision.Confidence < 0.65 && (!hasExpectancy || !expectancy.GreaterThan(minExpectancyEdge)) {
 		result.Allowed = false
 		result.Reason = fmt.Sprintf(
 			"pre-trade regime gate blocked %s: choppy market with low confidence (%.2f)",
@@ -2351,7 +2359,7 @@ func (s *AIScalpingService) classifyScalpingRegime(signal aiMarketSignal, action
 	return "neutral", 0.85, ""
 }
 
-func (s *AIScalpingService) estimateNetExpectancy(ctx context.Context, symbol, action string) (float64, int, bool) {
+func (s *AIScalpingService) estimateNetExpectancy(ctx context.Context, symbol, action string) (decimal.Decimal, int, bool) {
 	normalizedSymbol := normalizeSymbolForComparison(symbol)
 	normalizedAction := strings.ToLower(strings.TrimSpace(action))
 	minSamples := s.config.MinExpectancyN
@@ -2376,7 +2384,7 @@ func (s *AIScalpingService) estimateNetExpectancy(ctx context.Context, symbol, a
 			)
 		} else if found {
 			if scoped.SampleSize == 0 {
-				return 0, 0, false
+				return decimal.Zero, 0, false
 			}
 			if scoped.SampleSize >= minSamples {
 				return scoped.NetExpectancy, scoped.SampleSize, true
@@ -2386,8 +2394,8 @@ func (s *AIScalpingService) estimateNetExpectancy(ctx context.Context, symbol, a
 
 		trades, err := s.tradeMemory.GetRecentTrades(ctx, 250)
 		if err == nil && len(trades) > 0 {
-			sumWin := 0.0
-			sumLoss := 0.0
+			sumWin := decimal.Zero
+			sumLoss := decimal.Zero
 			wins := 0
 			losses := 0
 			for _, trade := range trades {
@@ -2401,16 +2409,16 @@ func (s *AIScalpingService) estimateNetExpectancy(ctx context.Context, symbol, a
 				if outcome != "win" && outcome != "loss" {
 					continue
 				}
-				pnl := trade.PnL.Abs().InexactFloat64()
-				if pnl <= 0 {
+				pnl := trade.PnL.Abs()
+				if !pnl.GreaterThan(decimal.Zero) {
 					continue
 				}
 				if outcome == "win" {
 					wins++
-					sumWin += pnl
+					sumWin = sumWin.Add(pnl)
 				} else {
 					losses++
-					sumLoss += pnl
+					sumLoss = sumLoss.Add(pnl)
 				}
 			}
 			if wins+losses >= minSamples {
@@ -2426,7 +2434,7 @@ func (s *AIScalpingService) estimateNetExpectancy(ctx context.Context, symbol, a
 	perf := GetScalpingPerformance().GetPerformance()
 	total := readIntMetric(perf["total_trades"])
 	if total <= 0 {
-		return 0, 0, false
+		return decimal.Zero, 0, false
 	}
 
 	winRate := readFloatMetric(perf["win_rate"])
@@ -2443,26 +2451,28 @@ func (s *AIScalpingService) estimateNetExpectancy(ctx context.Context, symbol, a
 	avgWin := math.Abs(readFloatMetric(perf["avg_win"]))
 	avgLoss := math.Abs(readFloatMetric(perf["avg_loss"]))
 	if avgWin == 0 && avgLoss == 0 {
-		return 0, total, false
+		return decimal.Zero, total, false
 	}
-	return winRate*avgWin - (1-winRate)*avgLoss, total, true
+	return decimalFromConfigFloat(winRate).Mul(decimalFromConfigFloat(avgWin)).
+		Sub(decimalFromConfigFloat(1 - winRate).Mul(decimalFromConfigFloat(avgLoss))), total, true
 }
 
-func calculateNetExpectancy(wins, losses int, sumWin, sumLoss float64) float64 {
+func calculateNetExpectancy(wins, losses int, sumWin, sumLoss decimal.Decimal) decimal.Decimal {
 	total := wins + losses
 	if total == 0 {
-		return 0
+		return decimal.Zero
 	}
-	winRate := float64(wins) / float64(total)
-	avgWin := 0.0
+	totalDec := decimal.NewFromInt(int64(total))
+	winRate := decimal.NewFromInt(int64(wins)).Div(totalDec)
+	avgWin := decimal.Zero
 	if wins > 0 {
-		avgWin = sumWin / float64(wins)
+		avgWin = sumWin.Div(decimal.NewFromInt(int64(wins)))
 	}
-	avgLoss := 0.0
+	avgLoss := decimal.Zero
 	if losses > 0 {
-		avgLoss = sumLoss / float64(losses)
+		avgLoss = sumLoss.Div(decimal.NewFromInt(int64(losses)))
 	}
-	return winRate*avgWin - (1-winRate)*avgLoss
+	return winRate.Mul(avgWin).Sub(decimal.NewFromInt(1).Sub(winRate).Mul(avgLoss))
 }
 
 func (s *AIScalpingService) validateDecision(decision *AITradingDecision, signals []aiMarketSignal) error {
@@ -3386,7 +3396,7 @@ func (s *AIScalpingService) fallbackSymbolExpectancyAllowed(ctx context.Context,
 	if stats.SampleSize < minimumSample {
 		return true
 	}
-	return stats.NetExpectancy > 0
+	return stats.NetExpectancy.GreaterThan(decimal.Zero)
 }
 
 func fallbackProjectedNetEdgePct(spreadPct float64, rewardPct float64) float64 {

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -1092,14 +1092,14 @@ func TestAIScalpingService_EstimateNetExpectancy_PrefersScopedRealizedJournal(t 
 		expectancy, sample, found := svc.estimateNetExpectancy(ctx, "BTC/USDT", "buy")
 		assert.True(t, found)
 		assert.Equal(t, 2, sample)
-		assert.InDelta(t, 1.0, expectancy, 0.0001)
+		assert.InDelta(t, 1.0, expectancy.InexactFloat64(), 0.0001)
 	})
 
 	t.Run("action_miss_does_not_mix_opposite_side_scoped_results", func(t *testing.T) {
 		expectancy, sample, found := svc.estimateNetExpectancy(ctx, "BTC/USDT", "sell")
 		assert.False(t, found)
 		assert.Zero(t, sample)
-		assert.Zero(t, expectancy)
+		assert.True(t, expectancy.IsZero())
 	})
 }
 
@@ -1150,7 +1150,7 @@ func TestAIScalpingService_EstimateNetExpectancy_ScopedSampleBelowMinThresholdDo
 	expectancy, sample, found := svc.estimateNetExpectancy(ctx, "BTC/USDT", "buy")
 	assert.False(t, found)
 	assert.Equal(t, 1, sample)
-	assert.InDelta(t, 3.0, expectancy, 0.0001)
+	assert.InDelta(t, 3.0, expectancy.InexactFloat64(), 0.0001)
 }
 
 func TestAIScalpingService_EstimateNetExpectancy_ScopedSampleBelowMinThresholdFallsBackToLegacyHistory(t *testing.T) {
@@ -1205,7 +1205,7 @@ func TestAIScalpingService_EstimateNetExpectancy_ScopedSampleBelowMinThresholdFa
 	expectancy, sample, found := svc.estimateNetExpectancy(ctx, "BTC/USDT", "buy")
 	assert.True(t, found)
 	assert.Equal(t, 2, sample)
-	assert.InDelta(t, 0.5, expectancy, 0.0001)
+	assert.InDelta(t, 0.5, expectancy.InexactFloat64(), 0.0001)
 }
 
 func TestAIScalpingService_EstimateNetExpectancy_ScopedJournalUsesFeeAdjustedNetPnL(t *testing.T) {
@@ -1256,7 +1256,7 @@ func TestAIScalpingService_EstimateNetExpectancy_ScopedJournalUsesFeeAdjustedNet
 	expectancy, sample, found := svc.estimateNetExpectancy(ctx, "BTC/USDT", "buy")
 	assert.True(t, found)
 	assert.Equal(t, 2, sample)
-	assert.InDelta(t, -0.2, expectancy, 0.0001)
+	assert.InDelta(t, -0.2, expectancy.InexactFloat64(), 0.0001)
 }
 
 func TestAIScalpingService_EstimateNetExpectancy_ScopedQueryErrorFallsBackToLegacyHistory(t *testing.T) {
@@ -1293,7 +1293,7 @@ func TestAIScalpingService_EstimateNetExpectancy_ScopedQueryErrorFallsBackToLega
 	expectancy, sample, found := svc.estimateNetExpectancy(ctx, "BTC/USDT", "buy")
 	assert.True(t, found)
 	assert.Equal(t, 2, sample)
-	assert.InDelta(t, 0.5, expectancy, 0.0001)
+	assert.InDelta(t, 0.5, expectancy.InexactFloat64(), 0.0001)
 }
 
 func TestAIScalpingService_EstimateNetExpectancy_BreakevenScopedHistoryDoesNotFallbackToLegacy(t *testing.T) {
@@ -1332,7 +1332,7 @@ func TestAIScalpingService_EstimateNetExpectancy_BreakevenScopedHistoryDoesNotFa
 	expectancy, sample, found := svc.estimateNetExpectancy(ctx, "BTC/USDT", "buy")
 	assert.False(t, found)
 	assert.Zero(t, sample)
-	assert.Zero(t, expectancy)
+	assert.True(t, expectancy.IsZero())
 }
 
 func TestNormalizeHoldReasonCategory_RuntimeSignals(t *testing.T) {
@@ -2153,6 +2153,60 @@ func TestAIScalpingService_PreTradeGate_ExpectancyBlock(t *testing.T) {
 	assert.False(t, result.Allowed)
 	assert.Contains(t, result.Reason, "expectancy gate")
 	assert.GreaterOrEqual(t, result.SampleSize, 5)
+}
+
+func TestAIScalpingService_PreTradeGate_AllowsExactDecimalExpectancyEdge(t *testing.T) {
+	original := globalScalpingPerformance
+	globalScalpingPerformance = NewScalpingPerformance()
+	t.Cleanup(func() {
+		globalScalpingPerformance = original
+	})
+
+	db := setupTestDB(t)
+	tm, err := NewTradeMemory(db)
+	require.NoError(t, err)
+	setupRealizedPnLJournal(t, db)
+
+	_, err = db.Exec(`INSERT INTO realized_pnl_journal (
+		id, order_id, chat_id, exchange, symbol, side, filled_amount, entry_price, exit_price, realized_pnl, fees, source, closed_at, created_at
+	) VALUES
+		('rp_edge_win', 'ord_edge_win', 'chat-edge', 'bitget', 'ADA/USDT', 'buy', 1, 100, 100.3, 0.3, 0, 'autonomous', datetime('now'), datetime('now')),
+		('rp_edge_loss', 'ord_edge_loss', 'chat-edge', 'bitget', 'ADA/USDT', 'buy', 1, 100, 99.9, -0.1, 0, 'autonomous', datetime('now'), datetime('now'))`)
+	require.NoError(t, err)
+
+	svc := &AIScalpingService{
+		config: AIScalpingConfig{
+			PreTradeGate:      true,
+			MinExpectancyEdge: 0.1,
+			MinExpectancyN:    2,
+			RegimeHighBand:    85,
+			RegimeLowBand:     15,
+		},
+		tradeMemory: tm,
+	}
+	decision := &AITradingDecision{
+		Action:     "buy",
+		Symbol:     "ADA/USDT",
+		Confidence: 0.75,
+	}
+	signals := []aiMarketSignal{
+		{
+			Symbol:             "ADA/USDT",
+			Price:              1.0,
+			BidAskSpread:       0.03,
+			OrderBookImbalance: 0.32,
+			RangePosition24h:   55,
+		},
+	}
+	ctx := WithScalpingAutonomyScope(context.Background(), ScalpingAutonomyScope{
+		ChatID:   "chat-edge",
+		Exchange: "bitget",
+	})
+
+	result := svc.evaluatePreTradeGate(ctx, decision, signals)
+	require.True(t, result.Allowed, result.Reason)
+	assert.Equal(t, 2, result.SampleSize)
+	assert.True(t, result.NetExpectancy.Equal(decimal.RequireFromString("0.1")), result.NetExpectancy.String())
 }
 
 func TestAIScalpingService_ExecuteTradingCycle_AppliesGateAdjustedMaxCapitalToDecision(t *testing.T) {


### PR DESCRIPTION
## Summary
- make TradeExpectancyStats and pre-trade gate expectancy carry decimal.Decimal internally
- keep scoped realized PnL and legacy trade-memory sums in decimal math through calculateNetExpectancy and estimateNetExpectancy
- compare pre-trade expectancy thresholds with decimal comparisons, converting to float only for existing telemetry/log display fields
- add a regression where scoped expectancy exactly equals the configured minimum edge so float rounding cannot incorrectly block a trade

Closes NeuraTrade-egn.

## Validation
- go test ./internal/services -run 'TestTradeMemory_GetScopedExpectancyStats|TestAIScalpingService_EstimateNetExpectancy|TestAIScalpingService_PreTradeGate'\n- git diff --check\n- go test ./internal/services\n- go test ./...\n- make lint\n- make build\n\nNote: this PR is stacked on #409 / fix/status-entry-attempt-blocker-display and should not be merged independently of the stack.

## Summary by Sourcery

Use decimal-based expectancy throughout scalping pre-trade gating to avoid floating-point rounding issues and ensure exact-edge trades are handled correctly.

Bug Fixes:
- Prevent pre-trade expectancy gate from incorrectly blocking trades when scoped expectancy exactly matches the configured minimum edge due to float rounding.

Enhancements:
- Represent trade expectancy stats and pre-trade gate net expectancy with decimal.Decimal rather than float to keep expectancy math in decimal space.
- Maintain decimal math for scoped realized PnL and legacy trade-history sums, converting to float only for telemetry and decision/log display fields.
- Adjust fallback symbol expectancy checks to use decimal comparisons for determining whether positive edge exists.

Tests:
- Update existing trade memory and AI scalping expectancy tests to assert against decimal-based expectancy values.
- Add a regression test confirming the pre-trade gate allows trades when scoped decimal expectancy equals the configured minimum edge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced numeric precision in trading expectancy calculations for improved accuracy in metrics computation

* **Tests**
  * Updated test assertions to validate precision improvements across trading services

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->