### PR TITLE
Cache recent Bitget leverage sync checks

### DIFF
--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -34,16 +35,26 @@ type BitgetOrderExecutor struct {
 	walletBalance       float64
 	httpClient          *http.Client
 	leverageMu          sync.Mutex
+	leverageCacheMu     sync.Mutex
+	leverageCache       map[bitgetLeverageCacheKey]bitgetLeverageCacheEntry
+	leverageMetrics     bitgetLeverageSyncMetrics
+	leverageCacheTTL    time.Duration
 }
+
+const (
+	defaultBitgetLeverageCacheTTL = 2 * time.Minute
+	bitgetLeverageCacheTTLEnv     = "NEURATRADE_BITGET_LEVERAGE_CACHE_TTL"
+)
 
 // NewBitgetOrderExecutor creates a new Bitget order executor
 func NewBitgetOrderExecutor(apiKey, apiSecret, passphrase string) *BitgetOrderExecutor {
 	return &BitgetOrderExecutor{
-		apiKey:     apiKey,
-		apiSecret:  apiSecret,
-		passphrase: passphrase,
-		baseURL:    "https://api.bitget.com",
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		apiKey:           apiKey,
+		apiSecret:        apiSecret,
+		passphrase:       passphrase,
+		baseURL:          "https://api.bitget.com",
+		httpClient:       &http.Client{Timeout: 30 * time.Second},
+		leverageCacheTTL: loadBitgetLeverageCacheTTL(),
 	}
 }
 
