### PR TITLE
fix: eliminate SQL injection risks across backend

### DIFF
--- a/services/backend-api/internal/api/handlers/scalping_backtest.go
+++ b/services/backend-api/internal/api/handlers/scalping_backtest.go
@@ -239,7 +239,8 @@ func (h *ScalpingBacktestHandler) ListScalpingBacktests(c *gin.Context) {
 		query += " WHERE status = $1"
 		args = append(args, statusFilter)
 	}
-	query += " ORDER BY created_at DESC LIMIT " + strconv.Itoa(limit)
+	query += " ORDER BY created_at DESC LIMIT $" + strconv.Itoa(len(args)+1)
+	args = append(args, limit)
 
 	rows, err := h.db.Query(c.Request.Context(), query, args...)
 	if err != nil {

--- a/services/backend-api/internal/api/handlers/telegram_internal.go
+++ b/services/backend-api/internal/api/handlers/telegram_internal.go
@@ -601,7 +601,7 @@ func (h *TelegramInternalHandler) GetDoctor(c *gin.Context) {
 		})
 	}
 
-	polymarketCount, err := h.countConnectedWallets(c.Request.Context(), chatID, "provider = 'polymarket' AND status = 'connected'")
+	polymarketCount, err := h.countConnectedWallets(c.Request.Context(), chatID, "polymarket", "", "connected", false)
 	if err != nil {
 		checks = append(checks, gin.H{
 			"name":     "polymarket-wallet",
@@ -631,7 +631,7 @@ func (h *TelegramInternalHandler) GetDoctor(c *gin.Context) {
 		})
 	}
 
-	exchangeCount, err := h.countConnectedWallets(c.Request.Context(), chatID, "provider <> 'polymarket' AND wallet_type = 'exchange' AND status = 'connected'")
+	exchangeCount, err := h.countConnectedWallets(c.Request.Context(), chatID, "polymarket", "exchange", "connected", true)
 	if err != nil {
 		exchangeCount = 0
 	}
@@ -1175,12 +1175,12 @@ func (h *TelegramInternalHandler) ensureOperatorSchema(ctx context.Context) erro
 func (h *TelegramInternalHandler) collectReadinessFailures(ctx context.Context, chatID string) ([]string, error) {
 	failedChecks := make([]string, 0, 2)
 
-	pmWalletCount, err := h.countConnectedWallets(ctx, chatID, "provider = 'polymarket' AND status = 'connected'")
+	pmWalletCount, err := h.countConnectedWallets(ctx, chatID, "polymarket", "", "connected", false)
 	if err != nil {
 		pmWalletCount = 0
 	}
 
-	exchangeCount, err := h.countConnectedWallets(ctx, chatID, "provider <> 'polymarket' AND wallet_type = 'exchange' AND status = 'connected'")
+	exchangeCount, err := h.countConnectedWallets(ctx, chatID, "polymarket", "exchange", "connected", true)
 	if err != nil {
 		exchangeCount = 0
 	}
@@ -1201,10 +1201,29 @@ func (h *TelegramInternalHandler) collectReadinessFailures(ctx context.Context, 
 	return failedChecks, nil
 }
 
-func (h *TelegramInternalHandler) countConnectedWallets(ctx context.Context, chatID, filter string) (int, error) {
-	query := `SELECT COUNT(*) FROM telegram_operator_wallets WHERE chat_id = $1 AND ` + filter
+func (h *TelegramInternalHandler) countConnectedWallets(ctx context.Context, chatID, provider, walletType, status string, excludeProvider bool) (int, error) {
+	query := `SELECT COUNT(*) FROM telegram_operator_wallets WHERE chat_id = $1`
+	args := []interface{}{chatID}
+
+	if provider != "" {
+		if excludeProvider {
+			query += fmt.Sprintf(" AND provider <> $%d", len(args)+1)
+		} else {
+			query += fmt.Sprintf(" AND provider = $%d", len(args)+1)
+		}
+		args = append(args, provider)
+	}
+	if walletType != "" {
+		query += fmt.Sprintf(" AND wallet_type = $%d", len(args)+1)
+		args = append(args, walletType)
+	}
+	if status != "" {
+		query += fmt.Sprintf(" AND status = $%d", len(args)+1)
+		args = append(args, status)
+	}
+
 	var count int
-	err := h.db.QueryRow(ctx, query, chatID).Scan(&count)
+	err := h.db.QueryRow(ctx, query, args...).Scan(&count)
 	if err != nil {
 		return 0, err
 	}

--- a/services/backend-api/internal/api/handlers/telegram_internal_test.go
+++ b/services/backend-api/internal/api/handlers/telegram_internal_test.go
@@ -581,11 +581,11 @@ func TestTelegramInternalHandler_GetDoctor_Healthy(t *testing.T) {
 	mockDB.ExpectExec("CREATE TABLE IF NOT EXISTS telegram_operator_wallets").WillReturnResult(pgxmock.NewResult("CREATE TABLE", 0))
 	mockDB.ExpectExec("CREATE TABLE IF NOT EXISTS telegram_operator_state").WillReturnResult(pgxmock.NewResult("CREATE TABLE", 0))
 	mockDB.ExpectQuery("SELECT 1").WillReturnRows(pgxmock.NewRows([]string{"one"}).AddRow(1))
-	mockDB.ExpectQuery(`SELECT COUNT\(\*\) FROM telegram_operator_wallets WHERE chat_id = \$1 AND provider = 'polymarket' AND status = 'connected'`).
-		WithArgs("777").
+	mockDB.ExpectQuery(`SELECT COUNT\(\*\) FROM telegram_operator_wallets WHERE chat_id = \$1 AND provider = \$2 AND status = \$3`).
+		WithArgs("777", "polymarket", "connected").
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(1))
-	mockDB.ExpectQuery(`SELECT COUNT\(\*\) FROM telegram_operator_wallets WHERE chat_id = \$1 AND provider <> 'polymarket' AND wallet_type = 'exchange' AND status = 'connected'`).
-		WithArgs("777").
+	mockDB.ExpectQuery(`SELECT COUNT\(\*\) FROM telegram_operator_wallets WHERE chat_id = \$1 AND provider <> \$2 AND wallet_type = \$3 AND status = \$4`).
+		WithArgs("777", "polymarket", "exchange", "connected").
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(1))
 	mockDB.ExpectQuery(`SELECT COALESCE\(\(SELECT autonomous_enabled FROM telegram_operator_state WHERE chat_id = \$1 LIMIT 1\), false\)`).
 		WithArgs("777").
@@ -623,11 +623,11 @@ func TestTelegramInternalHandler_GetDoctor_NoSelectedAIModelDoesNotWarnProbeUnav
 	mockDB.ExpectExec("CREATE TABLE IF NOT EXISTS telegram_operator_wallets").WillReturnResult(pgxmock.NewResult("CREATE TABLE", 0))
 	mockDB.ExpectExec("CREATE TABLE IF NOT EXISTS telegram_operator_state").WillReturnResult(pgxmock.NewResult("CREATE TABLE", 0))
 	mockDB.ExpectQuery("SELECT 1").WillReturnRows(pgxmock.NewRows([]string{"one"}).AddRow(1))
-	mockDB.ExpectQuery(`SELECT COUNT\(\*\) FROM telegram_operator_wallets WHERE chat_id = \$1 AND provider = 'polymarket' AND status = 'connected'`).
-		WithArgs("777").
+	mockDB.ExpectQuery(`SELECT COUNT\(\*\) FROM telegram_operator_wallets WHERE chat_id = \$1 AND provider = \$2 AND status = \$3`).
+		WithArgs("777", "polymarket", "connected").
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(1))
-	mockDB.ExpectQuery(`SELECT COUNT\(\*\) FROM telegram_operator_wallets WHERE chat_id = \$1 AND provider <> 'polymarket' AND wallet_type = 'exchange' AND status = 'connected'`).
-		WithArgs("777").
+	mockDB.ExpectQuery(`SELECT COUNT\(\*\) FROM telegram_operator_wallets WHERE chat_id = \$1 AND provider <> \$2 AND wallet_type = \$3 AND status = \$4`).
+		WithArgs("777", "polymarket", "exchange", "connected").
 		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(1))
 	mockDB.ExpectQuery(`SELECT COALESCE\(\(SELECT autonomous_enabled FROM telegram_operator_state WHERE chat_id = \$1 LIMIT 1\), false\)`).
 		WithArgs("777").

--- a/services/backend-api/internal/services/quest_store.go
+++ b/services/backend-api/internal/services/quest_store.go
@@ -30,56 +30,52 @@ func (s *DBQuestStore) InitSchema(ctx context.Context) error {
 		return fmt.Errorf("database connection is nil")
 	}
 
-	_, err := s.db.Exec(ctx, fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s (
-			id TEXT PRIMARY KEY,
-			name TEXT NOT NULL,
-			description TEXT,
-			type TEXT NOT NULL,
-			cadence TEXT NOT NULL,
-			cron_expr TEXT,
-			status TEXT NOT NULL,
-			prompt TEXT,
-			target_count INTEGER DEFAULT 0,
-			current_count INTEGER DEFAULT 0,
-			checkpoint TEXT,
-			created_at TIMESTAMP NOT NULL,
-			updated_at TIMESTAMP NOT NULL,
-			last_executed_at TIMESTAMP,
-			completed_at TIMESTAMP,
-			last_error TEXT,
-			metadata TEXT
-		)
-	`, runtimeQuestTable))
+	_, err := s.db.Exec(ctx, "CREATE TABLE IF NOT EXISTS "+runtimeQuestTable+` (
+		id TEXT PRIMARY KEY,
+		name TEXT NOT NULL,
+		description TEXT,
+		type TEXT NOT NULL,
+		cadence TEXT NOT NULL,
+		cron_expr TEXT,
+		status TEXT NOT NULL,
+		prompt TEXT,
+		target_count INTEGER DEFAULT 0,
+		current_count INTEGER DEFAULT 0,
+		checkpoint TEXT,
+		created_at TIMESTAMP NOT NULL,
+		updated_at TIMESTAMP NOT NULL,
+		last_executed_at TIMESTAMP,
+		completed_at TIMESTAMP,
+		last_error TEXT,
+		metadata TEXT
+	)`)
 	if err != nil {
 		return fmt.Errorf("failed to create %s table: %w", runtimeQuestTable, err)
 	}
 
-	_, err = s.db.Exec(ctx, fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s (
-			chat_id TEXT PRIMARY KEY,
-			is_active BOOLEAN NOT NULL,
-			started_at TIMESTAMP,
-			paused_at TIMESTAMP,
-			active_quests TEXT,
-			updated_at TIMESTAMP NOT NULL
-		)
-	`, runtimeStateTable))
+	_, err = s.db.Exec(ctx, "CREATE TABLE IF NOT EXISTS "+runtimeStateTable+` (
+		chat_id TEXT PRIMARY KEY,
+		is_active BOOLEAN NOT NULL,
+		started_at TIMESTAMP,
+		paused_at TIMESTAMP,
+		active_quests TEXT,
+		updated_at TIMESTAMP NOT NULL
+	)`)
 	if err != nil {
 		return fmt.Errorf("failed to create %s table: %w", runtimeStateTable, err)
 	}
 
