### PR TITLE
fix: SQLite migration 015 duplicate columns + test env var leak

### DIFF
--- a/services/backend-api/database/sqlite-migrate.sh
+++ b/services/backend-api/database/sqlite-migrate.sh
@@ -29,7 +29,10 @@ sqlite_column_exists() {
 }
 
 apply_paper_trades_column_migrations() {
-  sqlite_table_exists "paper_trades" || return 0
+  if ! sqlite_table_exists "paper_trades"; then
+    printf "error: paper_trades table missing; 015 depends on 012_create_paper_trades_table.sql\n" >&2
+    return 1
+  fi
 
   # Defensive migration: add missing columns only if they don't already exist.
   # On fresh databases created after 012_create_paper_trades_table.sql, all
@@ -44,14 +47,22 @@ apply_paper_trades_column_migrations() {
     "DECIMAL(20, 8) NOT NULL DEFAULT 0"
     "DECIMAL(20, 8) NOT NULL DEFAULT 0"
     "DECIMAL(20, 8) NOT NULL DEFAULT 0"
-    "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
+    "TEXT NOT NULL DEFAULT '1970-01-01T00:00:00Z'"
   )
+
+  if [ ${#cols[@]} -ne ${#defs[@]} ]; then
+    printf "error: cols/defs length mismatch (%d vs %d)\n" "${#cols[@]}" "${#defs[@]}" >&2
+    return 1
+  fi
 
   for i in "${!cols[@]}"; do
     if ! sqlite_column_exists "paper_trades" "${cols[$i]}"; then
       sqlite3 "$DB_PATH" "ALTER TABLE paper_trades ADD COLUMN ${cols[$i]} ${defs[$i]};"
     fi
   done
+
+  # Backfill updated_at for existing rows that got the epoch placeholder default.
+  sqlite3 "$DB_PATH" "UPDATE paper_trades SET updated_at = CURRENT_TIMESTAMP WHERE updated_at = '1970-01-01T00:00:00Z';"
 }
 
 repair_legacy_funding_arbitrage_opportunities() {
@@ -90,6 +101,11 @@ apply_file() {
     repair_legacy_funding_arbitrage_opportunities
   fi
 
+  # 015_alter_paper_trades_columns.sql is intentionally bypassed here.
+  # The raw SQL uses .bail off to tolerate duplicate columns, but sqlite3
+  # still returns non-zero when statements fail. We run a shell-side
+  # conditional check (pragma_table_info) so the migration is idempotent
+  # on both fresh and legacy databases.
   if [ "$name" = "015_alter_paper_trades_columns.sql" ]; then
     apply_paper_trades_column_migrations
     sqlite3 "$DB_PATH" "INSERT INTO schema_migrations(filename) VALUES('$name');"

--- a/services/backend-api/database/sqlite-migrate.sh
+++ b/services/backend-api/database/sqlite-migrate.sh
@@ -28,6 +28,32 @@ sqlite_column_exists() {
   sqlite3 "$DB_PATH" "SELECT 1 FROM pragma_table_info('$table_name') WHERE name = '$column_name' LIMIT 1;" | grep -q "1"
 }
 
+apply_paper_trades_column_migrations() {
+  sqlite_table_exists "paper_trades" || return 0
+
+  # Defensive migration: add missing columns only if they don't already exist.
+  # On fresh databases created after 012_create_paper_trades_table.sql, all
+  # columns are already present, so this becomes a no-op.
+  local -a cols=("strategy_id" "quest_id" "exchange" "symbol" "side" "size" "fees" "cost_basis" "updated_at")
+  local -a defs=(
+    "TEXT NOT NULL DEFAULT ''"
+    "INTEGER"
+    "TEXT NOT NULL DEFAULT ''"
+    "TEXT NOT NULL DEFAULT ''"
+    "TEXT NOT NULL DEFAULT 'buy'"
+    "DECIMAL(20, 8) NOT NULL DEFAULT 0"
+    "DECIMAL(20, 8) NOT NULL DEFAULT 0"
+    "DECIMAL(20, 8) NOT NULL DEFAULT 0"
+    "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
+  )
+
+  for i in "${!cols[@]}"; do
+    if ! sqlite_column_exists "paper_trades" "${cols[$i]}"; then
+      sqlite3 "$DB_PATH" "ALTER TABLE paper_trades ADD COLUMN ${cols[$i]} ${defs[$i]};"
+    fi
+  done
+}
+
 repair_legacy_funding_arbitrage_opportunities() {
   sqlite_table_exists "funding_arbitrage_opportunities" || return 0
   sqlite_column_exists "funding_arbitrage_opportunities" "estimated_profit_percentage" && return 0
@@ -62,6 +88,13 @@ apply_file() {
 
   if [ "$name" = "011_create_funding_arbitrage_opportunities.sql" ]; then
     repair_legacy_funding_arbitrage_opportunities
+  fi
+
+  if [ "$name" = "015_alter_paper_trades_columns.sql" ]; then
+    apply_paper_trades_column_migrations
+    sqlite3 "$DB_PATH" "INSERT INTO schema_migrations(filename) VALUES('$name');"
+    printf "applied %s\n" "$name"
+    return 0
   fi
 
   sqlite3 "$DB_PATH" <"$file"

--- a/services/backend-api/database/sqlite-migrate.sh
+++ b/services/backend-api/database/sqlite-migrate.sh
@@ -47,7 +47,7 @@ apply_paper_trades_column_migrations() {
     "DECIMAL(20, 8) NOT NULL DEFAULT 0"
     "DECIMAL(20, 8) NOT NULL DEFAULT 0"
     "DECIMAL(20, 8) NOT NULL DEFAULT 0"
-    "TEXT NOT NULL DEFAULT '1970-01-01T00:00:00Z'"
+    "DATETIME NOT NULL DEFAULT '1970-01-01T00:00:00Z'"
   )
 
   if [ ${#cols[@]} -ne ${#defs[@]} ]; then

--- a/services/backend-api/database/sqlite-migrate.sh
+++ b/services/backend-api/database/sqlite-migrate.sh
@@ -107,7 +107,7 @@ apply_file() {
   # conditional check (pragma_table_info) so the migration is idempotent
   # on both fresh and legacy databases.
   if [ "$name" = "015_alter_paper_trades_columns.sql" ]; then
-    apply_paper_trades_column_migrations
+    apply_paper_trades_column_migrations || return $?
     sqlite3 "$DB_PATH" "INSERT INTO schema_migrations(filename) VALUES('$name');"
     printf "applied %s\n" "$name"
     return 0

--- a/services/backend-api/internal/api/routes_test.go
+++ b/services/backend-api/internal/api/routes_test.go
@@ -953,6 +953,10 @@ func TestProviderBaseURL(t *testing.T) {
 }
 
 func TestResolveProviderNodeUsesCentralProviderEnvNames(t *testing.T) {
+	// Prevent external env vars (e.g., ANTHROPIC_MODEL set by the runtime)
+	// from leaking into test assertions for providers we don't explicitly configure.
+	t.Setenv("ANTHROPIC_MODEL", "")
+
 	t.Setenv("NEURATRADE_AI_PROVIDER_ZAI_CODING_PLAN_API_KEY", "key")
 	t.Setenv("NEURATRADE_AI_PROVIDER_ZAI_CODING_PLAN_BASE_URL", "https://override.example/v1")
 	t.Setenv("NEURATRADE_AI_PROVIDER_ZAI_CODING_PLAN_MODEL", "model-override")


### PR DESCRIPTION
## Summary
Two independent fixes that unblock the full test suite on fresh environments:

1. **SQLite migration 015** — On fresh databases, `015_alter_paper_trades_columns.sql` tried to add columns (`strategy_id`, `quest_id`, `exchange`, `symbol`, `side`, `size`, `fees`, `cost_basis`, `updated_at`) that already existed in `paper_trades` from migration `012`. Even with `.bail off`, `sqlite3` returns non-zero when statements fail, causing the migration runner to abort. Added `apply_paper_trades_column_migrations()` to `sqlite-migrate.sh` which checks each column's existence via `pragma_table_info` before adding it, following the same special-case pattern already used for migration `011`.

2. **Env var leak in route tests** — `TestResolveProviderNodeUsesCentralProviderEnvNames` failed when `ANTHROPIC_MODEL` was set externally (e.g., by the AI runtime). Added `t.Setenv(\"ANTHROPIC_MODEL\", \"\")` at the top of the test to neutralize external leakage and ensure hermetic assertions.

## Test Plan
- [x] `go test ./database -v` — 3/3 pass
- [x] `go test ./...` — 4970 passed, 0 failed, 52 skipped
- [x] `bash scripts/coverage-check.sh` — 77.9% >= 77% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database migration robustness for paper trading: idempotent column additions and safe normalization of legacy timestamp values to reduce migration failures.

* **Tests**
  * Strengthened test isolation by ensuring external environment variables do not affect provider-related test assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->