@@ -500,6 +511,35 @@ func (a bitgetFuturesAccount) effectiveLeverageForMarginMode(holdSide string, ma
 
 type bitgetLeverageField string
 
+type bitgetLeverageCacheKey struct {
+	Symbol          string
+	HoldSide        string
+	MarginMode      string
+	DesiredLeverage int
+}
+
+type bitgetLeverageCacheEntry struct {
+	EffectiveLeverage int
+	Status            string
+	ExpiresAt         time.Time
+}
+
+type bitgetLeverageSyncMetrics struct {
+	TotalCalls      int64
+	CacheHits       int64
+	CacheMisses     int64
+	TotalAPICalls   int64
+	TotalSetCalls   int64
+	LastSymbol      string
+	LastStatus      string
+	LastError       string
+	LastCacheHit    bool
+	LastAPICalls    int
+	LastSetCalls    int
+	LastDuration    time.Duration
+	LastCompletedAt time.Time
+}
+
 func (f *bitgetLeverageField) UnmarshalJSON(data []byte) error {
 	if f == nil {
 		return nil
@@ -549,29 +589,53 @@ func (e *BitgetOrderExecutor) ensureFuturesLeverage(
 	desiredLeverage int,
 	holdSide string,
 	marginMode string,
-) (int, string, error) {
+) (effectiveLeverage int, syncStatus string, err error) {
+	if e == nil {
+		return 0, "", fmt.Errorf("executor is nil")
+	}
+	started := time.Now()
+	apiCalls := 0
+	setCalls := 0
+	cacheHit := false
+	defer func() {
+		e.recordLeverageSyncMetrics(symbol, syncStatus, cacheHit, apiCalls, setCalls, time.Since(started), err)
+	}()
+
 	if desiredLeverage <= 0 {
 		return 0, "", fmt.Errorf("desired leverage must be positive")
 	}
 
+	cacheKey := normalizeBitgetLeverageCacheKey(symbol, desiredLeverage, holdSide, marginMode)
+	if cached, ok := e.cachedFuturesLeverage(cacheKey, time.Now()); ok {
+		cacheHit = true
+		fmt.Printf("[BITGET-ORDER] Futures leverage cache hit for %s: %dx (%s/%s)\n",
+			symbol, cached.EffectiveLeverage, cacheKey.MarginMode, cacheKey.HoldSide)
+		return cached.EffectiveLeverage, "cache hit: " + cached.Status, nil
+	}
+
+	apiCalls++
 	account, err := e.getFuturesAccount(ctx, symbol)
 	if err != nil {
-		return 0, "", fmt.Errorf("failed to get futures account for %s: %w", symbol, err)
+		return 0, "", fmt.Errorf("failed to get futures account for %q: %w", symbol, err)
 	}
 	current := account.effectiveLeverageForMarginMode(holdSide, marginMode)
 	if account.MarginMode == strings.ToLower(strings.TrimSpace(marginMode)) && current == desiredLeverage {
 		fmt.Printf("[BITGET-ORDER] Futures leverage already synced for %s: %dx (%s/%s)\n",
 			symbol, current, account.MarginMode, account.PosMode)
+		e.cacheFuturesLeverage(cacheKey, current, "exchange confirmed", time.Now())
 		return current, "exchange confirmed", nil
 	}
 
+	setCalls++
+	apiCalls++
 	if err := e.setFuturesLeverage(ctx, symbol, desiredLeverage, holdSide, marginMode); err != nil {
-		return 0, "", fmt.Errorf("failed to set futures leverage for %s to %dx: %w", symbol, desiredLeverage, err)
+		return 0, "", fmt.Errorf("failed to set futures leverage for %q to %dx: %w", symbol, desiredLeverage, err)
 	}
 
+	apiCalls++
 	verified, err := e.getFuturesAccount(ctx, symbol)
 	if err != nil {
-		return 0, "", fmt.Errorf("failed to verify futures leverage for %s: %w", symbol, err)
+		return 0, "", fmt.Errorf("failed to verify futures leverage for %q: %w", symbol, err)
 	}
 	effective := verified.effectiveLeverageForMarginMode(holdSide, marginMode)
 	expectedMarginMode := strings.ToLower(strings.TrimSpace(marginMode))
@@ -617,7 +681,151 @@ func (e *BitgetOrderExecutor) ensureFuturesLeverage(
 
 	fmt.Printf("[BITGET-ORDER] Futures leverage synced for %s: %dx (%s/%s)\n",
 		symbol, effective, verified.MarginMode, verified.PosMode)
+	e.cacheFuturesLeverage(cacheKey, effective, "exchange synced", time.Now())
 	return effective, "exchange synced", nil
+}
+
+func normalizeBitgetLeverageCacheKey(symbol string, desiredLeverage int, holdSide string, marginMode string) bitgetLeverageCacheKey {
+	return bitgetLeverageCacheKey{
+		Symbol:          strings.ToUpper(strings.TrimSpace(symbol)),
+		HoldSide:        strings.ToLower(strings.TrimSpace(holdSide)),
+		MarginMode:      strings.ToLower(strings.TrimSpace(marginMode)),
+		DesiredLeverage: desiredLeverage,
+	}
+}
+
+func loadBitgetLeverageCacheTTL() time.Duration {
+	value := strings.TrimSpace(os.Getenv(bitgetLeverageCacheTTLEnv))
+	if value == "" {
+		return defaultBitgetLeverageCacheTTL
+	}
+	if ttl, err := time.ParseDuration(value); err == nil && ttl > 0 {
+		return ttl
+	}
+	if seconds, err := strconv.Atoi(value); err == nil && seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	return defaultBitgetLeverageCacheTTL
+}
+
+func (e *BitgetOrderExecutor) futuresLeverageCacheTTL() time.Duration {
+	if e != nil && e.leverageCacheTTL > 0 {
+		return e.leverageCacheTTL
+	}
+	return defaultBitgetLeverageCacheTTL
+}
+
+func (e *BitgetOrderExecutor) cachedFuturesLeverage(key bitgetLeverageCacheKey, now time.Time) (bitgetLeverageCacheEntry, bool) {
+	if e == nil {
+		return bitgetLeverageCacheEntry{}, false
+	}
+	e.leverageCacheMu.Lock()
+	defer e.leverageCacheMu.Unlock()
+	if e.leverageCache == nil {
+		return bitgetLeverageCacheEntry{}, false
+	}
+	entry, ok := e.leverageCache[key]
+	if !ok {
+		return bitgetLeverageCacheEntry{}, false
+	}
+	if !entry.ExpiresAt.After(now) {
+		delete(e.leverageCache, key)
+		return bitgetLeverageCacheEntry{}, false
+	}
+	return entry, true
+}
+
+func (e *BitgetOrderExecutor) cacheFuturesLeverage(key bitgetLeverageCacheKey, effectiveLeverage int, status string, now time.Time) {
+	if e == nil || effectiveLeverage <= 0 {
+		return
+	}
+	e.leverageCacheMu.Lock()
+	defer e.leverageCacheMu.Unlock()
+	if e.leverageCache == nil {
+		e.leverageCache = make(map[bitgetLeverageCacheKey]bitgetLeverageCacheEntry)
+	}
+	for cachedKey := range e.leverageCache {
+		if cachedKey.Symbol == key.Symbol &&
+			cachedKey.HoldSide == key.HoldSide &&
+			cachedKey.MarginMode == key.MarginMode &&
+			cachedKey.DesiredLeverage != key.DesiredLeverage {
+			delete(e.leverageCache, cachedKey)
+		}
+	}
+	e.leverageCache[key] = bitgetLeverageCacheEntry{
+		EffectiveLeverage: effectiveLeverage,
+		Status:            status,
+		ExpiresAt:         now.Add(e.futuresLeverageCacheTTL()),
+	}
+}
+
+func (e *BitgetOrderExecutor) recordLeverageSyncMetrics(symbol string, status string, cacheHit bool, apiCalls int, setCalls int, duration time.Duration, err error) {
+	if e == nil {
+		return
+	}
+	if err != nil && strings.TrimSpace(status) == "" {
+		status = "failed"
+	}
+	lastError := ""
+	if err != nil {
+		lastError = err.Error()
+	}
+	func() {
+		e.leverageCacheMu.Lock()
+		defer e.leverageCacheMu.Unlock()
+		e.leverageMetrics.TotalCalls++
+		if cacheHit {
+			e.leverageMetrics.CacheHits++
+		} else {
+			e.leverageMetrics.CacheMisses++
+		}
+		e.leverageMetrics.TotalAPICalls += int64(apiCalls)
+		e.leverageMetrics.TotalSetCalls += int64(setCalls)
+		e.leverageMetrics.LastSymbol = strings.ToUpper(strings.TrimSpace(symbol))
+		e.leverageMetrics.LastStatus = status
+		e.leverageMetrics.LastError = lastError
+		e.leverageMetrics.LastCacheHit = cacheHit
+		e.leverageMetrics.LastAPICalls = apiCalls
+		e.leverageMetrics.LastSetCalls = setCalls
+		e.leverageMetrics.LastDuration = duration
+		e.leverageMetrics.LastCompletedAt = time.Now().UTC()
+	}()
+	if err != nil {
+		fmt.Printf("[BITGET-ORDER] Futures leverage sync failed for %s after %s (api_calls=%d set_calls=%d cache_hit=%t): %v\n",
+			symbol, duration, apiCalls, setCalls, cacheHit, err)
+		return
+	}
+	fmt.Printf("[BITGET-ORDER] Futures leverage sync completed for %s in %s (status=%s api_calls=%d set_calls=%d cache_hit=%t)\n",
+		symbol, duration, status, apiCalls, setCalls, cacheHit)
+}
+
+// LeverageSyncDiagnostics reports recent Bitget futures leverage-sync cache and API-call metrics.
+func (e *BitgetOrderExecutor) LeverageSyncDiagnostics() map[string]interface{} {
+	if e == nil {
+		return map[string]interface{}{}
+	}
+	e.leverageCacheMu.Lock()
+	defer e.leverageCacheMu.Unlock()
+	lastCompletedAt := ""
+	if !e.leverageMetrics.LastCompletedAt.IsZero() {
+		lastCompletedAt = e.leverageMetrics.LastCompletedAt.Format(time.RFC3339)
+	}
+	return map[string]interface{}{
+		"total_calls":       e.leverageMetrics.TotalCalls,
+		"cache_hits":        e.leverageMetrics.CacheHits,
+		"cache_misses":      e.leverageMetrics.CacheMisses,
+		"total_api_calls":   e.leverageMetrics.TotalAPICalls,
+		"total_set_calls":   e.leverageMetrics.TotalSetCalls,
+		"cache_size":        len(e.leverageCache),
+		"last_symbol":       e.leverageMetrics.LastSymbol,
+		"last_status":       e.leverageMetrics.LastStatus,
+		"last_error":        e.leverageMetrics.LastError,
+		"last_cache_hit":    e.leverageMetrics.LastCacheHit,
+		"last_api_calls":    e.leverageMetrics.LastAPICalls,
+		"last_set_calls":    e.leverageMetrics.LastSetCalls,
+		"last_duration_ms":  e.leverageMetrics.LastDuration.Milliseconds(),
+		"last_completed_at": lastCompletedAt,
+	}
 }
 
 func (e *BitgetOrderExecutor) getFuturesAccount(ctx context.Context, symbol string) (*bitgetFuturesAccount, error) {

--- a/services/backend-api/internal/services/bitget_order_executor_test.go
+++ b/services/backend-api/internal/services/bitget_order_executor_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -101,6 +102,22 @@ func TestBitgetOrderExecutor_MinNotionalUsesDynamicEnv(t *testing.T) {
 	t.Setenv("NEURATRADE_BITGET_FUTURES_MIN_NOTIONAL_USDT", "7.25")
 
 	assert.True(t, bitgetFuturesMinUSDTNotional().Equal(decimal.NewFromFloat(7.25)))
+}
+
+func TestBitgetOrderExecutor_LeverageCacheTTLUsesDynamicEnv(t *testing.T) {
+	t.Setenv(bitgetLeverageCacheTTLEnv, "45s")
+
+	executor := NewBitgetOrderExecutor("test-key", "test-secret", "test-pass")
+
+	assert.Equal(t, 45*time.Second, executor.futuresLeverageCacheTTL())
+}
+
+func TestBitgetOrderExecutor_LeverageCacheTTLInvalidEnvUsesDefault(t *testing.T) {
+	t.Setenv(bitgetLeverageCacheTTLEnv, "-1s")
+
+	executor := NewBitgetOrderExecutor("test-key", "test-secret", "test-pass")
+
+	assert.Equal(t, defaultBitgetLeverageCacheTTL, executor.futuresLeverageCacheTTL())
 }
 
 func TestBitgetOrderExecutor_PlaceOrderWithDetails_BlocksUnprotectedSpotFallback(t *testing.T) {
@@ -250,6 +267,186 @@ func TestBitgetOrderExecutor_EnsureFuturesLeverage_NoOpWhenAlreadySynced(t *test
 	assert.Equal(t, 1, accountCalls)
 }
 
+func TestBitgetOrderExecutor_EnsureFuturesLeverage_UsesRecentVerifiedCache(t *testing.T) {
+	accountCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/account/account":
+			accountCalls++
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":{
+				"marginMode":"isolated",
+				"posMode":"one_way_mode",
+				"isolatedLongLever":"5"
+			}}`))
+		case "/api/v2/mix/account/set-leverage":
+			t.Fatalf("unexpected leverage mutation request")
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("test-key", "test-secret", "test-pass")
+	executor.baseURL = server.URL
+
+	leverage, status, err := executor.ensureFuturesLeverage(context.Background(), "BTCUSDT", 5, "long", bitgetFuturesOrderMarginMode)
+	require.NoError(t, err)
+	assert.Equal(t, 5, leverage)
+	assert.Equal(t, "exchange confirmed", status)
+
+	leverage, status, err = executor.ensureFuturesLeverage(context.Background(), "BTCUSDT", 5, "long", bitgetFuturesOrderMarginMode)
+	require.NoError(t, err)
+	assert.Equal(t, 5, leverage)
+	assert.Equal(t, "cache hit: exchange confirmed", status)
+	assert.Equal(t, 1, accountCalls)
+
+	diagnostics := executor.LeverageSyncDiagnostics()
+	assert.Equal(t, int64(2), diagnostics["total_calls"])
+	assert.Equal(t, int64(1), diagnostics["cache_hits"])
+	assert.Equal(t, int64(1), diagnostics["cache_misses"])
+	assert.Equal(t, int64(1), diagnostics["total_api_calls"])
+	assert.Equal(t, 0, diagnostics["last_api_calls"])
+	assert.Equal(t, true, diagnostics["last_cache_hit"])
+	assert.Equal(t, 1, diagnostics["cache_size"])
+}
+
+func TestBitgetOrderExecutor_EnsureFuturesLeverage_ExpiredCacheRevalidates(t *testing.T) {
+	accountCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/account/account":
+			accountCalls++
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":{
+				"marginMode":"isolated",
+				"posMode":"one_way_mode",
+				"isolatedLongLever":"5"
+			}}`))
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("test-key", "test-secret", "test-pass")
+	executor.baseURL = server.URL
+
+	_, _, err := executor.ensureFuturesLeverage(context.Background(), "BTCUSDT", 5, "long", bitgetFuturesOrderMarginMode)
+	require.NoError(t, err)
+
+	key := normalizeBitgetLeverageCacheKey("BTCUSDT", 5, "long", bitgetFuturesOrderMarginMode)
+	executor.leverageCacheMu.Lock()
+	entry := executor.leverageCache[key]
+	entry.ExpiresAt = time.Now().Add(-time.Second)
+	executor.leverageCache[key] = entry
+	executor.leverageCacheMu.Unlock()
+
+	leverage, status, err := executor.ensureFuturesLeverage(context.Background(), "BTCUSDT", 5, "long", bitgetFuturesOrderMarginMode)
+	require.NoError(t, err)
+	assert.Equal(t, 5, leverage)
+	assert.Equal(t, "exchange confirmed", status)
+	assert.Equal(t, 2, accountCalls)
+}
+
+func TestBitgetOrderExecutor_EnsureFuturesLeverage_InvalidatesSameTupleWhenDesiredLeverageChanges(t *testing.T) {
+	accountCalls := 0
+	setCalls := 0
+	currentLeverage := "5"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/account/account":
+			accountCalls++
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":{
+				"marginMode":"isolated",
+				"posMode":"one_way_mode",
+				"isolatedLongLever":"` + currentLeverage + `"
+			}}`))
+		case "/api/v2/mix/account/set-leverage":
+			setCalls++
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var setBody map[string]interface{}
+			require.NoError(t, json.Unmarshal(body, &setBody))
+			currentLeverage = setBody["leverage"].(string)
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok"}`))
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("test-key", "test-secret", "test-pass")
+	executor.baseURL = server.URL
+
+	leverage, status, err := executor.ensureFuturesLeverage(context.Background(), "BTCUSDT", 5, "long", bitgetFuturesOrderMarginMode)
+	require.NoError(t, err)
+	assert.Equal(t, 5, leverage)
+	assert.Equal(t, "exchange confirmed", status)
+
+	leverage, status, err = executor.ensureFuturesLeverage(context.Background(), "BTCUSDT", 3, "long", bitgetFuturesOrderMarginMode)
+	require.NoError(t, err)
+	assert.Equal(t, 3, leverage)
+	assert.Equal(t, "exchange synced", status)
+	assert.Equal(t, 3, accountCalls)
+	assert.Equal(t, 1, setCalls)
+
+	key5x := normalizeBitgetLeverageCacheKey("BTCUSDT", 5, "long", bitgetFuturesOrderMarginMode)
+	key3x := normalizeBitgetLeverageCacheKey("BTCUSDT", 3, "long", bitgetFuturesOrderMarginMode)
+	executor.leverageCacheMu.Lock()
+	_, has5x := executor.leverageCache[key5x]
+	_, has3x := executor.leverageCache[key3x]
+	executor.leverageCacheMu.Unlock()
+	assert.False(t, has5x)
+	assert.True(t, has3x)
+
+	leverage, status, err = executor.ensureFuturesLeverage(context.Background(), "BTCUSDT", 5, "long", bitgetFuturesOrderMarginMode)
+	require.NoError(t, err)
+	assert.Equal(t, 5, leverage)
+	assert.Equal(t, "exchange synced", status)
+	assert.Equal(t, 5, accountCalls)
+	assert.Equal(t, 2, setCalls)
+}
+
+func TestBitgetOrderExecutor_EnsureFuturesLeverage_DiagnosticsOnFailure(t *testing.T) {
+	accountCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/account/account":
+			accountCalls++
+			_, _ = w.Write([]byte(`{"code":"30001","msg":"rate limit","data":{}}`))
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("test-key", "test-secret", "test-pass")
+	executor.baseURL = server.URL
+
+	leverage, status, err := executor.ensureFuturesLeverage(context.Background(), "BTCUSDT", 5, "long", bitgetFuturesOrderMarginMode)
+	require.Error(t, err)
+	assert.Equal(t, 0, leverage)
+	assert.Empty(t, status)
+	assert.Contains(t, err.Error(), "failed to get futures account")
+	assert.Equal(t, 1, accountCalls)
+
+	diagnostics := executor.LeverageSyncDiagnostics()
+	assert.Equal(t, int64(1), diagnostics["total_calls"])
+	assert.Equal(t, int64(0), diagnostics["cache_hits"])
+	assert.Equal(t, int64(1), diagnostics["cache_misses"])
+	assert.Equal(t, int64(1), diagnostics["total_api_calls"])
+	assert.Equal(t, int64(0), diagnostics["total_set_calls"])
+	assert.Equal(t, "BTCUSDT", diagnostics["last_symbol"])
+	assert.Equal(t, "failed", diagnostics["last_status"])
+	assert.Contains(t, diagnostics["last_error"], "failed to get futures account")
+	assert.Equal(t, false, diagnostics["last_cache_hit"])
+	assert.Equal(t, 1, diagnostics["last_api_calls"])
+	assert.Equal(t, 0, diagnostics["last_set_calls"])
+}
+
 func TestBitgetOrderExecutor_EnsureFuturesLeverage_SetsAndVerifiesIntendedIsolatedMode(t *testing.T) {
 	accountCalls := 0
 	setCalls := 0
@@ -316,6 +513,14 @@ func TestBitgetOrderExecutor_EnsureFuturesLeverage_RejectsNonPositiveDesiredLeve
 	_, _, err = executor.ensureFuturesLeverage(context.Background(), "BTCUSDT", -5, "long", bitgetFuturesOrderMarginMode)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "desired leverage must be positive")