-	_, err = s.db.Exec(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s(status)`, runtimeQuestStatusIdx, runtimeQuestTable))
+	_, err = s.db.Exec(ctx, "CREATE INDEX IF NOT EXISTS "+runtimeQuestStatusIdx+" ON "+runtimeQuestTable+"(status)")
 	if err != nil {
 		return fmt.Errorf("failed to create runtime quest status index: %w", err)
 	}
 
-	_, err = s.db.Exec(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s(type)`, runtimeQuestTypeIdx, runtimeQuestTable))
+	_, err = s.db.Exec(ctx, "CREATE INDEX IF NOT EXISTS "+runtimeQuestTypeIdx+" ON "+runtimeQuestTable+"(type)")
 	if err != nil {
 		return fmt.Errorf("failed to create runtime quest type index: %w", err)
 	}
 
-	_, err = s.db.Exec(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s(updated_at)`, runtimeStateUpdatedIdx, runtimeStateTable))
+	_, err = s.db.Exec(ctx, "CREATE INDEX IF NOT EXISTS "+runtimeStateUpdatedIdx+" ON "+runtimeStateTable+"(updated_at)")
 	if err != nil {
 		return fmt.Errorf("failed to create runtime autonomous_state updated_at index: %w", err)
 	}
@@ -101,24 +97,22 @@ func (s *DBQuestStore) SaveQuest(ctx context.Context, quest *Quest) error {
 		return fmt.Errorf("marshal quest metadata: %w", err)
 	}
 
-	query := fmt.Sprintf(`
-		INSERT INTO %s (
-			id, name, description, type, cadence, cron_expr, status, prompt,
-			target_count, current_count, checkpoint, created_at, updated_at,
-			last_executed_at, completed_at, last_error, metadata
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-		ON CONFLICT (id) DO UPDATE SET
-			name = EXCLUDED.name,
-			description = EXCLUDED.description,
-			status = EXCLUDED.status,
-			current_count = EXCLUDED.current_count,
-			checkpoint = EXCLUDED.checkpoint,
-			updated_at = EXCLUDED.updated_at,
-			last_executed_at = EXCLUDED.last_executed_at,
-			completed_at = EXCLUDED.completed_at,
-			last_error = EXCLUDED.last_error,
-			metadata = EXCLUDED.metadata
-	`, runtimeQuestTable)
+	query := `INSERT INTO ` + runtimeQuestTable + ` (
+		id, name, description, type, cadence, cron_expr, status, prompt,
+		target_count, current_count, checkpoint, created_at, updated_at,
+		last_executed_at, completed_at, last_error, metadata
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+	ON CONFLICT (id) DO UPDATE SET
+		name = EXCLUDED.name,
+		description = EXCLUDED.description,
+		status = EXCLUDED.status,
+		current_count = EXCLUDED.current_count,
+		checkpoint = EXCLUDED.checkpoint,
+		updated_at = EXCLUDED.updated_at,
+		last_executed_at = EXCLUDED.last_executed_at,
+		completed_at = EXCLUDED.completed_at,
+		last_error = EXCLUDED.last_error,
+		metadata = EXCLUDED.metadata`
 
 	_, err = s.db.Exec(ctx, query,
 		quest.ID, quest.Name, quest.Description, quest.Type, quest.Cadence, quest.CronExpr,
@@ -140,12 +134,10 @@ func (s *DBQuestStore) GetQuest(ctx context.Context, id string) (*Quest, error) 
 	var cronExpr, lastError sql.NullString
 	var lastExecutedAt, completedAt sql.NullTime
 
-	err := s.db.QueryRow(ctx, fmt.Sprintf(`
-		SELECT id, name, description, type, cadence, cron_expr, status, prompt,
-			   target_count, current_count, checkpoint, created_at, updated_at,
-			   last_executed_at, completed_at, last_error, metadata
-		FROM %s WHERE id = $1
-	`, runtimeQuestTable), id).Scan(
+	err := s.db.QueryRow(ctx, `SELECT id, name, description, type, cadence, cron_expr, status, prompt,
+		   target_count, current_count, checkpoint, created_at, updated_at,
+		   last_executed_at, completed_at, last_error, metadata
+		FROM `+runtimeQuestTable+` WHERE id = $1`, id).Scan(
 		&quest.ID, &quest.Name, &quest.Description, &quest.Type, &quest.Cadence,
 		&cronExpr, &quest.Status, &quest.Prompt, &quest.TargetCount, &quest.CurrentCount,
 		&checkpointJSON, &quest.CreatedAt, &quest.UpdatedAt,
@@ -183,10 +175,10 @@ func (s *DBQuestStore) ListQuests(ctx context.Context, chatID string, status Que
 		return nil, fmt.Errorf("database connection is nil")
 	}
 
-	query := fmt.Sprintf(`SELECT id, name, description, type, cadence, cron_expr, status, prompt,
+	query := `SELECT id, name, description, type, cadence, cron_expr, status, prompt,
 			  target_count, current_count, checkpoint, created_at, updated_at,
 			  last_executed_at, completed_at, last_error, metadata
-			  FROM %s WHERE 1=1`, runtimeQuestTable)
+			  FROM ` + runtimeQuestTable + ` WHERE 1=1`
 	args := make([]interface{}, 0, 1)
 	argIndex := 1
 
@@ -271,10 +263,8 @@ func (s *DBQuestStore) UpdateQuestProgress(ctx context.Context, id string, curre
 
 	checkpointJSON, _ := json.Marshal(checkpoint)
 
-	_, err := s.db.Exec(ctx, fmt.Sprintf(`
-		UPDATE %s SET current_count = $2, checkpoint = $3, updated_at = $4
-		WHERE id = $1
-	`, runtimeQuestTable), id, current, checkpointJSON, time.Now().UTC())
+	_, err := s.db.Exec(ctx, `UPDATE `+runtimeQuestTable+` SET current_count = $2, checkpoint = $3, updated_at = $4
+		WHERE id = $1`, id, current, checkpointJSON, time.Now().UTC())
 
 	return err
 }
@@ -284,10 +274,8 @@ func (s *DBQuestStore) UpdateLastExecuted(ctx context.Context, id string, execut
 		return fmt.Errorf("database connection is nil")
 	}
 
-	_, err := s.db.Exec(ctx, fmt.Sprintf(`
-		UPDATE %s SET last_executed_at = $2, updated_at = $3
-		WHERE id = $1
-	`, runtimeQuestTable), id, executedAt, time.Now().UTC())
+	_, err := s.db.Exec(ctx, `UPDATE `+runtimeQuestTable+` SET last_executed_at = $2, updated_at = $3
+		WHERE id = $1`, id, executedAt, time.Now().UTC())
 
 	return err
 }
@@ -299,16 +287,14 @@ func (s *DBQuestStore) SaveAutonomousState(ctx context.Context, state *Autonomou
 
 	activeQuestsJSON, _ := json.Marshal(state.ActiveQuests)
 
-	query := fmt.Sprintf(`
-		INSERT INTO %s (chat_id, is_active, started_at, paused_at, active_quests, updated_at)
+	query := `INSERT INTO ` + runtimeStateTable + ` (chat_id, is_active, started_at, paused_at, active_quests, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6)
 		ON CONFLICT (chat_id) DO UPDATE SET
 			is_active = EXCLUDED.is_active,
 			started_at = EXCLUDED.started_at,
 			paused_at = EXCLUDED.paused_at,
 			active_quests = EXCLUDED.active_quests,
-			updated_at = EXCLUDED.updated_at
-	`, runtimeStateTable)
+			updated_at = EXCLUDED.updated_at`
 
 	_, err := s.db.Exec(ctx, query,
 		state.ChatID, state.IsActive, state.StartedAt, state.PausedAt,
@@ -327,10 +313,8 @@ func (s *DBQuestStore) GetAutonomousState(ctx context.Context, chatID string) (*
 	var activeQuestsJSON []byte
 	var startedAt, pausedAt sql.NullTime
 
-	err := s.db.QueryRow(ctx, fmt.Sprintf(`
-		SELECT chat_id, is_active, started_at, paused_at, active_quests
-		FROM %s WHERE chat_id = $1
-	`, runtimeStateTable), chatID).Scan(
+	err := s.db.QueryRow(ctx, `SELECT chat_id, is_active, started_at, paused_at, active_quests
+		FROM `+runtimeStateTable+` WHERE chat_id = $1`, chatID).Scan(
 		&state.ChatID, &state.IsActive, &startedAt, &pausedAt, &activeQuestsJSON,
 	)
 	if err != nil {
@@ -356,7 +340,7 @@ func (s *DBQuestStore) DeleteQuest(ctx context.Context, id string) error {
 		return fmt.Errorf("database connection is nil")
 	}
 
-	_, err := s.db.Exec(ctx, fmt.Sprintf(`DELETE FROM %s WHERE id = $1`, runtimeQuestTable), id)
+	_, err := s.db.Exec(ctx, `DELETE FROM `+runtimeQuestTable+` WHERE id = $1`, id)
 	return err
 }
 

--- a/services/backend-api/internal/services/quest_store.go
+++ b/services/backend-api/internal/services/quest_store.go
@@ -352,9 +352,9 @@ func (s *DBQuestStore) CountQuests(ctx context.Context, status QuestStatus) (int
 	var count int
 	var err error
 	if status == "" {
-		err = s.db.QueryRow(ctx, `SELECT COUNT(*) FROM autonomous_quests`).Scan(&count)
+		err = s.db.QueryRow(ctx, `SELECT COUNT(*) FROM `+runtimeQuestTable).Scan(&count)
 	} else {
-		err = s.db.QueryRow(ctx, `SELECT COUNT(*) FROM autonomous_quests WHERE status = $1`, string(status)).Scan(&count)
+		err = s.db.QueryRow(ctx, `SELECT COUNT(*) FROM `+runtimeQuestTable+` WHERE status = $1`, string(status)).Scan(&count)
 	}
 	return count, err
 }

--- a/services/backend-api/internal/services/trading_lifecycle_store.go
+++ b/services/backend-api/internal/services/trading_lifecycle_store.go
@@ -1191,19 +1191,20 @@ func (s *TradingLifecycleStore) ListManagedOpenPositions(ctx context.Context, ch
 	`
 	args := make([]interface{}, 0, 3)
 	if strings.TrimSpace(chatID) != "" {
-		query += " AND chat_id = $1"
+		query += fmt.Sprintf(" AND chat_id = $%d", len(args)+1)
 		args = append(args, strings.TrimSpace(chatID))
 		if strings.TrimSpace(exchange) != "" {
-			query += " AND exchange = $2"
+			query += fmt.Sprintf(" AND exchange = $%d", len(args)+1)
 			args = append(args, strings.TrimSpace(exchange))
 		}
 	} else if strings.TrimSpace(exchange) != "" {
-		query += " AND exchange = $1"
+		query += fmt.Sprintf(" AND exchange = $%d", len(args)+1)
 		args = append(args, strings.TrimSpace(exchange))
 	}
 	query += " ORDER BY updated_at DESC"
 	if limit > 0 {
-		query += fmt.Sprintf(" LIMIT %d", limit)
+		query += fmt.Sprintf(" LIMIT $%d", len(args)+1)
+		args = append(args, limit)
 	}
 
 	rows, err := s.db.Query(ctx, query, args...)
@@ -1506,7 +1507,8 @@ func (s *TradingLifecycleStore) GetRecentLossStreak(
 	}
 	query += " ORDER BY closed_at DESC"
 	if limit := recentLossStreakQueryLimit(); limit > 0 {
-		query += fmt.Sprintf(" LIMIT %d", limit)
+		query += fmt.Sprintf(" LIMIT $%d", len(args)+1)
+		args = append(args, limit)
 	}
 
 	rows, err := s.db.Query(ctx, query, args...)


### PR DESCRIPTION
## Summary
- quest_store.go: remove fmt.Sprintf from all SQL query constructions
- handlers/scalping_backtest.go: parameterize LIMIT clause
- telegram_internal.go: replace raw SQL filter concatenation with parameterized query builder
- trading_lifecycle_store.go: parameterize LIMIT clauses
- Update tests to match new parameterized wallet count queries

## Test plan
- [x] go build ./...
- [x] make lint passes
- [x] go test ./internal/api/handlers/... passes
- [x] go test ./internal/services/... passes

🤖 Generated with [Claude Code](https://claude.com/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal database query construction across multiple backend services for enhanced stability and maintainability.

* **Tests**
  * Updated test expectations to align with internal query structure changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->