### PR TITLE
Wrap detached goroutines in lifecycle contexts

### DIFF
--- a/services/backend-api/cmd/server/main.go
+++ b/services/backend-api/cmd/server/main.go
@@ -498,6 +498,7 @@ func run() error {
 		api.RouteOptions{
 			KillSwitch: runtimeKillSwitch,
 			SafeMode:   runtimeSafeMode,
+			Context:    ctx,
 		},
 	)
 	defer cleanupRoutes()

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -62,6 +62,7 @@ type routeDB interface {
 type RouteOptions struct {
 	KillSwitch *apprisk.KillSwitchImpl
 	SafeMode   *apprisk.SafeModeImpl
+	Context    context.Context
 }
 
 func (o RouteOptions) riskControls() (*apprisk.KillSwitchImpl, *apprisk.SafeModeImpl) {
@@ -74,6 +75,13 @@ func (o RouteOptions) riskControls() (*apprisk.KillSwitchImpl, *apprisk.SafeMode
 		safeMode = apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
 	}
 	return killSwitch, safeMode
+}
+
+func (o RouteOptions) lifecycleContext() (context.Context, context.CancelFunc) {
+	if o.Context != nil {
+		return context.WithCancel(o.Context)
+	}
+	return context.WithCancel(context.Background())
 }
 
 func diagnosticFloat(metrics map[string]interface{}, key string) (float64, bool) {
@@ -430,6 +438,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 //
 //nolint:staticcheck // SA1019: SignalAggregator and TechnicalAnalysisService are deprecated but required for backward compatibility until scalping composer migration completes.
 func SetupRoutesWithOptions(router *gin.Engine, db routeDB, redis *database.RedisClient, ccxtService ccxt.CCXTService, collectorService *services.CollectorService, cleanupService *services.CleanupService, cacheAnalyticsService *services.CacheAnalyticsService, signalAggregator *services.SignalAggregator, analyticsService *services.AnalyticsService, telegramConfig *config.TelegramConfig, aiConfig *config.AIConfig, featuresConfig *config.FeaturesConfig, authMiddleware *middleware.AuthMiddleware, walletValidator *services.WalletValidator, opModeService *services.OperationalModeService, technicalAnalysisService *services.TechnicalAnalysisService, options RouteOptions) func() {
+	lifecycleCtx, cancelLifecycle := options.lifecycleContext()
 	configureLiveReadinessGuard(opModeService)
 
 	// Initialize admin middleware
@@ -1003,7 +1012,7 @@ func SetupRoutesWithOptions(router *gin.Engine, db routeDB, redis *database.Redi
 		} else {
 			// Mandatory startup reconciliation in non-test runtime.
 			// This runs before autonomous chat restore so resumability/protection is refreshed first.
-			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			ctx, cancel := context.WithTimeout(lifecycleCtx, 45*time.Second)
 			results, err := reconciler.ReconcileAll(ctx, services.ReconciliationStartup, "")
 			cancel()
 			if err != nil {
@@ -1033,12 +1042,18 @@ func SetupRoutesWithOptions(router *gin.Engine, db routeDB, redis *database.Redi
 		if periodicSeconds > 0 {
 			interval := time.Duration(periodicSeconds) * time.Second
 			log.Printf("Periodic reconciliation enabled (interval=%s)", interval)
-			go func() {
+			go func(ctx context.Context) {
 				ticker := time.NewTicker(interval)
 				defer ticker.Stop()
-				for range ticker.C {
-					ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
-					results, err := reconciler.ReconcileAll(ctx, services.ReconciliationPeriodic, "")
+				for {
+					select {
+					case <-ctx.Done():
+						log.Printf("Periodic reconciliation stopped: %v", ctx.Err())
+						return
+					case <-ticker.C:
+					}
+					reconcileCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
+					results, err := reconciler.ReconcileAll(reconcileCtx, services.ReconciliationPeriodic, "")
 					cancel()
 					if err != nil {
 						log.Printf("Periodic reconciliation error: %v", err)
@@ -1048,7 +1063,7 @@ func SetupRoutesWithOptions(router *gin.Engine, db routeDB, redis *database.Redi
 						log.Printf("Periodic reconciliation: %s", reconciler.GetReconciliationSummary(&r))
 					}
 				}
-			}()
+			}(lifecycleCtx)
 		} else {
 			log.Printf("Periodic reconciliation disabled (NEURATRADE_PERIODIC_RECONCILIATION_SECONDS=0)")
 		}
@@ -1100,11 +1115,11 @@ func SetupRoutesWithOptions(router *gin.Engine, db routeDB, redis *database.Redi
 	// It can be re-enabled only when AI arbitrage mode is explicitly turned on.
 	if featuresConfig != nil && featuresConfig.EnableAIArbitrage {
 		arbitrageBridge := services.NewArbitrageExecutionBridge(db, questEngine, signalAggregator, nil)
-		go func() {
-			if err := arbitrageBridge.Start(context.Background()); err != nil {
+		go func(ctx context.Context) {
+			if err := arbitrageBridge.Start(ctx); err != nil {
 				log.Printf("Arbitrage execution bridge error: %v", err)
 			}
-		}()
+		}(lifecycleCtx)
 		log.Printf("Arbitrage execution bridge enabled (features.enable_ai_arbitrage=true)")
 	} else {
 		log.Printf("Arbitrage execution bridge disabled in scalping-first mode")
@@ -1432,6 +1447,7 @@ func SetupRoutesWithOptions(router *gin.Engine, db routeDB, redis *database.Redi
 
 	// Return cleanup function for WebSocket handler and other resources
 	return func() {
+		cancelLifecycle()
 		if webSocketHandler != nil {
 			webSocketHandler.Stop()
 		}

--- a/services/backend-api/internal/api/routes_test.go
+++ b/services/backend-api/internal/api/routes_test.go
@@ -199,6 +199,28 @@ func TestSetupRoutesWithOptions_AgentRiskControlsUseProvidedInstances(t *testing
 	}
 }
 
+func TestRouteOptionsLifecycleContextUsesProvidedContext(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctx, cleanup := (RouteOptions{Context: parent}).lifecycleContext()
+
+	cleanup()
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.NoError(t, parent.Err())
+
+	cancel()
+	require.ErrorIs(t, parent.Err(), context.Canceled)
+}
+
+func TestRouteOptionsLifecycleContextCreatesOwnedContext(t *testing.T) {
+	ctx, cleanup := (RouteOptions{}).lifecycleContext()
+	require.NoError(t, ctx.Err())
+
+	cleanup()
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
 // Test HealthResponse struct
 func TestHealthResponse_Struct(t *testing.T) {
 	now := time.Now()

--- a/services/backend-api/internal/services/ai/brain.go
+++ b/services/backend-api/internal/services/ai/brain.go
@@ -8,12 +8,14 @@ import (
 	"math/rand"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/irfndi/neuratrade/internal/ai/llm"
 )
 
 const defaultAIBrainModel = "deepseek-chat"
+const defaultLearningRecordTimeout = 5 * time.Second
 
 // TradingAction represents the action AI decides to take
 type TradingAction string
@@ -151,6 +153,11 @@ type AITradingBrain struct {
 	learningSystem LearningSystem
 	config         AIBrainConfig
 	logger         *log.Logger
+	lifecycleCtx   context.Context
+	cancel         context.CancelFunc
+	lifecycleMu    sync.Mutex
+	closed         bool
+	wg             sync.WaitGroup
 }
 
 // AIBrainConfig holds configuration for AI Brain
@@ -191,13 +198,46 @@ func NewAITradingBrain(
 	learningSystem LearningSystem,
 	config AIBrainConfig,
 ) *AITradingBrain {
+	return NewAITradingBrainWithContext(context.Background(), llmClient, toolRegistry, learningSystem, config)
+}
+
+// NewAITradingBrainWithContext creates an AI trading brain bound to a caller-owned lifecycle context.
+func NewAITradingBrainWithContext(
+	ctx context.Context,
+	llmClient llm.Client,
+	toolRegistry ToolRegistry,
+	learningSystem LearningSystem,
+	config AIBrainConfig,
+) *AITradingBrain {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	lifecycleCtx, cancel := context.WithCancel(ctx)
 	return &AITradingBrain{
 		llmClient:      llmClient,
 		toolRegistry:   toolRegistry,
 		learningSystem: learningSystem,
 		config:         config,
 		logger:         log.Default(),
+		lifecycleCtx:   lifecycleCtx,
+		cancel:         cancel,
 	}
+}
+
+// Close cancels background learning work and waits for it to exit.
+func (brain *AITradingBrain) Close() {
+	if brain == nil {
+		return
+	}
+	brain.lifecycleMu.Lock()
+	if !brain.closed {
+		brain.closed = true
+		if brain.cancel != nil {
+			brain.cancel()
+		}
+	}
+	brain.lifecycleMu.Unlock()
+	brain.wg.Wait()
 }
 
 // Reason processes market data and makes trading decision
@@ -260,21 +300,18 @@ func (brain *AITradingBrain) Reason(ctx context.Context, req *ReasoningRequest) 
 
 	// Record decision for learning
 	if brain.config.EnableLearning {
-		go func() {
-			if err := brain.learningSystem.RecordDecision(context.Background(), &DecisionRecord{
-				ID:          decision.ID,
-				Timestamp:   time.Now(),
-				Strategy:    req.Strategy,
-				MarketState: req.MarketState,
-				Decision:    *decision,
-				Reasoning:   llmResp.Message.Content,
-				Confidence:  decision.Confidence,
-				ModelUsed:   brain.config.Model,
-				TokensUsed:  llmResp.Usage.TotalTokens,
-			}); err != nil {
-				log.Printf("Failed to record decision for learning: %v", err)
-			}
-		}()
+		record := &DecisionRecord{
+			ID:          decision.ID,
+			Timestamp:   time.Now(),
+			Strategy:    req.Strategy,
+			MarketState: req.MarketState,
+			Decision:    *decision,
+			Reasoning:   llmResp.Message.Content,
+			Confidence:  decision.Confidence,
+			ModelUsed:   brain.config.Model,
+			TokensUsed:  llmResp.Usage.TotalTokens,
+		}
+		brain.recordDecisionAsync(record)
 	}
 
 	executionTime := time.Since(startTime)
@@ -291,6 +328,29 @@ func (brain *AITradingBrain) Reason(ctx context.Context, req *ReasoningRequest) 
 		ModelUsed:     brain.config.Model,
 		TokensUsed:    llmResp.Usage.TotalTokens,
 	}, nil
+}
+
+func (brain *AITradingBrain) recordDecisionAsync(record *DecisionRecord) {
+	if brain == nil || brain.learningSystem == nil || record == nil {
+		return
+	}
+	brain.lifecycleMu.Lock()
+	if brain.closed || brain.lifecycleCtx == nil || brain.lifecycleCtx.Err() != nil {
+		brain.lifecycleMu.Unlock()
+		return
+	}
+	parentCtx := brain.lifecycleCtx
+	brain.wg.Add(1)
+	brain.lifecycleMu.Unlock()
+
+	go func() {
+		defer brain.wg.Done()
+		ctx, cancel := context.WithTimeout(parentCtx, defaultLearningRecordTimeout)
+		defer cancel()
+		if err := brain.learningSystem.RecordDecision(ctx, record); err != nil {
+			brain.logger.Printf("Failed to record decision for learning: %v", err)
+		}
+	}()
 }
 
 // buildSystemPrompt creates the system prompt based on strategy

--- a/services/backend-api/internal/services/ai/brain_test.go
+++ b/services/backend-api/internal/services/ai/brain_test.go
@@ -111,6 +111,26 @@ func (m *MockLearningSystem) RecordOutcome(ctx context.Context, decisionID strin
 	return nil
 }
 
+type blockingLearningSystem struct {
+	started chan struct{}
+	done    chan struct{}
+}
+
+func (b *blockingLearningSystem) RecordDecision(ctx context.Context, record *DecisionRecord) error {
+	close(b.started)
+	<-ctx.Done()
+	close(b.done)
+	return ctx.Err()
+}
+
+func (b *blockingLearningSystem) GetSimilarDecisions(ctx context.Context, symbol string, limit int) ([]*DecisionRecord, error) {
+	return nil, nil
+}
+
+func (b *blockingLearningSystem) RecordOutcome(ctx context.Context, decisionID string, outcome *TradeOutcome) error {
+	return nil
+}
+
 func TestMain(m *testing.M) {
 	// Disable logging during tests
 	log.SetOutput(os.NewFile(0, os.DevNull))
@@ -229,6 +249,72 @@ func TestAITradingBrain_Reason_Success(t *testing.T) {
 	}
 	if resp.Confidence < 0 || resp.Confidence > 1 {
 		t.Errorf("Expected confidence between 0 and 1, got %f", resp.Confidence)
+	}
+}
+
+func TestAITradingBrain_CloseCancelsAsyncLearningRecord(t *testing.T) {
+	mockLLM := &MockLLMClient{
+		response: &llm.CompletionResponse{
+			Message: llm.Message{
+				Role:    "assistant",
+				Content: `{"action": "buy", "symbol": "BTC/USDT", "side": "buy", "size_percent": 1.5, "confidence": 0.85, "reasoning": "Strong uptrend"}`,
+			},
+			Usage: llm.UsageMetrics{TotalTokens: 100},
+		},
+	}
+	mockRegistry := NewMockToolRegistry()
+	learning := &blockingLearningSystem{
+		started: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+	config := DefaultAIBrainConfig()
+	brain := NewAITradingBrain(mockLLM, mockRegistry, learning, config)
+
+	req := &ReasoningRequest{
+		RequestID: "test-close",
+		Timestamp: time.Now(),
+		Strategy:  "scalping",
+		MarketState: MarketState{
+			Symbol:    "BTC/USDT",
+			Exchange:  "binance",
+			Price:     45000.00,
+			Volume24h: 1000000,
+			Timestamp: time.Now(),
+		},
+		PortfolioState: PortfolioState{
+			Balance:        10000.00,
+			AvailableFunds: 8000.00,
+		},
+	}
+
+	resp, err := brain.Reason(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("Expected non-nil response")
+	}
+	select {
+	case <-learning.started:
+	case <-time.After(time.Second):
+		t.Fatal("Timed out waiting for async learning record to start")
+	}
+
+	closeReturned := make(chan struct{})
+	go func() {
+		brain.Close()
+		close(closeReturned)
+	}()
+
+	select {
+	case <-learning.done:
+	case <-time.After(time.Second):
+		t.Fatal("Timed out waiting for async learning record cancellation")
+	}
+	select {
+	case <-closeReturned:
+	case <-time.After(time.Second):
+		t.Fatal("Timed out waiting for brain Close")
 	}
 }
 

--- a/services/backend-api/internal/services/ai/scalping.go
+++ b/services/backend-api/internal/services/ai/scalping.go
@@ -116,6 +116,9 @@ func (s *AIScalpingService) Stop() {
 	s.logger.Println("[AI Scalping] Stopping service")
 	s.cancel()
 	s.wg.Wait()
+	if s.brain != nil {
+		s.brain.Close()
+	}
 }
 
 // GetActivePositions returns active positions

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -751,6 +751,8 @@ type AIScalpingService struct {
 	autonomyState                     AIScalpingAutonomyState
 	shadowMu                          sync.RWMutex
 	shadow                            *ShadowEvaluationCoordinator
+	shadowMirrorMu                    sync.Mutex
+	shadowMirrorSlots                 chan struct{}
 }
 
 type symbolExecutionGuard struct {
@@ -778,6 +780,8 @@ const (
 	runtimeStatusCircuitOpen      = "circuit_open"
 	runtimeStatusLLMDegraded      = "llm_degraded"
 )
+
+const defaultShadowMirrorConcurrency = 4
 
 func isInfrastructureRuntimeStatus(status string) bool {
 	switch strings.ToLower(strings.TrimSpace(status)) {
@@ -1167,7 +1171,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 	var funnel appautonomy.CandidateFunnelSnapshot
 	defer func() {
 		finalizeDecisionMetadata(decision, &policy, effectiveMinConfidence, effectiveMaxCapital, funnel)
-		s.mirrorShadowDecisionAsync(decision, portfolio, policy)
+		s.mirrorShadowDecisionAsync(context.WithoutCancel(ctx), decision, portfolio, policy)
 	}()
 	if !walletBasis(portfolio).GreaterThan(decimal.Zero) {
 		reason := "wallet basis is zero; waiting for funded balance before autonomous execution"
@@ -2993,6 +2997,7 @@ func runtimeDegradedHoldDecision(reason string, category string) *AITradingDecis
 }
 
 func (s *AIScalpingService) mirrorShadowDecisionAsync(
+	ctx context.Context,
 	decision *AITradingDecision,
 	portfolio TradingPortfolio,
 	policy appautonomy.ScalpingCyclePolicy,
@@ -3001,16 +3006,44 @@ func (s *AIScalpingService) mirrorShadowDecisionAsync(
 	if coordinator == nil || decision == nil {
 		return
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	decisionSnapshot := cloneAITradingDecision(decision)
 	portfolioSnapshot := portfolio
 	policySnapshot := policy
+	release, ok := s.acquireShadowMirrorSlot()
+	if !ok {
+		log.Printf("[AI-SCALPING] Shadow mirror decision skipped: concurrency limit reached")
+		return
+	}
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer release()
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 		if _, err := coordinator.MirrorDecision(ctx, decisionSnapshot, portfolioSnapshot, policySnapshot); err != nil {
 			log.Printf("[AI-SCALPING] Shadow mirror decision failed: %v", err)
 		}
 	}()
+}
+
+func (s *AIScalpingService) acquireShadowMirrorSlot() (func(), bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.shadowMirrorMu.Lock()
+	if s.shadowMirrorSlots == nil {
+		s.shadowMirrorSlots = make(chan struct{}, defaultShadowMirrorConcurrency)
+	}
+	slots := s.shadowMirrorSlots
+	s.shadowMirrorMu.Unlock()
+
+	select {
+	case slots <- struct{}{}:
+		return func() { <-slots }, true
+	default:
+		return nil, false
+	}
 }
 
 // cloneAITradingDecision returns an independent copy of the provided AITradingDecision.

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -3068,3 +3068,27 @@ func TestAIScalpingService_ExchangeForContextPrefersScopedExchange(t *testing.T)
 	assert.Equal(t, "binance", svc.exchangeForContext(ctx))
 	assert.Equal(t, "bitget", svc.exchangeForContext(context.Background()))
 }
+
+func TestAIScalpingService_AcquireShadowMirrorSlotIsBounded(t *testing.T) {
+	svc := &AIScalpingService{}
+	releases := make([]func(), 0, defaultShadowMirrorConcurrency)
+	for i := 0; i < defaultShadowMirrorConcurrency; i++ {
+		release, ok := svc.acquireShadowMirrorSlot()
+		require.True(t, ok)
+		require.NotNil(t, release)
+		releases = append(releases, release)
+	}
+
+	release, ok := svc.acquireShadowMirrorSlot()
+	require.False(t, ok)
+	require.Nil(t, release)
+
+	releases[0]()
+	release, ok = svc.acquireShadowMirrorSlot()
+	require.True(t, ok)
+	require.NotNil(t, release)
+	release()
+	for _, release := range releases[1:] {
+		release()
+	}
+}


### PR DESCRIPTION
## Summary
- thread route-owned reconciliation and arbitrage bridge loops through a RouteOptions lifecycle context
- add cancellable async learning lifecycle management to the legacy AI trading brain
- bound async shadow-decision mirroring with a non-blocking concurrency cap

## Validation
- go test ./internal/services/ai -run 'TestAITradingBrain_CloseCancelsAsyncLearningRecord|TestAITradingBrain_Reason_Success|TestNewAITradingBrain'\n- go test ./internal/services -run 'TestAIScalpingService_AcquireShadowMirrorSlotIsBounded'\n- go test ./internal/api -run 'TestRouteOptionsLifecycleContext|TestSetupRoutesWithOptions_AgentRiskControlsUseProvidedInstances'\n- git diff --check\n- go test ./internal/services/ai\n- go test ./internal/api\n- go test ./internal/services\n- go test ./...\n- make lint\n- make build\n\nIssue: NeuraTrade-fq8

## Summary by Sourcery

Thread background AI learning, reconciliation, and arbitrage goroutines through explicit lifecycle contexts and add bounds to concurrent shadow-mirroring operations.

New Features:
- Expose AI trading brain construction with a caller-owned lifecycle context and provide a Close method to shut down background learning work.
- Introduce a lifecycle context option for API routes that controls periodic reconciliation and arbitrage bridge execution.

Bug Fixes:
- Ensure async learning decision recording is cancelable and does not leak goroutines when the AI trading brain is closed.
- Prevent unbounded spawning of shadow decision mirror goroutines by enforcing a fixed concurrency limit.

Enhancements:
- Tighten AIScalpingService shutdown to also close the associated AI trading brain.
- Make periodic reconciliation and arbitrage bridge loops respect route lifecycle cancellation instead of using background contexts.

Tests:
- Add tests validating AI trading brain lifecycle cancellation of async learning, bounded shadow mirror slot acquisition, and RouteOptions lifecycle context behavior.