+}
+
+func TestBitgetOrderExecutor_EnsureFuturesLeverage_RejectsNilExecutor(t *testing.T) {
+	var executor *BitgetOrderExecutor
+
+	_, _, err := executor.ensureFuturesLeverage(context.Background(), "BTCUSDT", 5, "long", bitgetFuturesOrderMarginMode)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "executor is nil")
 }
 
 func TestBitgetOrderExecutor_EnsureFuturesLeverage_WrapsAccountFetchFailures(t *testing.T) {


### PR DESCRIPTION
## Summary
- cache recently verified Bitget futures leverage state by symbol/side/margin/leverage for a short TTL
- record leverage-sync diagnostics for cache hits, API calls, set calls, latency, and last error/status
- keep safety verification on cache misses and avoid caching exchange-preserved or failed sync states

## Validation
- go test ./internal/services -run 'TestBitgetOrderExecutor_EnsureFuturesLeverage|TestBitgetOrderExecutor_SyncFuturesLeverageForDetails'\n- go test ./internal/services\n- git diff --check\n- go test ./...\n- make lint\n- make build\n\nIssue: NeuraTrade-8hi

## Summary by Sourcery

Cache and track recent Bitget futures leverage syncs to reduce redundant API calls while preserving safety checks, and expose diagnostics for recent sync activity.

New Features:
- Add an in-memory, short-lived cache for recently verified Bitget futures leverage settings keyed by symbol, side, margin mode, and desired leverage.
- Expose leverage sync diagnostics from the Bitget order executor, reporting cache usage, API/set call counts, and recent sync status.

Enhancements:
- Augment Bitget futures leverage syncing to record per-call metrics including cache hits, API/set call usage, latency, and last error.
- Normalize leverage cache keys for consistent lookups across symbol, side, and margin mode variants.

Tests:
- Add tests to verify leverage sync reuses recent verified cache entries and respects cache expiration by revalidating via the Bitget account API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Leverage synchronization now implements intelligent caching with performance metrics tracking
  * New diagnostics endpoint provides real-time visibility into cache behavior and synchronization status

* **Tests**
  * Comprehensive test coverage added for leverage caching including expiration handling, cache invalidation, and failure scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->