### PR TITLE
Make scoped expectancy symbol matching portable

### DIFF
--- a/services/backend-api/internal/services/ai_memory.go
+++ b/services/backend-api/internal/services/ai_memory.go
@@ -569,19 +569,9 @@ func (tm *TradeMemory) GetScopedExpectancyStats(
 	exchange := strings.TrimSpace(scope.Exchange)
 	normalizedSymbol := normalizeSymbolForComparison(symbol)
 	normalizedAction := normalizeLifecycleSide(action)
-	const normalizedScopedSymbolSQL = `
-		UPPER(REPLACE(
-			CASE
-				WHEN INSTR(TRIM(symbol), ':') > 0 THEN SUBSTR(TRIM(symbol), 1, INSTR(TRIM(symbol), ':') - 1)
-				ELSE TRIM(symbol)
-			END,
-			'-',
-			'/'
-		))
-	`
 
 	scopedExpectancyBaseQuery := fmt.Sprintf(`
-		SELECT %s AS net_realized_pnl
+		SELECT symbol, %s AS net_realized_pnl
 		FROM realized_pnl_journal
 		WHERE closed_at >= ? AND closed_at <= ?
 			AND %s
@@ -604,8 +594,9 @@ func (tm *TradeMemory) GetScopedExpectancyStats(
 		normalizedAction,
 	}
 	if normalizedSymbol != "" {
-		query += "\n\t\t\tAND " + normalizedScopedSymbolSQL + " = ?"
-		args = append(args, normalizedSymbol)
+		escapedSymbol := escapeSQLLikePattern(normalizedSymbol)
+		query += "\n\t\t\tAND (UPPER(REPLACE(TRIM(symbol), '-', '/')) = ? OR UPPER(REPLACE(TRIM(symbol), '-', '/')) LIKE ? ESCAPE '\\')"
+		args = append(args, normalizedSymbol, escapedSymbol+":%")
 	}
 	query += scopedExpectancyOrderClause
 	if limit > 0 {
@@ -627,21 +618,27 @@ func (tm *TradeMemory) GetScopedExpectancyStats(
 	sumLoss := decimal.Zero
 	matchedRows := 0
 	for rows.Next() {
+		var rowSymbol string
 		var pnl decimal.Decimal
-		if err := rows.Scan(&pnl); err != nil {
+		if err := rows.Scan(&rowSymbol, &pnl); err != nil {
 			return nil, false, fmt.Errorf("scan scoped expectancy stats: %w", err)
 		}
-		matchedRows++
-		if pnl.IsZero() {
+		if normalizedSymbol != "" && normalizeSymbolForComparison(rowSymbol) != normalizedSymbol {
 			continue
 		}
-		if pnl.GreaterThan(decimal.Zero) {
+		matchedRows++
+		switch {
+		case pnl.IsZero():
+		case pnl.GreaterThan(decimal.Zero):
 			stats.Wins++
 			sumWin = sumWin.Add(pnl)
-			continue
+		default:
+			stats.Losses++
+			sumLoss = sumLoss.Add(pnl.Abs())
 		}
-		stats.Losses++
-		sumLoss = sumLoss.Add(pnl.Abs())
+		if limit > 0 && normalizedSymbol != "" && matchedRows >= limit {
+			break
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, false, fmt.Errorf("iterate scoped expectancy stats: %w", err)
@@ -661,6 +658,11 @@ func (tm *TradeMemory) GetScopedExpectancyStats(
 		sumLoss,
 	)
 	return stats, true, nil
+}
+
+func escapeSQLLikePattern(value string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return replacer.Replace(value)
 }
 
 func hasRealizedPnLWindowScope(scope ScalpingAutonomyScope) bool {

--- a/services/backend-api/internal/services/ai_memory_test.go
+++ b/services/backend-api/internal/services/ai_memory_test.go
@@ -624,6 +624,78 @@ func TestTradeMemory_GetScopedExpectancyStats_UsesConfiguredDefaultsAndDetermini
 	assert.InDelta(t, 3.0, stats.NetExpectancy.InexactFloat64(), 0.0001)
 }
 
+func TestTradeMemory_GetScopedExpectancyStats_AppliesLimitAfterAppSymbolNormalization(t *testing.T) {
+	db := setupTestDB(t)
+	tm, err := NewTradeMemoryWithConfig(db, TradeMemoryConfig{
+		MemoryLookbackHoursDefault: 24,
+		MemorySampleLimitDefault:   1,
+	})
+	require.NoError(t, err)
+
+	setupRealizedPnLJournal(t, db)
+
+	closedAt := time.Now().UTC().Truncate(time.Second)
+	_, err = db.Exec(`INSERT INTO realized_pnl_journal (
+		id, order_id, chat_id, exchange, symbol, side, filled_amount, entry_price, exit_price, realized_pnl, fees, source, closed_at, created_at
+	) VALUES
+		('rp_newer_other_symbol', 'ord_newer_other_symbol', 'chat-1', 'bitget', 'ETH/USDT', 'buy', 1, 100, 120, 20, 0, 'autonomous', ?, ?),
+		('rp_matching_suffix', 'ord_matching_suffix', 'chat-1', 'bitget', 'BTC-USDT:USDT', 'buy', 1, 100, 103, 3, 0, 'autonomous', ?, ?)`,
+		closedAt, closedAt,
+		closedAt.Add(-time.Minute), closedAt.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+
+	ctx := WithScalpingAutonomyScope(context.Background(), ScalpingAutonomyScope{
+		ChatID:   "chat-1",
+		Exchange: "bitget",
+	})
+
+	stats, found, err := tm.GetScopedExpectancyStats(ctx, "BTC/USDT", "buy", 0, 0)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotNil(t, stats)
+	assert.Equal(t, 1, stats.SampleSize)
+	assert.Equal(t, 1, stats.Wins)
+	assert.Zero(t, stats.Losses)
+	assert.InDelta(t, 3.0, stats.NetExpectancy.InexactFloat64(), 0.0001)
+}
+
+func TestTradeMemory_GetScopedExpectancyStats_SQLPrefilterKeepsLimitBounded(t *testing.T) {
+	db := setupTestDB(t)
+	tm, err := NewTradeMemoryWithConfig(db, TradeMemoryConfig{
+		MemoryLookbackHoursDefault: 24,
+		MemorySampleLimitDefault:   1,
+	})
+	require.NoError(t, err)
+
+	setupRealizedPnLJournal(t, db)
+
+	closedAt := time.Now().UTC().Truncate(time.Second)
+	_, err = db.Exec(`INSERT INTO realized_pnl_journal (
+		id, order_id, chat_id, exchange, symbol, side, filled_amount, entry_price, exit_price, realized_pnl, fees, source, closed_at, created_at
+	) VALUES
+		('rp_newer_prefix_only', 'ord_newer_prefix_only', 'chat-1', 'bitget', 'BTC/USDT2', 'buy', 1, 100, 120, 20, 0, 'autonomous', ?, ?),
+		('rp_matching_suffix_limited', 'ord_matching_suffix_limited', 'chat-1', 'bitget', 'BTC-USDT:USDT', 'buy', 1, 100, 103, 3, 0, 'autonomous', ?, ?)`,
+		closedAt, closedAt,
+		closedAt.Add(-time.Minute), closedAt.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+
+	ctx := WithScalpingAutonomyScope(context.Background(), ScalpingAutonomyScope{
+		ChatID:   "chat-1",
+		Exchange: "bitget",
+	})
+
+	stats, found, err := tm.GetScopedExpectancyStats(ctx, "BTC/USDT", "buy", 0, 0)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotNil(t, stats)
+	assert.Equal(t, 1, stats.SampleSize)
+	assert.Equal(t, 1, stats.Wins)
+	assert.Zero(t, stats.Losses)
+	assert.InDelta(t, 3.0, stats.NetExpectancy.InexactFloat64(), 0.0001)
+}
+
 func TestTradeMemory_RecordLesson(t *testing.T) {
 	db := setupTestDB(t)
 	tm, err := NewTradeMemory(db)


### PR DESCRIPTION
## Summary
- remove SQLite-specific INSTR/SUBSTR symbol normalization from GetScopedExpectancyStats
- normalize realized PnL journal symbols in Go before expectancy aggregation
- preserve sample-limit semantics by applying the limit after normalized symbol matching
- add regression coverage where a newer non-matching symbol does not crowd out the latest matching normalized symbol

Closes NeuraTrade-t0b.

## Validation
- go test ./internal/services -run 'TestTradeMemory_GetScopedExpectancyStats'\n- rg -n 'INSTR\\(|SUBSTR\\(|normalizedScopedSymbolSQL' services/backend-api/internal/services/ai_memory.go (no matches)\n- git diff --check\n- go test ./internal/services\n- go test ./...\n- make lint\n- make build\n\nNote: this PR is stacked on #410 / fix/scoped-expectancy-decimal and should not be merged independently of the stack.

## Summary by Sourcery

Normalize scoped expectancy symbol matching in application code instead of SQL and ensure sampling limits are applied after normalization.

Bug Fixes:
- Fix scoped expectancy stats to correctly match normalized symbols without relying on SQLite-specific INSTR/SUBSTR behavior.
- Ensure sample limits for scoped expectancy are enforced after normalized symbol matching so newer non-matching symbols do not displace valid matches.

Tests:
- Add regression test to verify scoped expectancy limit behavior when newer non-matching symbols exist alongside older matching normalized symbols.