### PR TITLE
refactor: replace raw log.* with structured zaplogrus across internal/

### DIFF
--- a/services/backend-api/internal/api/handlers/agent_control.go
+++ b/services/backend-api/internal/api/handlers/agent_control.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"net/http"
 	"strings"
 	"sync"

--- a/services/backend-api/internal/api/handlers/agent_control.go
+++ b/services/backend-api/internal/api/handlers/agent_control.go
@@ -2,7 +2,6 @@
 package handlers
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/gin-gonic/gin"
 	"github.com/irfndi/neuratrade/internal/autonomous"

--- a/services/backend-api/internal/api/handlers/agent_control.go
+++ b/services/backend-api/internal/api/handlers/agent_control.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"net/http"
 	"strings"
 	"sync"

--- a/services/backend-api/internal/api/handlers/agent_control.go
+++ b/services/backend-api/internal/api/handlers/agent_control.go
@@ -198,7 +198,7 @@ func (h *AgentControlHandler) DisableSafeMode(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "disable_safe_mode"})
 		return
 	}
-	zaplogrus.Warnf("agent_control: safe mode disabled")
+	zaplogrus.Infof("agent_control: safe mode disabled")
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "disable_safe_mode",

--- a/services/backend-api/internal/api/handlers/agent_control.go
+++ b/services/backend-api/internal/api/handlers/agent_control.go
@@ -2,10 +2,10 @@
 package handlers
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -113,7 +113,7 @@ func (h *AgentControlHandler) PauseExchange(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "pause_exchange"})
 		return
 	}
-	log.Printf("agent_control: exchange %s collection paused", req.ExchangeID)
+	zaplogrus.Infof("agent_control: exchange %s collection paused", req.ExchangeID)
 	c.JSON(http.StatusOK, gin.H{
 		"status":      "ok",
 		"action":      "pause_exchange",
@@ -148,7 +148,7 @@ func (h *AgentControlHandler) ResumeExchange(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "resume_exchange"})
 		return
 	}
-	log.Printf("agent_control: exchange %s collection resumed", req.ExchangeID)
+	zaplogrus.Infof("agent_control: exchange %s collection resumed", req.ExchangeID)
 	c.JSON(http.StatusOK, gin.H{
 		"status":      "ok",
 		"action":      "resume_exchange",
@@ -173,7 +173,7 @@ func (h *AgentControlHandler) EnableSafeMode(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "enable_safe_mode"})
 		return
 	}
-	log.Printf("agent_control: safe mode enabled")
+	zaplogrus.Infof("agent_control: safe mode enabled")
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "enable_safe_mode",
@@ -197,7 +197,7 @@ func (h *AgentControlHandler) DisableSafeMode(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "disable_safe_mode"})
 		return
 	}
-	log.Printf("agent_control: safe mode disabled")
+	zaplogrus.Warnf("agent_control: safe mode disabled")
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "disable_safe_mode",
@@ -250,7 +250,7 @@ func (h *AgentControlHandler) EngageKillSwitch(c *gin.Context) {
 	if !engageVal {
 		action = "disengage_kill_switch"
 	}
-	log.Printf("agent_control: kill switch %s", action)
+	zaplogrus.Infof("agent_control: kill switch %s", action)
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "kill_switch",
@@ -289,7 +289,7 @@ func (h *AgentControlHandler) CancelAllOrders(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "action": "cancel_all_orders"})
 		return
 	}
-	log.Printf("agent_control: all orders cancelled (exchange=%s, symbol=%s)", req.ExchangeID, req.Symbol)
+	zaplogrus.Infof("agent_control: all orders cancelled (exchange=%s, symbol=%s)", req.ExchangeID, req.Symbol)
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"action": "cancel_all_orders",
@@ -388,7 +388,7 @@ func (h *AgentControlHandler) StreamEvents(c *gin.Context) {
 		case event := <-subscription:
 			payload, err := json.Marshal(event)
 			if err != nil {
-				log.Printf("agent_control: failed to marshal event for stream: %v", err)
+				zaplogrus.Warnf("agent_control: failed to marshal event for stream: %v", err)
 				continue
 			}
 

--- a/services/backend-api/internal/api/handlers/arbitrage.go
+++ b/services/backend-api/internal/api/handlers/arbitrage.go
@@ -186,7 +186,7 @@ func (h *ArbitrageHandler) GetArbitrageOpportunities(c *gin.Context) {
 	// Get recent market data from database
 	opportunities, err := h.FindArbitrageOpportunities(c.Request.Context(), minProfit, limit, symbolFilter)
 	if err != nil {
-		zaplogrus.Infof("Error finding arbitrage opportunities: %v", err)
+		zaplogrus.Warnf("Error finding arbitrage opportunities: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to find arbitrage opportunities"})
 		return
 	}

--- a/services/backend-api/internal/api/handlers/arbitrage.go
+++ b/services/backend-api/internal/api/handlers/arbitrage.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/gin-gonic/gin"
 	"github.com/irfndi/neuratrade/internal/ccxt"

--- a/services/backend-api/internal/api/handlers/arbitrage.go
+++ b/services/backend-api/internal/api/handlers/arbitrage.go
@@ -1,10 +1,10 @@
 package handlers
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
 	"net/http"
 	"sort"
@@ -180,17 +180,17 @@ func (h *ArbitrageHandler) GetArbitrageOpportunities(c *gin.Context) {
 		return
 	}
 
-	log.Printf("Finding arbitrage opportunities with min_profit=%.2f, limit=%d, symbol=%s", minProfit, limit, symbolFilter)
+	zaplogrus.Infof("Finding arbitrage opportunities with min_profit=%.2f, limit=%d, symbol=%s", minProfit, limit, symbolFilter)
 
 	// Get recent market data from database
 	opportunities, err := h.FindArbitrageOpportunities(c.Request.Context(), minProfit, limit, symbolFilter)
 	if err != nil {
-		log.Printf("Error finding arbitrage opportunities: %v", err)
+		zaplogrus.Infof("Error finding arbitrage opportunities: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to find arbitrage opportunities"})
 		return
 	}
 
-	log.Printf("Found %d arbitrage opportunities", len(opportunities))
+	zaplogrus.Infof("Found %d arbitrage opportunities", len(opportunities))
 
 	// Send notifications for high-profit opportunities
 	go h.sendArbitrageNotifications(opportunities)
@@ -232,7 +232,7 @@ func (h *ArbitrageHandler) sendArbitrageNotifications(opportunities []ArbitrageO
 	if len(notifiableOpportunities) > 0 {
 		ctx := context.Background()
 		if err := h.notificationService.NotifyMarketOpportunities(ctx, notifiableOpportunities); err != nil {
-			log.Printf("Failed to send market notifications: %v", err)
+			zaplogrus.Warnf("Failed to send market notifications: %v", err)
 		}
 	}
 }
@@ -1171,7 +1171,7 @@ func (h *ArbitrageHandler) calculateArbitrageStats(ctx context.Context, interval
 		var sym SymbolStats
 		var avgProf float64
 		if err := rows.Scan(&sym.Symbol, &sym.Count, &avgProf); err != nil {
-			log.Printf("Failed to scan symbol stats: %v", err)
+			zaplogrus.Warnf("Failed to scan symbol stats: %v", err)
 			continue
 		}
 		sym.AvgProfit = decimal.NewFromFloat(avgProf)
@@ -1195,7 +1195,7 @@ func (h *ArbitrageHandler) calculateArbitrageStats(ctx context.Context, interval
 		var pair PairStats
 		var avgProf float64
 		if err := rows.Scan(&pair.BuyExchange, &pair.SellExchange, &pair.Count, &avgProf); err != nil {
-			log.Printf("Failed to scan pair stats: %v", err)
+			zaplogrus.Warnf("Failed to scan pair stats: %v", err)
 			continue
 		}
 		pair.AvgProfit = decimal.NewFromFloat(avgProf)

--- a/services/backend-api/internal/api/handlers/arbitrage.go
+++ b/services/backend-api/internal/api/handlers/arbitrage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 	"net/http"
 	"sort"

--- a/services/backend-api/internal/api/handlers/arbitrage.go
+++ b/services/backend-api/internal/api/handlers/arbitrage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 	"net/http"
 	"sort"

--- a/services/backend-api/internal/api/handlers/autonomous.go
+++ b/services/backend-api/internal/api/handlers/autonomous.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"net/http"
 	"os"
 	"strconv"

--- a/services/backend-api/internal/api/handlers/autonomous.go
+++ b/services/backend-api/internal/api/handlers/autonomous.go
@@ -1,10 +1,10 @@
 package handlers
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -1227,7 +1227,7 @@ func (h *AutonomousHandler) enrichPortfolioWithLifecycle(ctx context.Context, ch
 	if err == nil {
 		response.OpenOrders = openOrders
 	} else {
-		log.Printf("Failed to count open orders for chat %s: %v", chatID, err)
+		zaplogrus.Warnf("Failed to count open orders for chat %s: %v", chatID, err)
 	}
 
 	if len(response.Positions) > 0 {
@@ -1236,7 +1236,7 @@ func (h *AutonomousHandler) enrichPortfolioWithLifecycle(ctx context.Context, ch
 
 	managed, err := h.lifecycleStore.ListManagedOpenPositions(ctx, chatID, "", 25)
 	if err != nil {
-		log.Printf("Failed to list managed open positions for chat %s: %v", chatID, err)
+		zaplogrus.Warnf("Failed to list managed open positions for chat %s: %v", chatID, err)
 		return false
 	}
 	if len(managed) == 0 {
@@ -1315,7 +1315,7 @@ func (h *AutonomousHandler) buildLifecyclePerformanceSummary(ctx context.Context
 
 	perf, err := h.lifecycleStore.GetRealizedPerformance(ctx, chatID, "", since)
 	if err != nil {
-		log.Printf("Failed lifecycle performance query for chat %s: %v", chatID, err)
+		zaplogrus.Warnf("Failed lifecycle performance query for chat %s: %v", chatID, err)
 		return PerformanceSummaryResponse{}, false
 	}
 	if perf.Trades == 0 {
@@ -1323,7 +1323,7 @@ func (h *AutonomousHandler) buildLifecyclePerformanceSummary(ctx context.Context
 	}
 	returns, err := h.lifecycleStore.GetNetRealizedReturnSeries(ctx, chatID, "", since)
 	if err != nil {
-		log.Printf("Failed lifecycle return-series query for chat %s: %v", chatID, err)
+		zaplogrus.Warnf("Failed lifecycle return-series query for chat %s: %v", chatID, err)
 		returns = nil
 	}
 	risk := services.ComputeRiskAdjustedMetrics(returns)
@@ -1587,21 +1587,21 @@ func (r *ReadinessChecker) checkWallets(c *gin.Context, chatID string) *CheckRes
 	configHasBinance := false
 	// nolint:gosec // Fixed config path, not user input
 	configPath := os.ExpandEnv("$HOME/.neuratrade/config.json") // Fixed config path, not user input
-	log.Printf("DEBUG: Checking config at %s", configPath)
+	zaplogrus.Infof("DEBUG: Checking config at %s", configPath)
 	// #nosec G304 -- fixed operator config path under $HOME/.neuratrade
 	if content, err := os.ReadFile(configPath); err == nil {
 		var config map[string]interface{}
 		if err := json.Unmarshal(content, &config); err == nil {
-			log.Printf("DEBUG: Config loaded, has ccxt: %v", config["ccxt"] != nil)
+			zaplogrus.Infof("DEBUG: Config loaded, has ccxt: %v", config["ccxt"] != nil)
 			// Check new config structure: ccxt.exchanges.binance.api_key
 			if ccxt, ok := config["ccxt"].(map[string]interface{}); ok {
-				log.Printf("DEBUG: Has ccxt section")
+				zaplogrus.Infof("DEBUG: Has ccxt section")
 				if exchanges, ok := ccxt["exchanges"].(map[string]interface{}); ok {
-					log.Printf("DEBUG: Has exchanges section")
+					zaplogrus.Infof("DEBUG: Has exchanges section")
 					if binance, ok := exchanges["binance"].(map[string]interface{}); ok {
-						log.Printf("DEBUG: Has binance section")
+						zaplogrus.Infof("DEBUG: Has binance section")
 						if apiKey, ok := binance["api_key"].(string); ok && apiKey != "" {
-							log.Printf("DEBUG: Binance API key is configured")
+							zaplogrus.Infof("DEBUG: Binance API key is configured")
 							configHasBinance = true
 						}
 					}

--- a/services/backend-api/internal/api/handlers/autonomous.go
+++ b/services/backend-api/internal/api/handlers/autonomous.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"

--- a/services/backend-api/internal/api/handlers/autonomous.go
+++ b/services/backend-api/internal/api/handlers/autonomous.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"net/http"
 	"os"
 	"strconv"

--- a/services/backend-api/internal/api/handlers/market.go
+++ b/services/backend-api/internal/api/handlers/market.go
@@ -1,10 +1,10 @@
 package handlers
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
 	"net/http"
 	"strconv"
@@ -109,13 +109,13 @@ func (h *MarketHandler) CacheMarketPrices(ctx context.Context, cacheKey string, 
 
 	dataJSON, err := json.Marshal(data)
 	if err != nil {
-		log.Printf("Failed to marshal market prices for caching: %v", err)
+		zaplogrus.Warnf("Failed to marshal market prices for caching: %v", err)
 		return
 	}
 
 	ttl := 10 * time.Second
 	if err := h.redis.Set(ctx, cacheKey, string(dataJSON), ttl); err != nil {
-		log.Printf("Failed to cache market prices: %v", err)
+		zaplogrus.Warnf("Failed to cache market prices: %v", err)
 	}
 }
 
@@ -138,7 +138,7 @@ func (h *MarketHandler) GetCachedMarketPrices(ctx context.Context, cacheKey stri
 
 	var data MarketPricesResponse
 	if err := json.Unmarshal([]byte(cachedData), &data); err != nil {
-		log.Printf("Failed to unmarshal cached market prices: %v", err)
+		zaplogrus.Warnf("Failed to unmarshal cached market prices: %v", err)
 		if h.cacheAnalytics != nil {
 			h.cacheAnalytics.RecordMiss("market_data")
 		}
@@ -148,7 +148,7 @@ func (h *MarketHandler) GetCachedMarketPrices(ctx context.Context, cacheKey stri
 	if h.cacheAnalytics != nil {
 		h.cacheAnalytics.RecordHit("market_data")
 	}
-	log.Printf("Cache hit for market prices: %s", cacheKey)
+	zaplogrus.Infof("Cache hit for market prices: %s", cacheKey)
 	return &data, true
 }
 
@@ -160,13 +160,13 @@ func (h *MarketHandler) CacheTicker(ctx context.Context, cacheKey string, data T
 
 	dataJSON, err := json.Marshal(data)
 	if err != nil {
-		log.Printf("Failed to marshal ticker for caching: %v", err)
+		zaplogrus.Warnf("Failed to marshal ticker for caching: %v", err)
 		return
 	}
 
 	ttl := 10 * time.Second
 	if err := h.redis.Set(ctx, cacheKey, string(dataJSON), ttl); err != nil {
-		log.Printf("Failed to cache ticker: %v", err)
+		zaplogrus.Warnf("Failed to cache ticker: %v", err)
 	}
 }
 
@@ -189,7 +189,7 @@ func (h *MarketHandler) GetCachedTicker(ctx context.Context, cacheKey string) (*
 
 	var data TickerResponse
 	if err := json.Unmarshal([]byte(cachedData), &data); err != nil {
-		log.Printf("Failed to unmarshal cached ticker: %v", err)
+		zaplogrus.Warnf("Failed to unmarshal cached ticker: %v", err)
 		if h.cacheAnalytics != nil {
 			h.cacheAnalytics.RecordMiss("tickers")
 		}
@@ -199,7 +199,7 @@ func (h *MarketHandler) GetCachedTicker(ctx context.Context, cacheKey string) (*
 	if h.cacheAnalytics != nil {
 		h.cacheAnalytics.RecordHit("tickers")
 	}
-	log.Printf("Cache hit for ticker: %s", cacheKey)
+	zaplogrus.Infof("Cache hit for ticker: %s", cacheKey)
 	return &data, true
 }
 
@@ -211,13 +211,13 @@ func (h *MarketHandler) CacheBulkTickers(ctx context.Context, cacheKey string, d
 
 	dataJSON, err := json.Marshal(data)
 	if err != nil {
-		log.Printf("Failed to marshal bulk tickers for caching: %v", err)
+		zaplogrus.Warnf("Failed to marshal bulk tickers for caching: %v", err)
 		return
 	}
 
 	ttl := 10 * time.Second
 	if err := h.redis.Set(ctx, cacheKey, string(dataJSON), ttl); err != nil {
-		log.Printf("Failed to cache bulk tickers: %v", err)
+		zaplogrus.Warnf("Failed to cache bulk tickers: %v", err)
 	}
 }
 
@@ -240,7 +240,7 @@ func (h *MarketHandler) GetCachedBulkTickers(ctx context.Context, cacheKey strin
 
 	var data BulkTickerResponse
 	if err := json.Unmarshal([]byte(cachedData), &data); err != nil {
-		log.Printf("Failed to unmarshal cached bulk tickers: %v", err)
+		zaplogrus.Warnf("Failed to unmarshal cached bulk tickers: %v", err)
 		if h.cacheAnalytics != nil {
 			h.cacheAnalytics.RecordMiss("bulk_tickers")
 		}
@@ -251,7 +251,7 @@ func (h *MarketHandler) GetCachedBulkTickers(ctx context.Context, cacheKey strin
 	if h.cacheAnalytics != nil {
 		h.cacheAnalytics.RecordHit("bulk_tickers")
 	}
-	log.Printf("Cache hit for bulk tickers: %s", cacheKey)
+	zaplogrus.Infof("Cache hit for bulk tickers: %s", cacheKey)
 	return &data, true
 }
 
@@ -263,13 +263,13 @@ func (h *MarketHandler) CacheOrderBook(ctx context.Context, cacheKey string, dat
 
 	dataJSON, err := json.Marshal(data)
 	if err != nil {
-		log.Printf("Failed to marshal order book for caching: %v", err)
+		zaplogrus.Warnf("Failed to marshal order book for caching: %v", err)
 		return
 	}
 
 	ttl := 5 * time.Second // Shorter TTL for order books as they change frequently
 	if err := h.redis.Set(ctx, cacheKey, string(dataJSON), ttl); err != nil {
-		log.Printf("Failed to cache order book: %v", err)
+		zaplogrus.Warnf("Failed to cache order book: %v", err)
 	}
 }
 
@@ -292,7 +292,7 @@ func (h *MarketHandler) GetCachedOrderBook(ctx context.Context, cacheKey string)
 
 	var data OrderBookResponse
 	if err := json.Unmarshal([]byte(cachedData), &data); err != nil {
-		log.Printf("Failed to unmarshal cached order book: %v", err)
+		zaplogrus.Warnf("Failed to unmarshal cached order book: %v", err)
 		if h.cacheAnalytics != nil {
 			h.cacheAnalytics.RecordMiss("order_books")
 		}
@@ -303,7 +303,7 @@ func (h *MarketHandler) GetCachedOrderBook(ctx context.Context, cacheKey string)
 	if h.cacheAnalytics != nil {
 		h.cacheAnalytics.RecordHit("order_books")
 	}
-	log.Printf("Cache hit for order book: %s", cacheKey)
+	zaplogrus.Infof("Cache hit for order book: %s", cacheKey)
 	return &data, true
 }
 

--- a/services/backend-api/internal/api/handlers/market.go
+++ b/services/backend-api/internal/api/handlers/market.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,6 +8,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/gin-gonic/gin"
 	"github.com/irfndi/neuratrade/internal/ccxt"

--- a/services/backend-api/internal/api/handlers/market.go
+++ b/services/backend-api/internal/api/handlers/market.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 	"net/http"
 	"strconv"

--- a/services/backend-api/internal/api/handlers/market.go
+++ b/services/backend-api/internal/api/handlers/market.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 	"net/http"
 	"strconv"

--- a/services/backend-api/internal/api/handlers/sqlite/market_handler.go
+++ b/services/backend-api/internal/api/handlers/sqlite/market_handler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/irfndi/neuratrade/internal/database"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"github.com/shopspring/decimal"
 )
 
@@ -168,7 +168,7 @@ func (h *MarketHandler) makeCCXTRequest(ctx context.Context, method, path string
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Printf("Error closing response body: %v", err)
+			zaplogrus.WithError(err).Warn("Error closing response body")
 		}
 	}()
 
@@ -214,7 +214,7 @@ func (h *MarketHandler) checkCCXTHealth(ctx context.Context) bool {
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Printf("Error closing response body: %v", err)
+			zaplogrus.WithError(err).Warn("Error closing response body")
 		}
 	}()
 
@@ -284,7 +284,7 @@ func (h *MarketHandler) GetMarketPrices(c *gin.Context) {
 
 	if err := h.makeCCXTRequest(ctx, "GET", path, nil, &ccxtResponse); err != nil {
 		// Log internal error details for debugging
-		log.Printf("[MarketHandler] Failed to fetch tickers: %v", err)
+		zaplogrus.WithError(err).Warn("Failed to fetch tickers")
 		// Return sanitized error to client (don't leak internal details)
 		c.JSON(http.StatusBadGateway, ErrorResponse{
 			Error: "Failed to fetch market data from exchange",

--- a/services/backend-api/internal/api/handlers/user.go
+++ b/services/backend-api/internal/api/handlers/user.go
@@ -1,12 +1,12 @@
 package handlers
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -263,7 +263,7 @@ func (h *UserHandler) RegisterUser(c *gin.Context) {
 			return
 		}
 		// Database not available (dev mode) - log warning and continue
-		log.Printf("[WARN] User registration proceeded without database persistence: %v", err2)
+		zaplogrus.Warnf("[WARN] User registration proceeded without database persistence: %v", err2)
 	}
 
 	// Return user response (without password)
@@ -404,7 +404,7 @@ func (h *UserHandler) UpdateUserProfile(c *gin.Context) {
 	// Get the old user data for cache invalidation
 	oldUser, err := h.getUserByID(c.Request.Context(), userID)
 	if err != nil {
-		log.Printf("Warning: Could not get old user data for cache invalidation: %v", err)
+		zaplogrus.Warnf("Warning: Could not get old user data for cache invalidation: %v", err)
 	}
 
 	var execErr error
@@ -470,7 +470,7 @@ func (h *UserHandler) userExists(ctx context.Context, email string) (bool, error
 	query := "SELECT COUNT(*) FROM users WHERE email = $1"
 	err := h.db.QueryRow(ctx, query, email).Scan(&count)
 	if err != nil {
-		log.Printf("[USER] Failed to check existing user by email %q: %v", email, err)
+		zaplogrus.Warnf("[USER] Failed to check existing user by email %q: %v", email, err)
 		return false, err
 	}
 	return count > 0, nil
@@ -554,11 +554,11 @@ func (h *UserHandler) getUserByID(ctx context.Context, userID string) (*models.U
 			if unmarshalErr := json.Unmarshal([]byte(cachedData), &user); unmarshalErr == nil {
 				return &user, nil
 			} else {
-				log.Printf("Failed to unmarshal cached user %s: %v", userID, unmarshalErr)
+				zaplogrus.Warnf("Failed to unmarshal cached user %s: %v", userID, unmarshalErr)
 			}
 		} else if err != redis.Nil {
 			// Log non-cache-miss Redis errors
-			log.Printf("Redis error getting user %s: %v", userID, err)
+			zaplogrus.Infof("Redis error getting user %s: %v", userID, err)
 		}
 	}
 
@@ -589,10 +589,10 @@ func (h *UserHandler) getUserByID(ctx context.Context, userID string) (*models.U
 		userJSON, err := json.Marshal(user)
 		if err == nil {
 			if err := h.redis.Set(ctx, cacheKey, string(userJSON), 5*time.Minute).Err(); err != nil {
-				log.Printf("Failed to cache user %s: %v", userID, err)
+				zaplogrus.Warnf("Failed to cache user %s: %v", userID, err)
 			}
 		} else {
-			log.Printf("Failed to marshal user %s for caching: %v", userID, err)
+			zaplogrus.Warnf("Failed to marshal user %s for caching: %v", userID, err)
 		}
 	}
 
@@ -608,18 +608,18 @@ func (h *UserHandler) invalidateUserCache(ctx context.Context, userID string, ol
 	// Invalidate user ID cache
 	userCacheKey := fmt.Sprintf("user:id:%s", userID)
 	if err := h.redis.Del(ctx, userCacheKey).Err(); err != nil {
-		log.Printf("Failed to invalidate user cache for ID %s: %v", userID, err)
+		zaplogrus.Warnf("Failed to invalidate user cache for ID %s: %v", userID, err)
 	} else {
-		log.Printf("Invalidated user cache for ID %s", userID)
+		zaplogrus.Warnf("Invalidated user cache for ID %s", userID)
 	}
 
 	// Invalidate old telegram chat ID cache if it existed
 	if oldUser != nil && oldUser.TelegramChatID != nil {
 		oldTelegramKey := fmt.Sprintf("user:telegram:%s", *oldUser.TelegramChatID)
 		if err := h.redis.Del(ctx, oldTelegramKey).Err(); err != nil {
-			log.Printf("Failed to invalidate old telegram cache for chat ID %s: %v", *oldUser.TelegramChatID, err)
+			zaplogrus.Warnf("Failed to invalidate old telegram cache for chat ID %s: %v", *oldUser.TelegramChatID, err)
 		} else {
-			log.Printf("Invalidated old telegram cache for chat ID %s", *oldUser.TelegramChatID)
+			zaplogrus.Warnf("Invalidated old telegram cache for chat ID %s", *oldUser.TelegramChatID)
 		}
 	}
 
@@ -627,9 +627,9 @@ func (h *UserHandler) invalidateUserCache(ctx context.Context, userID string, ol
 	if newTelegramChatID != nil {
 		newTelegramKey := fmt.Sprintf("user:telegram:%s", *newTelegramChatID)
 		if err := h.redis.Del(ctx, newTelegramKey).Err(); err != nil {
-			log.Printf("Failed to invalidate new telegram cache for chat ID %s: %v", *newTelegramChatID, err)
+			zaplogrus.Warnf("Failed to invalidate new telegram cache for chat ID %s: %v", *newTelegramChatID, err)
 		} else {
-			log.Printf("Invalidated new telegram cache for chat ID %s", *newTelegramChatID)
+			zaplogrus.Warnf("Invalidated new telegram cache for chat ID %s", *newTelegramChatID)
 		}
 	}
 }
@@ -677,11 +677,11 @@ func (h *UserHandler) GetUserByTelegramChatID(ctx context.Context, chatID string
 			if unmarshalErr := json.Unmarshal([]byte(cachedData), &user); unmarshalErr == nil {
 				return &user, nil
 			} else {
-				log.Printf("Failed to unmarshal cached user for chat %s: %v", chatID, unmarshalErr)
+				zaplogrus.Warnf("Failed to unmarshal cached user for chat %s: %v", chatID, unmarshalErr)
 			}
 		} else if err != redis.Nil {
 			// Log non-cache-miss Redis errors
-			log.Printf("Redis error getting user for chat %s: %v", chatID, err)
+			zaplogrus.Infof("Redis error getting user for chat %s: %v", chatID, err)
 		}
 	}
 
@@ -717,10 +717,10 @@ func (h *UserHandler) GetUserByTelegramChatID(ctx context.Context, chatID string
 		userJSON, err := json.Marshal(user)
 		if err == nil {
 			if err := h.redis.Set(ctx, cacheKey, string(userJSON), 5*time.Minute).Err(); err != nil {
-				log.Printf("Failed to cache user for chat %s: %v", chatID, err)
+				zaplogrus.Warnf("Failed to cache user for chat %s: %v", chatID, err)
 			}
 		} else {
-			log.Printf("Failed to marshal user for chat %s for caching: %v", chatID, err)
+			zaplogrus.Warnf("Failed to marshal user for chat %s for caching: %v", chatID, err)
 		}
 	}
 

--- a/services/backend-api/internal/api/handlers/user.go
+++ b/services/backend-api/internal/api/handlers/user.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"net/http"
 	"strings"
 	"time"

--- a/services/backend-api/internal/api/handlers/user.go
+++ b/services/backend-api/internal/api/handlers/user.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/irfndi/neuratrade/internal/database"
 	"github.com/irfndi/neuratrade/internal/models"
+	"github.com/irfndi/neuratrade/internal/utils"
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -471,7 +472,7 @@ func (h *UserHandler) userExists(ctx context.Context, email string) (bool, error
 	query := "SELECT COUNT(*) FROM users WHERE email = $1"
 	err := h.db.QueryRow(ctx, query, email).Scan(&count)
 	if err != nil {
-		zaplogrus.Warnf("[USER] Failed to check existing user by email %q: %v", email, err)
+		zaplogrus.Warnf("[USER] Failed to check existing user by email %q: %v", utils.MaskEmail(email), err)
 		return false, err
 	}
 	return count > 0, nil

--- a/services/backend-api/internal/api/handlers/user.go
+++ b/services/backend-api/internal/api/handlers/user.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"net/http"
 	"strings"
 	"time"

--- a/services/backend-api/internal/api/handlers/user.go
+++ b/services/backend-api/internal/api/handlers/user.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -10,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -88,7 +89,7 @@ func configureLiveReadinessGuard(opModeService *services.OperationalModeService)
 		return
 	}
 	if liveReadinessGuardDisabled(os.Getenv("NEURATRADE_REQUIRE_LIVE_READINESS_PROOF")) {
-		log.Printf("WARNING: real-money live readiness proof guard disabled by NEURATRADE_REQUIRE_LIVE_READINESS_PROOF")
+		zaplogrus.Warnf("WARNING: real-money live readiness proof guard disabled by NEURATRADE_REQUIRE_LIVE_READINESS_PROOF")
 		opModeService.SetLiveModeGuard(nil)
 		return
 	}
@@ -106,15 +107,15 @@ func configureLiveReadinessGuard(opModeService *services.OperationalModeService)
 		if len(filtered) > 0 {
 			requiredStrategies = filtered
 		} else {
-			log.Printf("WARNING: NEURATRADE_LIVE_READINESS_STRATEGIES contained only empty/whitespace entries; using defaults")
+			zaplogrus.Warnf("WARNING: NEURATRADE_LIVE_READINESS_STRATEGIES contained only empty/whitespace entries; using defaults")
 		}
 	}
 	manifestPath := strings.TrimSpace(os.Getenv(services.LiveReadinessManifestEnv))
 	opModeService.SetLiveModeGuard(services.ManifestLiveModeGuard(manifestPath, requiredStrategies))
 	if manifestPath != "" {
-		log.Printf("Real-money live readiness proof guard enabled with manifest %s; live mode requires strategy evidence", manifestPath)
+		zaplogrus.Infof("Real-money live readiness proof guard enabled with manifest %s; live mode requires strategy evidence", manifestPath)
 	} else {
-		log.Printf("Real-money live readiness proof guard enabled; live mode requires %s with strategy evidence", services.LiveReadinessManifestEnv)
+		zaplogrus.Infof("Real-money live readiness proof guard enabled; live mode requires %s with strategy evidence", services.LiveReadinessManifestEnv)
 	}
 }
 
@@ -331,7 +332,7 @@ func loadRouteRuntimeConfig() (bitgetAPIKey, bitgetSecret, bitgetPassphrase, cha
 
 	var cfg routeRuntimeConfigFile
 	if err := json.Unmarshal(configFile, &cfg); err != nil {
-		log.Printf("WARNING: failed to parse runtime config %s: %v", configPath, err)
+		zaplogrus.Warnf("WARNING: failed to parse runtime config %s: %v", configPath, err)
 		return "", "", "", ""
 	}
 
@@ -481,7 +482,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	if telegramConfig != nil {
 		notificationService = services.NewNotificationService(db, redis, telegramConfig.ServiceURL, telegramConfig.GrpcAddress, telegramConfig.AdminAPIKey)
 	} else {
-		log.Printf("[TELEGRAM] WARNING: telegramConfig is nil, notification service will run with default settings")
+		zaplogrus.Warnf("[TELEGRAM] WARNING: telegramConfig is nil, notification service will run with default settings")
 		notificationService = services.NewNotificationService(db, redis, "http://telegram-service:3002", "telegram-service:50052", "")
 	}
 
@@ -541,13 +542,13 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 
 	dailyBudget, err := decimal.NewFromString(dailyBudgetStr)
 	if err != nil {
-		log.Printf("WARNING: Invalid AI_DAILY_BUDGET value '%s', using default 10.00", dailyBudgetStr)
+		zaplogrus.Warnf("WARNING: Invalid AI_DAILY_BUDGET value '%s', using default 10.00", dailyBudgetStr)
 		dailyBudget = decimal.NewFromFloat(10.00)
 	}
 
 	monthlyBudget, err := decimal.NewFromString(monthlyBudgetStr)
 	if err != nil {
-		log.Printf("WARNING: Invalid AI_MONTHLY_BUDGET value '%s', using default 200.00", monthlyBudgetStr)
+		zaplogrus.Warnf("WARNING: Invalid AI_MONTHLY_BUDGET value '%s', using default 200.00", monthlyBudgetStr)
 		monthlyBudget = decimal.NewFromFloat(200.00)
 	}
 
@@ -563,14 +564,14 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	if db != nil {
 		dbQuestStore := services.NewDBQuestStore(db)
 		if err := dbQuestStore.InitSchema(context.Background()); err != nil {
-			log.Printf("Failed to initialize runtime quest persistence schema, falling back to in-memory store: %v", err)
+			zaplogrus.Warnf("Failed to initialize runtime quest persistence schema, falling back to in-memory store: %v", err)
 		} else {
 			questStore = dbQuestStore
 			questStoreMode = "database"
 		}
 	}
 	questEngine := services.NewQuestEngineWithNotification(questStore, redisClientRaw, notificationService)
-	log.Printf("Quest runtime store initialized in %s mode", questStoreMode)
+	zaplogrus.Infof("Quest runtime store initialized in %s mode", questStoreMode)
 
 	riskConfig := risk.DefaultRiskManagerConfig()
 	riskManager := risk.NewRiskManagerAgent(riskConfig)
@@ -644,13 +645,13 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 			snapshot, snapshotErr := portfolioSafety.GetPortfolioSnapshot(safetyCtx, chatID, exchanges)
 			if snapshotErr != nil {
 				cancelSafety()
-				log.Printf("[QUEST] Risk bridge snapshot check failed for chat %s: %v", chatID, snapshotErr)
+				zaplogrus.Warnf("[QUEST] Risk bridge snapshot check failed for chat %s: %v", chatID, snapshotErr)
 				continue
 			}
 			safety, safetyErr := portfolioSafety.CheckSafety(safetyCtx, chatID, snapshot)
 			cancelSafety()
 			if safetyErr != nil {
-				log.Printf("[QUEST] Risk bridge safety check failed for chat %s: %v", chatID, safetyErr)
+				zaplogrus.Warnf("[QUEST] Risk bridge safety check failed for chat %s: %v", chatID, safetyErr)
 				continue
 			}
 			if !safety.TradingAllowed {
@@ -684,15 +685,15 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	// In scalping-first mode we avoid restoring old active rows without metadata/chat ownership.
 	loadLegacyQuests := os.Getenv("NEURATRADE_LOAD_LEGACY_ACTIVE_QUESTS") == "1" ||
 		os.Getenv("NEURATRADE_LOAD_LEGACY_ACTIVE_QUESTS") == "true"
-	log.Printf("DEBUG: db is nil: %v", db == nil)
+	zaplogrus.Infof("DEBUG: db is nil: %v", db == nil)
 	if db != nil && loadLegacyQuests {
 		if questStoreMode == "database" {
-			log.Println("Skipping legacy active quest preload to keep runtime tables isolated from legacy quests")
+			zaplogrus.Warn("Skipping legacy active quest preload to keep runtime tables isolated from legacy quests")
 		} else {
-			log.Println("Loading legacy active quests from database into memory...")
+			zaplogrus.Info("Loading legacy active quests from database into memory...")
 			rows, err := db.Query(context.Background(), "SELECT id, type, cadence, status, target_value, checkpoint, created_at FROM quests WHERE status = 'active'")
 			if err != nil {
-				log.Printf("Failed to load quests from database: %v", err)
+				zaplogrus.Warnf("Failed to load quests from database: %v", err)
 			} else {
 				defer rows.Close()
 				loadedCount := 0
@@ -702,7 +703,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 					var checkpoint []byte
 					var createdAt time.Time
 					if err := rows.Scan(&id, &questType, &cadence, &status, &targetValue, &checkpoint, &createdAt); err != nil {
-						log.Printf("Failed to scan quest row: %v", err)
+						zaplogrus.Warnf("Failed to scan quest row: %v", err)
 						continue
 					}
 					quest := &services.Quest{
@@ -721,25 +722,25 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 						}
 					}
 					if err := questStore.SaveQuest(context.Background(), quest); err != nil {
-						log.Printf("Failed to save quest %s: %v", id, err)
+						zaplogrus.Warnf("Failed to save quest %s: %v", id, err)
 					}
-					log.Printf("Loaded quest from DB: %s (type: %s, status: %s)", id, questType, status)
+					zaplogrus.Infof("Loaded quest from DB: %s (type: %s, status: %s)", id, questType, status)
 					loadedCount++
 				}
-				log.Printf("Loaded %d quests from database", loadedCount)
+				zaplogrus.Infof("Loaded %d quests from database", loadedCount)
 			}
 		}
 	} else if db != nil {
-		log.Println("Skipping legacy active quest preload (set NEURATRADE_LOAD_LEGACY_ACTIVE_QUESTS=1 to enable)")
+		zaplogrus.Warn("Skipping legacy active quest preload (set NEURATRADE_LOAD_LEGACY_ACTIVE_QUESTS=1 to enable)")
 	}
 
 	// Initialize futures arbitrage handler first (needed for quest handlers)
 	var futuresArbitrageHandler *handlers.FuturesArbitrageHandler
 	if db != nil {
 		futuresArbitrageHandler = handlers.NewFuturesArbitrageHandlerWithQuerier(db)
-		log.Printf("Futures arbitrage handler initialized successfully")
+		zaplogrus.Infof("Futures arbitrage handler initialized successfully")
 	} else {
-		log.Printf("Database not available for futures arbitrage handler initialization")
+		zaplogrus.Infof("Database not available for futures arbitrage handler initialization")
 	}
 
 	// Create autonomous monitoring for tracking quest execution
@@ -752,7 +753,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	case *database.PostgresDB:
 		sqlDB = concreteDB.SQL
 	default:
-		log.Printf("Warning: Unknown database type, AI learning disabled")
+		zaplogrus.Warnf("Warning: Unknown database type, AI learning disabled")
 	}
 
 	runtimeDeps := autonomyruntime.Dependencies{
@@ -768,7 +769,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	// Create integrated quest runtime handlers through app/autonomy module.
 	integratedHandlers, integratedHandlersErr := autonomyruntime.BuildIntegratedHandlers(runtimeDeps)
 	if integratedHandlersErr != nil {
-		log.Printf("Warning: autonomy runtime rollout store unavailable, using local fallback handlers: %v", integratedHandlersErr)
+		zaplogrus.Warnf("Warning: autonomy runtime rollout store unavailable, using local fallback handlers: %v", integratedHandlersErr)
 		integratedHandlers = autonomyruntime.BuildLocalIntegratedHandlers(runtimeDeps)
 	}
 
@@ -776,13 +777,13 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	if sqlDB != nil {
 		telemetryStore = services.NewScalpingTelemetryStoreFromSQLDB(sqlDB, nil)
 		if telemetryStore == nil {
-			log.Printf("Warning: scalping telemetry store unavailable due to nil SQL database")
+			zaplogrus.Warnf("Warning: scalping telemetry store unavailable due to nil SQL database")
 		} else {
 			schemaCtx, schemaCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			err := telemetryStore.EnsureSchema(schemaCtx)
 			schemaCancel()
 			if err != nil {
-				log.Printf("Warning: failed to initialize scalping telemetry store: %v", err)
+				zaplogrus.Warnf("Warning: failed to initialize scalping telemetry store: %v", err)
 				telemetryStore = nil
 			} else {
 				integratedHandlers.SetTelemetryStore(telemetryStore)
@@ -793,10 +794,10 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	// Wire order executor to integrated handlers for scalping execution
 	adminAPIKey := os.Getenv("ADMIN_API_KEY")
 	if adminAPIKey == "" {
-		log.Printf("WARNING: ADMIN_API_KEY is not set; CCXT order executor requests will be unauthenticated")
+		zaplogrus.Warnf("WARNING: ADMIN_API_KEY is not set; CCXT order executor requests will be unauthenticated")
 	}
 
-	log.Printf("Using Bitget Order Executor for real exchange API calls")
+	zaplogrus.Infof("Using Bitget Order Executor for real exchange API calls")
 
 	// Load runtime credentials/chat context from ~/.neuratrade/config.json first.
 	bitgetAPIKey, bitgetSecret, bitgetPassphrase, chatID := loadRouteRuntimeConfig()
@@ -816,17 +817,17 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	}
 
 	if chatID == "" {
-		log.Printf("WARNING: TELEGRAM_CHAT_ID is not configured in env or ~/.neuratrade/config.json; trade notifications disabled")
+		zaplogrus.Warnf("WARNING: TELEGRAM_CHAT_ID is not configured in env or ~/.neuratrade/config.json; trade notifications disabled")
 	}
 
 	var orderExecutor services.ScalpingOrderExecutor
 	var liveOrderExecutor services.ScalpingOrderExecutor
 	canUseBitgetCreds := bitgetAPIKey != "" && bitgetSecret != "" && bitgetPassphrase != ""
 	if bitgetAPIKey != "" && bitgetSecret != "" && bitgetPassphrase == "" {
-		log.Printf("⚠️ Bitget API key/secret detected but passphrase is missing; falling back to paper trading")
+		zaplogrus.Warnf("⚠️ Bitget API key/secret detected but passphrase is missing; falling back to paper trading")
 	}
 	if canUseBitgetCreds && chatID != "" && sqlDB != nil && !hasConnectedExchangeWallet(sqlDB, chatID, "bitget") {
-		log.Printf("⚠️ Runtime Bitget credentials do not map to an active Bitget wallet for chat %s; falling back to paper trading", chatID)
+		zaplogrus.Warnf("⚠️ Runtime Bitget credentials do not map to an active Bitget wallet for chat %s; falling back to paper trading", chatID)
 		canUseBitgetCreds = false
 	}
 	if canUseBitgetCreds {
@@ -834,18 +835,18 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		bitgetExec.SetNotificationService(notificationService)
 		bitgetExec.SetChatID(chatID)
 		liveOrderExecutor = bitgetExec
-		log.Printf("✅ Real order execution enabled on Bitget")
+		zaplogrus.Infof("✅ Real order execution enabled on Bitget")
 	}
 	paperOrderExec := services.NewNativeOrderExecutor(ccxtService, bitgetAPIKey, bitgetSecret)
 	paperOrderExec.SetNotificationService(notificationService)
 	paperOrderExec.SetChatID(chatID)
 	if liveOrderExecutor == nil {
-		log.Printf("⚠️ Real order execution unavailable at startup; live mode will be blocked until Bitget credentials and wallet mapping are valid")
+		zaplogrus.Warnf("⚠️ Real order execution unavailable at startup; live mode will be blocked until Bitget credentials and wallet mapping are valid")
 	}
 	orderExecutor = services.NewModeAwareOrderExecutor(liveOrderExecutor, paperOrderExec, opModeService)
 
 	orderExecutor = services.NewSafeOrderExecutor(orderExecutor, portfolioSafety, chatID)
-	log.Printf("Portfolio safety gate enabled for scalping order execution")
+	zaplogrus.Infof("Portfolio safety gate enabled for scalping order execution")
 
 	integratedHandlers.SetDrawdownHalt(drawdownHalt)
 	integratedHandlers.SetOrderExecutor(orderExecutor)
@@ -855,16 +856,16 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	// Set database for user settings lookup
 	var lifecycleStore *services.TradingLifecycleStore
 	if sqlDB != nil {
-		log.Printf("Database available for integrated handlers")
+		zaplogrus.Infof("Database available for integrated handlers")
 	}
 	if db != nil {
 		var lifecycleErr error
 		lifecycleStore, lifecycleErr = services.NewTradingLifecycleStore(db, log.Default())
 		if lifecycleErr != nil {
-			log.Printf("Warning: failed to initialize trading lifecycle store: %v", lifecycleErr)
+			zaplogrus.Warnf("Warning: failed to initialize trading lifecycle store: %v", lifecycleErr)
 		} else {
 			integratedHandlers.SetLifecycleStore(lifecycleStore)
-			log.Printf("Trading lifecycle store initialized for autonomous execution persistence")
+			zaplogrus.Infof("Trading lifecycle store initialized for autonomous execution persistence")
 		}
 	}
 
@@ -887,10 +888,10 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 			services.ResolveTradeMemoryConfigFromEnv(services.DefaultTradeMemoryConfig()),
 		)
 		if err != nil {
-			log.Printf("Warning: Failed to create trade memory: %v", err)
+			zaplogrus.Warnf("Warning: Failed to create trade memory: %v", err)
 		} else {
 			integratedHandlers.SetTradeMemory(tradeMemory)
-			log.Printf("Trade memory initialized for AI learning")
+			zaplogrus.Infof("Trade memory initialized for AI learning")
 		}
 	}
 
@@ -908,7 +909,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	}
 
 	if aiAPIKey != "" {
-		log.Printf("Initializing AI Scalping with primary provider: %s (base_url: %s)", aiProvider, aiBaseURL)
+		zaplogrus.Infof("Initializing AI Scalping with primary provider: %s (base_url: %s)", aiProvider, aiBaseURL)
 
 		httpTimeout := 300 * time.Second
 		if raw := strings.TrimSpace(os.Getenv("NEURATRADE_AI_HTTP_TIMEOUT_SECONDS")); raw != "" {
@@ -925,7 +926,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 
 		providerChain, chainErr := parseAIProviderChain(aiProvider)
 		if chainErr != nil {
-			log.Printf("AI provider chain invalid; falling back to primary provider only: %v", chainErr)
+			zaplogrus.Warnf("AI provider chain invalid; falling back to primary provider only: %v", chainErr)
 			questEngine.SetAIProviderChainStats(0, 0)
 			providerChain = nil
 			if validateAIProviderName(aiProvider) == nil {
@@ -936,7 +937,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		for _, provider := range providerChain {
 			nodeConfig := resolveProviderNode(aiProvider, aiAPIKey, aiBaseURL, provider)
 			if strings.TrimSpace(nodeConfig.APIKey) == "" && providerRequiresAPIKey(provider) {
-				log.Printf("Skipping AI provider %s in failover chain: missing API key", provider)
+				zaplogrus.Warnf("Skipping AI provider %s in failover chain: missing API key", provider)
 				continue
 			}
 
@@ -951,7 +952,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 			if strings.TrimSpace(nodeConfig.ModelOverride) != "" {
 				overrideMsg = nodeConfig.ModelOverride
 			}
-			log.Printf(
+			zaplogrus.Infof(
 				"AI failover node enabled: provider=%s base_url=%s model_override=%s",
 				provider,
 				nodeConfig.BaseURL,
@@ -963,10 +964,10 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		var llmClient llm.Client
 		switch len(failoverNodes) {
 		case 0:
-			log.Printf("AI provider chain has no usable nodes; AI scalping disabled")
+			zaplogrus.Warnf("AI provider chain has no usable nodes; AI scalping disabled")
 		case 1:
 			llmClient = failoverNodes[0].Client
-			log.Printf("AI provider chain active with single node: %s", failoverNodes[0].Provider)
+			zaplogrus.Warnf("AI provider chain active with single node: %s", failoverNodes[0].Provider)
 		default:
 			maxHops := 1
 			if raw := strings.TrimSpace(os.Getenv("NEURATRADE_AI_FAILOVER_MAX_HOPS")); raw != "" {
@@ -975,19 +976,19 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 				}
 			}
 			llmClient = llm.NewFailoverClient(failoverNodes, maxHops)
-			log.Printf("AI provider failover enabled: nodes=%d max_hops=%d", len(failoverNodes), maxHops)
+			zaplogrus.Warnf("AI provider failover enabled: nodes=%d max_hops=%d", len(failoverNodes), maxHops)
 		}
 
 		skillRegistry := skill.NewRegistry(filepath.Join(filepath.Dir(""), "skills"))
 		if err := skillRegistry.LoadAll(); err != nil {
-			log.Printf("Warning: Failed to load skills: %v", err)
+			zaplogrus.Warnf("Warning: Failed to load skills: %v", err)
 		}
 		if llmClient != nil {
 			integratedHandlers.SetAIScalping(llmClient, skillRegistry)
-			log.Printf("AI Scalping service initialized successfully")
+			zaplogrus.Infof("AI Scalping service initialized successfully")
 		}
 	} else {
-		log.Printf("AI API key not configured in ~/.neuratrade/config.json, AI scalping disabled")
+		zaplogrus.Warnf("AI API key not configured in ~/.neuratrade/config.json, AI scalping disabled")
 	}
 
 	if opModeService != nil {
@@ -1003,7 +1004,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 			return coordinator.ValidateStrategyMode(ctx, services.ScalpingStrategyID(chatID), autonomous.ModeLive)
 		})
 		for chatID, err := range opModeService.RevalidateLiveModeGuard(context.Background(), "startup_live_mode_guard") {
-			log.Printf("⚠️ Demoted persisted live mode after proof gate revalidation: chat_id=%s err=%v", chatID, err)
+			zaplogrus.Infof("⚠️ Demoted persisted live mode after proof gate revalidation: chat_id=%s err=%v", chatID, err)
 		}
 	}
 
@@ -1022,10 +1023,10 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 			services.DefaultReconcilerConfig(),
 			log.Default(),
 		)
-		log.Printf("Exchange position reconciler initialized")
+		zaplogrus.Infof("Exchange position reconciler initialized")
 
 		if gin.Mode() == gin.TestMode {
-			log.Printf("Startup reconciliation skipped in test mode")
+			zaplogrus.Warnf("Startup reconciliation skipped in test mode")
 		} else {
 			// Mandatory startup reconciliation in non-test runtime.
 			// This runs before autonomous chat restore so resumability/protection is refreshed first.
@@ -1033,10 +1034,10 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 			results, err := reconciler.ReconcileAll(ctx, services.ReconciliationStartup, "")
 			cancel()
 			if err != nil {
-				log.Printf("Startup reconciliation error: %v", err)
+				zaplogrus.Warnf("Startup reconciliation error: %v", err)
 			} else {
 				for _, r := range results {
-					log.Printf("Startup reconciliation: %s", reconciler.GetReconciliationSummary(&r))
+					zaplogrus.Infof("Startup reconciliation: %s", reconciler.GetReconciliationSummary(&r))
 				}
 			}
 		}
@@ -1047,18 +1048,18 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		if periodicRaw := strings.TrimSpace(os.Getenv("NEURATRADE_PERIODIC_RECONCILIATION_SECONDS")); periodicRaw != "" {
 			seconds, parseErr := strconv.Atoi(periodicRaw)
 			if parseErr != nil {
-				log.Printf("Invalid NEURATRADE_PERIODIC_RECONCILIATION_SECONDS=%q, using default %ds", periodicRaw, periodicSeconds)
+				zaplogrus.Warnf("Invalid NEURATRADE_PERIODIC_RECONCILIATION_SECONDS=%q, using default %ds", periodicRaw, periodicSeconds)
 			} else if seconds == 0 {
 				periodicSeconds = 0
 			} else if seconds > 0 {
 				periodicSeconds = seconds
 			} else {
-				log.Printf("Invalid NEURATRADE_PERIODIC_RECONCILIATION_SECONDS=%q, using default %ds", periodicRaw, periodicSeconds)
+				zaplogrus.Warnf("Invalid NEURATRADE_PERIODIC_RECONCILIATION_SECONDS=%q, using default %ds", periodicRaw, periodicSeconds)
 			}
 		}
 		if periodicSeconds > 0 {
 			interval := time.Duration(periodicSeconds) * time.Second
-			log.Printf("Periodic reconciliation enabled (interval=%s)", interval)
+			zaplogrus.Infof("Periodic reconciliation enabled (interval=%s)", interval)
 			go func() {
 				ticker := time.NewTicker(interval)
 				defer ticker.Stop()
@@ -1067,16 +1068,16 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 					results, err := reconciler.ReconcileAll(ctx, services.ReconciliationPeriodic, "")
 					cancel()
 					if err != nil {
-						log.Printf("Periodic reconciliation error: %v", err)
+						zaplogrus.Warnf("Periodic reconciliation error: %v", err)
 						continue
 					}
 					for _, r := range results {
-						log.Printf("Periodic reconciliation: %s", reconciler.GetReconciliationSummary(&r))
+						zaplogrus.Infof("Periodic reconciliation: %s", reconciler.GetReconciliationSummary(&r))
 					}
 				}
 			}()
 		} else {
-			log.Printf("Periodic reconciliation disabled (NEURATRADE_PERIODIC_RECONCILIATION_SECONDS=0)")
+			zaplogrus.Warnf("Periodic reconciliation disabled (NEURATRADE_PERIODIC_RECONCILIATION_SECONDS=0)")
 		}
 	}
 
@@ -1094,14 +1095,14 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 			query,
 		)
 		if err != nil {
-			log.Printf("Failed to restore autonomous-enabled chats: %v", err)
+			zaplogrus.Warnf("Failed to restore autonomous-enabled chats: %v", err)
 		} else {
 			defer rows.Close()
 			restored := 0
 			for rows.Next() {
 				var chatID string
 				if err := rows.Scan(&chatID); err != nil {
-					log.Printf("Failed to scan autonomous chat row: %v", err)
+					zaplogrus.Warnf("Failed to scan autonomous chat row: %v", err)
 					continue
 				}
 				chatID = strings.TrimSpace(chatID)
@@ -1109,7 +1110,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 					continue
 				}
 				if _, err := questEngine.BeginAutonomous(chatID); err != nil {
-					log.Printf("Failed to restore autonomous mode for chat %s: %v", chatID, err)
+					zaplogrus.Warnf("Failed to restore autonomous mode for chat %s: %v", chatID, err)
 					continue
 				}
 				restored++
@@ -1118,7 +1119,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 			if restoreAllChats {
 				mode = "all enabled chats"
 			}
-			log.Printf("Restored autonomous scalping for %d chat(s) from telegram_operator_state (%s)", restored, mode)
+			zaplogrus.Infof("Restored autonomous scalping for %d chat(s) from telegram_operator_state (%s)", restored, mode)
 		}
 	}
 
@@ -1128,12 +1129,12 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		arbitrageBridge := services.NewArbitrageExecutionBridge(db, questEngine, signalAggregator, nil)
 		go func() {
 			if err := arbitrageBridge.Start(context.Background()); err != nil {
-				log.Printf("Arbitrage execution bridge error: %v", err)
+				zaplogrus.Infof("Arbitrage execution bridge error: %v", err)
 			}
 		}()
-		log.Printf("Arbitrage execution bridge enabled (features.enable_ai_arbitrage=true)")
+		zaplogrus.Infof("Arbitrage execution bridge enabled (features.enable_ai_arbitrage=true)")
 	} else {
-		log.Printf("Arbitrage execution bridge disabled in scalping-first mode")
+		zaplogrus.Warnf("Arbitrage execution bridge disabled in scalping-first mode")
 	}
 	var autonomousHandler *handlers.AutonomousHandler
 	if reconciler != nil {
@@ -1175,9 +1176,9 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	var opModeHandler *handlers.OperationalModeHandler
 	if opModeService != nil {
 		opModeHandler = handlers.NewOperationalModeHandler(opModeService)
-		log.Printf("Operational mode handler initialized")
+		zaplogrus.Infof("Operational mode handler initialized")
 	} else {
-		log.Printf("WARNING: OperationalModeService is nil, trading mode endpoints disabled")
+		zaplogrus.Warnf("WARNING: OperationalModeService is nil, trading mode endpoints disabled")
 	}
 
 	sharedKillSwitch := apprisk.NewKillSwitch()
@@ -1231,9 +1232,9 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 				futuresArbitrage.GET("/market-summary", futuresArbitrageHandler.GetFuturesMarketSummary)
 				futuresArbitrage.POST("/position-sizing", futuresArbitrageHandler.GetPositionSizingRecommendation)
 			}
-			log.Printf("Futures arbitrage routes registered successfully")
+			zaplogrus.Infof("Futures arbitrage routes registered successfully")
 		} else {
-			log.Printf("Skipping futures arbitrage routes due to handler initialization failure")
+			zaplogrus.Warnf("Skipping futures arbitrage routes due to handler initialization failure")
 		}
 
 		// Technical analysis routes

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -977,7 +977,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 				}
 			}
 			llmClient = llm.NewFailoverClient(failoverNodes, maxHops)
-			zaplogrus.Warnf("AI provider failover enabled: nodes=%d max_hops=%d", len(failoverNodes), maxHops)
+			zaplogrus.Infof("AI provider failover enabled: nodes=%d max_hops=%d", len(failoverNodes), maxHops)
 		}
 
 		skillRegistry := skill.NewRegistry(filepath.Join(filepath.Dir(""), "skills"))

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"log"
 	"net/http"
 	"os"

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
+	"github.com/irfndi/neuratrade/internal/utils"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -828,7 +829,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		zaplogrus.Warnf("⚠️ Bitget API key/secret detected but passphrase is missing; falling back to paper trading")
 	}
 	if canUseBitgetCreds && chatID != "" && sqlDB != nil && !hasConnectedExchangeWallet(sqlDB, chatID, "bitget") {
-		zaplogrus.Warnf("⚠️ Runtime Bitget credentials do not map to an active Bitget wallet for chat %s; falling back to paper trading", chatID)
+		zaplogrus.Warnf("⚠️ Runtime Bitget credentials do not map to an active Bitget wallet for chat %s; falling back to paper trading", utils.MaskString(chatID, utils.DefaultMaskingConfig))
 		canUseBitgetCreds = false
 	}
 	if canUseBitgetCreds {

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -13,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"log"
 	"net/http"
 	"os"

--- a/services/backend-api/internal/app/autonomy/runtime/runtime.go
+++ b/services/backend-api/internal/app/autonomy/runtime/runtime.go
@@ -1,10 +1,10 @@
 package runtime
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/irfndi/neuratrade/internal/services"
@@ -74,7 +74,7 @@ func RegisterQuestRuntime(engine *services.QuestEngine, handlers *services.Integ
 	engine.RegisterHandler(services.QuestTypeTriggered, handlers.ExecuteRoutine)
 	engine.RegisterHandler(services.QuestTypeGoal, handlers.ExecuteRoutine)
 	engine.RegisterHandler(services.QuestTypeArbitrage, handlers.ExecuteArbitrage)
-	log.Println("[AUTONOMY-RUNTIME] integrated quest runtime registered")
+	zaplogrus.Info("[AUTONOMY-RUNTIME] integrated quest runtime registered")
 	return nil
 }
 

--- a/services/backend-api/internal/app/autonomy/runtime/runtime.go
+++ b/services/backend-api/internal/app/autonomy/runtime/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"time"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"

--- a/services/backend-api/internal/app/autonomy/runtime/runtime.go
+++ b/services/backend-api/internal/app/autonomy/runtime/runtime.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"time"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"

--- a/services/backend-api/internal/app/autonomy/runtime/runtime.go
+++ b/services/backend-api/internal/app/autonomy/runtime/runtime.go
@@ -1,11 +1,12 @@
 package runtime
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"fmt"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/services"
 )

--- a/services/backend-api/internal/app/bootstrap/bootstrap.go
+++ b/services/backend-api/internal/app/bootstrap/bootstrap.go
@@ -2,13 +2,14 @@
 package bootstrap
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"log/slog"
 

--- a/services/backend-api/internal/app/bootstrap/bootstrap.go
+++ b/services/backend-api/internal/app/bootstrap/bootstrap.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"os"
 	"strings"
 	"time"

--- a/services/backend-api/internal/app/bootstrap/bootstrap.go
+++ b/services/backend-api/internal/app/bootstrap/bootstrap.go
@@ -2,10 +2,10 @@
 package bootstrap
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -287,7 +287,7 @@ func (a *Application) buildRiskComponents(b *Builder) error {
 	// Create risk actor
 	ks, ok := a.KillSwitch.(*risk.KillSwitchImpl)
 	if !ok && a.KillSwitch != nil {
-		log.Printf(
+		zaplogrus.Infof(
 			"[bootstrap] warning: KillSwitch type assertion to *risk.KillSwitchImpl failed for a.KillSwitch (%T); RiskActor and RiskRef will remain nil",
 			a.KillSwitch,
 		)
@@ -300,7 +300,7 @@ func (a *Application) buildRiskComponents(b *Builder) error {
 	if pe, ok := a.Policy.(*risk.Engine); ok {
 		policyEngine = pe
 	} else if a.Policy != nil {
-		log.Printf(
+		zaplogrus.Infof(
 			"[bootstrap] warning: a.Policy (%T) is not *risk.Engine; RiskActorConfig will use nil policyEngine when creating RiskActor",
 			a.Policy,
 		)

--- a/services/backend-api/internal/app/bootstrap/bootstrap.go
+++ b/services/backend-api/internal/app/bootstrap/bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"os"
 	"strings"
 	"time"

--- a/services/backend-api/internal/app/execution/actor.go
+++ b/services/backend-api/internal/app/execution/actor.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 	"time"
 

--- a/services/backend-api/internal/app/execution/actor.go
+++ b/services/backend-api/internal/app/execution/actor.go
@@ -3,13 +3,13 @@
 package execution
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -622,7 +622,7 @@ func (a *ExecutionActor) validateRequest(req *ports.OrderRequest) error {
 // logAuditEvent creates and persists an audit event
 func (a *ExecutionActor) logAuditEvent(ctx context.Context, intentID, eventType, exchange, symbol, reason string, metadata map[string]interface{}) {
 	if a.auditLog == nil {
-		log.Printf("[AUDIT] logger unavailable for intent %s event %s", intentID, eventType)
+		zaplogrus.Warnf("[AUDIT] logger unavailable for intent %s event %s", intentID, eventType)
 		return
 	}
 
@@ -644,7 +644,7 @@ func (a *ExecutionActor) logAuditEvent(ctx context.Context, intentID, eventType,
 			lastEvent := history[len(history)-1]
 			hash, hashErr := calculateHash(lastEvent)
 			if hashErr != nil {
-				log.Printf("[AUDIT] failed to hash previous event intent=%s type=%s: %s", intentID, eventType, sanitizeExternalError(hashErr))
+				zaplogrus.Warnf("[AUDIT] failed to hash previous event intent=%s type=%s: %s", intentID, eventType, sanitizeExternalError(hashErr))
 			} else {
 				previousHash = hash
 			}
@@ -666,13 +666,13 @@ func (a *ExecutionActor) logAuditEvent(ctx context.Context, intentID, eventType,
 
 	if err := a.auditLog.LogOrderEvent(ctx, event); err != nil {
 		// Audit logging is best-effort by design.
-		log.Printf("[AUDIT] failed to log event intent=%s type=%s: %s", intentID, eventType, sanitizeExternalError(err))
+		zaplogrus.Warnf("[AUDIT] failed to log event intent=%s type=%s: %s", intentID, eventType, sanitizeExternalError(err))
 		return
 	}
 
 	eventHash, err := calculateHash(event)
 	if err != nil {
-		log.Printf("[AUDIT] failed to hash event intent=%s type=%s: %s", intentID, eventType, sanitizeExternalError(err))
+		zaplogrus.Warnf("[AUDIT] failed to hash event intent=%s type=%s: %s", intentID, eventType, sanitizeExternalError(err))
 		return
 	}
 	a.lastAuditHash[intentID] = eventHash
@@ -708,7 +708,7 @@ func (a *ExecutionActor) publishEvent(ctx context.Context, eventType string, int
 	}
 
 	if err := a.eventBus.Publish(ctx, orderEvent); err != nil {
-		log.Printf("[EVENT] failed to publish intent=%s type=%s: %s", intent.IntentID, eventType, sanitizeExternalError(err))
+		zaplogrus.Warnf("[EVENT] failed to publish intent=%s type=%s: %s", intent.IntentID, eventType, sanitizeExternalError(err))
 	}
 }
 

--- a/services/backend-api/internal/app/execution/actor.go
+++ b/services/backend-api/internal/app/execution/actor.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 	"time"
 

--- a/services/backend-api/internal/app/execution/actor.go
+++ b/services/backend-api/internal/app/execution/actor.go
@@ -3,7 +3,6 @@
 package execution
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -12,6 +11,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/google/uuid"
 	"github.com/irfndi/neuratrade/internal/platform/actor"

--- a/services/backend-api/internal/app/execution/service.go
+++ b/services/backend-api/internal/app/execution/service.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"time"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"

--- a/services/backend-api/internal/app/execution/service.go
+++ b/services/backend-api/internal/app/execution/service.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"time"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"

--- a/services/backend-api/internal/app/execution/service.go
+++ b/services/backend-api/internal/app/execution/service.go
@@ -3,11 +3,12 @@
 package execution
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/platform/actor"
 	"github.com/irfndi/neuratrade/internal/ports"

--- a/services/backend-api/internal/app/execution/service.go
+++ b/services/backend-api/internal/app/execution/service.go
@@ -3,10 +3,10 @@
 package execution
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/irfndi/neuratrade/internal/platform/actor"
@@ -70,7 +70,7 @@ func (s *ExecutionService) Start(ctx context.Context) error {
 	// Start the actor's message processing loop
 	go func() {
 		if err := s.actorRef.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			log.Printf("[execution] actor stopped: %s", sanitizeExternalError(err))
+			zaplogrus.Infof("[execution] actor stopped: %s", sanitizeExternalError(err))
 		}
 	}()
 

--- a/services/backend-api/internal/app/execution/store.go
+++ b/services/backend-api/internal/app/execution/store.go
@@ -1,12 +1,12 @@
 package execution
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -547,7 +547,7 @@ func parseOrderStatus(s string) ports.OrderStatus {
 	case "rejected":
 		return ports.OrderStatusRejected
 	default:
-		log.Printf("[execution.store] parseOrderStatus: unrecognized status %q, defaulting to pending", s)
+		zaplogrus.Infof("[execution.store] parseOrderStatus: unrecognized status %q, defaulting to pending", s)
 		return ports.OrderStatusPending
 	}
 }
@@ -559,7 +559,7 @@ func parseOrderSide(s string) ports.OrderSide {
 	case "sell":
 		return ports.OrderSideSell
 	default:
-		log.Printf("[execution.store] parseOrderSide: unrecognized side %q, defaulting to buy", s)
+		zaplogrus.Infof("[execution.store] parseOrderSide: unrecognized side %q, defaulting to buy", s)
 		return ports.OrderSideBuy
 	}
 }
@@ -571,7 +571,7 @@ func parseOrderType(s string) ports.OrderType {
 	case "limit":
 		return ports.OrderTypeLimit
 	default:
-		log.Printf("[execution.store] parseOrderType: unrecognized type %q, defaulting to market", s)
+		zaplogrus.Infof("[execution.store] parseOrderType: unrecognized type %q, defaulting to market", s)
 		return ports.OrderTypeMarket
 	}
 }

--- a/services/backend-api/internal/app/execution/store.go
+++ b/services/backend-api/internal/app/execution/store.go
@@ -1,7 +1,6 @@
 package execution
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -10,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/ports"
 	"github.com/shopspring/decimal"

--- a/services/backend-api/internal/app/execution/store.go
+++ b/services/backend-api/internal/app/execution/store.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strconv"
 	"strings"
 	"time"

--- a/services/backend-api/internal/app/execution/store.go
+++ b/services/backend-api/internal/app/execution/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strconv"
 	"strings"
 	"time"

--- a/services/backend-api/internal/app/risk/risk_actor.go
+++ b/services/backend-api/internal/app/risk/risk_actor.go
@@ -2,11 +2,12 @@
 package risk
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/platform/actor"
 	"github.com/irfndi/neuratrade/internal/platform/eventbus"

--- a/services/backend-api/internal/app/risk/risk_actor.go
+++ b/services/backend-api/internal/app/risk/risk_actor.go
@@ -4,7 +4,6 @@ package risk
 import (
 	"context"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/app/risk/risk_actor.go
+++ b/services/backend-api/internal/app/risk/risk_actor.go
@@ -4,6 +4,7 @@ package risk
 import (
 	"context"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/app/risk/risk_actor.go
+++ b/services/backend-api/internal/app/risk/risk_actor.go
@@ -2,9 +2,9 @@
 package risk
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -431,7 +431,7 @@ func (a *RiskActor) publishEvent(ctx context.Context, traceID, eventType string,
 	}
 
 	if err := a.eventBus.Publish(publishCtx, event); err != nil {
-		log.Printf("[risk] %v", fmt.Errorf("publish risk event type=%s: %w", eventType, err))
+		zaplogrus.Infof("[risk] %v", fmt.Errorf("publish risk event type=%s: %w", eventType, err))
 	}
 }
 

--- a/services/backend-api/internal/app/risk/safe_mode.go
+++ b/services/backend-api/internal/app/risk/safe_mode.go
@@ -2,11 +2,12 @@
 package risk
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/ports"
 )

--- a/services/backend-api/internal/app/risk/safe_mode.go
+++ b/services/backend-api/internal/app/risk/safe_mode.go
@@ -4,7 +4,6 @@ package risk
 import (
 	"context"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/app/risk/safe_mode.go
+++ b/services/backend-api/internal/app/risk/safe_mode.go
@@ -2,9 +2,9 @@
 package risk
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -231,7 +231,7 @@ func (t *AutoSafeModeTrigger) OnDrawdownUpdate(drawdown float64) {
 	if drawdown >= t.drawdownLimit {
 		if err := t.safeMode.EnableWithReason(context.Background(),
 			fmt.Sprintf("auto-triggered: drawdown %.2f%% >= limit %.2f%%", drawdown*100, t.drawdownLimit*100)); err != nil {
-			log.Printf("[risk] %v", fmt.Errorf("enable safe mode auto-trigger: %w", err))
+			zaplogrus.Infof("[risk] %v", fmt.Errorf("enable safe mode auto-trigger: %w", err))
 		}
 	}
 }
@@ -254,7 +254,7 @@ func (t *AutoSafeModeTrigger) OnTradeResult(profitable bool) {
 	if t.currentStreak >= t.lossStreak {
 		if err := t.safeMode.EnableWithReason(context.Background(),
 			fmt.Sprintf("auto-triggered: %d consecutive losses", t.currentStreak)); err != nil {
-			log.Printf("[risk] %v", fmt.Errorf("enable safe mode auto-trigger: %w", err))
+			zaplogrus.Infof("[risk] %v", fmt.Errorf("enable safe mode auto-trigger: %w", err))
 		}
 		t.currentStreak = 0 // Reset after triggering
 	}

--- a/services/backend-api/internal/app/risk/safe_mode.go
+++ b/services/backend-api/internal/app/risk/safe_mode.go
@@ -4,6 +4,7 @@ package risk
 import (
 	"context"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/autonomous/rollback_engine.go
+++ b/services/backend-api/internal/autonomous/rollback_engine.go
@@ -3,7 +3,6 @@ package autonomous
 import (
 	"context"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 	"sync"
 	"time"

--- a/services/backend-api/internal/autonomous/rollback_engine.go
+++ b/services/backend-api/internal/autonomous/rollback_engine.go
@@ -3,6 +3,7 @@ package autonomous
 import (
 	"context"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 	"sync"
 	"time"

--- a/services/backend-api/internal/autonomous/rollback_engine.go
+++ b/services/backend-api/internal/autonomous/rollback_engine.go
@@ -1,9 +1,9 @@
 package autonomous
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 	"time"
@@ -196,7 +196,7 @@ func (e *AutoRollbackEngine) executeRollback(
 	// Save event
 	if e.repo != nil {
 		if err := e.repo.SaveRollbackEvent(ctx, event); err != nil {
-			log.Printf(
+			zaplogrus.Infof(
 				"[AUTONOMY] SaveRollbackEvent failed (event_id=%s strategy_id=%s trigger=%s): %v",
 				event.ID,
 				event.StrategyID,
@@ -209,7 +209,7 @@ func (e *AutoRollbackEngine) executeRollback(
 	// Publish event
 	if e.events != nil {
 		if err := e.events.PublishRollbackEvent(ctx, event); err != nil {
-			log.Printf(
+			zaplogrus.Infof(
 				"[AUTONOMY] PublishRollbackEvent failed (event_id=%s strategy_id=%s trigger=%s): %v",
 				event.ID,
 				event.StrategyID,

--- a/services/backend-api/internal/autonomous/rollback_engine.go
+++ b/services/backend-api/internal/autonomous/rollback_engine.go
@@ -1,12 +1,13 @@
 package autonomous
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"

--- a/services/backend-api/internal/autonomous/rollout_manager.go
+++ b/services/backend-api/internal/autonomous/rollout_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 	"time"
 

--- a/services/backend-api/internal/autonomous/rollout_manager.go
+++ b/services/backend-api/internal/autonomous/rollout_manager.go
@@ -1,10 +1,10 @@
 package autonomous
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -235,7 +235,7 @@ func (m *StagedRolloutManager) promote(ctx context.Context, strategyID string, r
 	// Publish event
 	if m.events != nil {
 		if err := m.events.PublishStageTransition(ctx, &transition); err != nil {
-			log.Printf(
+			zaplogrus.Infof(
 				"[AUTONOMY] PublishStageTransition failed (strategy_id=%s from=%s to=%s reason=%s): %v",
 				strategyID,
 				transition.FromStage,
@@ -291,7 +291,7 @@ func (m *StagedRolloutManager) Rollback(ctx context.Context, strategyID string, 
 	// Publish event
 	if m.events != nil {
 		if err := m.events.PublishStageTransition(ctx, &transition); err != nil {
-			log.Printf(
+			zaplogrus.Infof(
 				"[AUTONOMY] PublishStageTransition failed (strategy_id=%s from=%s to=%s reason=%s): %v",
 				strategyID,
 				transition.FromStage,

--- a/services/backend-api/internal/autonomous/rollout_manager.go
+++ b/services/backend-api/internal/autonomous/rollout_manager.go
@@ -1,12 +1,13 @@
 package autonomous
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/shopspring/decimal"
 )

--- a/services/backend-api/internal/autonomous/rollout_manager.go
+++ b/services/backend-api/internal/autonomous/rollout_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 	"time"
 

--- a/services/backend-api/internal/cache/blacklist_cache.go
+++ b/services/backend-api/internal/cache/blacklist_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/cache/blacklist_cache.go
+++ b/services/backend-api/internal/cache/blacklist_cache.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/cache/blacklist_cache.go
+++ b/services/backend-api/internal/cache/blacklist_cache.go
@@ -1,10 +1,10 @@
 package cache
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -136,14 +136,14 @@ func (rbc *RedisBlacklistCache) IsBlacklisted(symbol string) (bool, string) {
 			return false, ""
 		}
 		// Log error but don't fail the check
-		log.Printf("Redis blacklist check error for %s: %v", symbol, err)
+		zaplogrus.Infof("Redis blacklist check error for %s: %v", symbol, err)
 		rbc.stats.Misses++
 		return false, ""
 	}
 
 	var entry BlacklistCacheEntry
 	if err := json.Unmarshal([]byte(val), &entry); err != nil {
-		log.Printf("Failed to unmarshal blacklist entry for %s: %v", symbol, err)
+		zaplogrus.Warnf("Failed to unmarshal blacklist entry for %s: %v", symbol, err)
 		rbc.stats.Misses++
 		return false, ""
 	}
@@ -190,27 +190,27 @@ func (rbc *RedisBlacklistCache) Add(symbol, reason string, ttl time.Duration) {
 		ctx := context.Background()
 		_, err := rbc.repo.AddExchange(ctx, symbol, reason, entry.ExpiresAt)
 		if err != nil {
-			log.Printf("Error persisting to database: %v", err)
+			zaplogrus.Infof("Error persisting to database: %v", err)
 			// Continue with Redis cache even if database fails
 		}
 	}
 
 	data, err := json.Marshal(entry)
 	if err != nil {
-		log.Printf("Failed to marshal blacklist entry for %s: %v", symbol, err)
+		zaplogrus.Warnf("Failed to marshal blacklist entry for %s: %v", symbol, err)
 		return
 	}
 
 	key := rbc.prefix + symbol
 	err = rbc.client.Set(rbc.ctx, key, data, ttl).Err()
 	if err != nil {
-		log.Printf("Failed to set blacklist entry for %s: %v", symbol, err)
+		zaplogrus.Warnf("Failed to set blacklist entry for %s: %v", symbol, err)
 		return
 	}
 
 	rbc.stats.Adds++
 	rbc.stats.TotalEntries++
-	log.Printf("Blacklisted symbol %s for %s (TTL: %v)", symbol, reason, ttl)
+	zaplogrus.Infof("Blacklisted symbol %s for %s (TTL: %v)", symbol, reason, ttl)
 }
 
 // Remove removes a symbol from the blacklist.
@@ -228,7 +228,7 @@ func (rbc *RedisBlacklistCache) Remove(symbol string) {
 		ctx := context.Background()
 		err := rbc.repo.RemoveExchange(ctx, symbol)
 		if err != nil {
-			log.Printf("Error removing from database: %v", err)
+			zaplogrus.Infof("Error removing from database: %v", err)
 			// Continue with Redis cache even if database fails
 		}
 	}
@@ -236,13 +236,13 @@ func (rbc *RedisBlacklistCache) Remove(symbol string) {
 	key := rbc.prefix + symbol
 	result := rbc.client.Del(rbc.ctx, key)
 	if result.Err() != nil {
-		log.Printf("Failed to remove blacklist entry for %s: %v", symbol, result.Err())
+		zaplogrus.Warnf("Failed to remove blacklist entry for %s: %v", symbol, result.Err())
 		return
 	}
 
 	if result.Val() > 0 {
 		rbc.stats.TotalEntries--
-		log.Printf("Removed symbol %s from blacklist", symbol)
+		zaplogrus.Infof("Removed symbol %s from blacklist", symbol)
 	}
 }
 
@@ -260,18 +260,18 @@ func (rbc *RedisBlacklistCache) Clear() {
 		keys = append(keys, iter.Val())
 	}
 	if err := iter.Err(); err != nil {
-		log.Printf("Failed to scan blacklist keys: %v", err)
+		zaplogrus.Warnf("Failed to scan blacklist keys: %v", err)
 		return
 	}
 
 	if len(keys) > 0 {
 		result := rbc.client.Del(rbc.ctx, keys...)
 		if result.Err() != nil {
-			log.Printf("Failed to clear blacklist: %v", result.Err())
+			zaplogrus.Warnf("Failed to clear blacklist: %v", result.Err())
 			return
 		}
 		rbc.stats.TotalEntries = 0
-		log.Printf("Cleared %d blacklisted symbols", result.Val())
+		zaplogrus.Infof("Cleared %d blacklisted symbols", result.Val())
 	}
 }
 
@@ -301,7 +301,7 @@ func (rbc *RedisBlacklistCache) GetStats() BlacklistCacheStats {
 // LogStats logs current cache statistics to the standard logger.
 func (rbc *RedisBlacklistCache) LogStats() {
 	stats := rbc.GetStats()
-	log.Printf("Blacklist Cache Stats - Total: %d, Hits: %d, Misses: %d, Adds: %d, Expired: %d",
+	zaplogrus.Infof("Blacklist Cache Stats - Total: %d, Hits: %d, Misses: %d, Adds: %d, Expired: %d",
 		stats.TotalEntries, stats.Hits, stats.Misses, stats.Adds, stats.ExpiredEntries)
 }
 
@@ -356,7 +356,7 @@ func (rbc *RedisBlacklistCache) LoadFromDatabase(ctx context.Context) error {
 
 		data, err := json.Marshal(cacheEntry)
 		if err != nil {
-			log.Printf("Error marshaling blacklist entry for %s: %v", entry.ExchangeName, err)
+			zaplogrus.Infof("Error marshaling blacklist entry for %s: %v", entry.ExchangeName, err)
 			continue
 		}
 
@@ -373,12 +373,12 @@ func (rbc *RedisBlacklistCache) LoadFromDatabase(ctx context.Context) error {
 
 		err = rbc.client.Set(ctx, key, data, ttl).Err()
 		if err != nil {
-			log.Printf("Error loading blacklist entry to cache for %s: %v", entry.ExchangeName, err)
+			zaplogrus.Infof("Error loading blacklist entry to cache for %s: %v", entry.ExchangeName, err)
 			continue
 		}
 	}
 
-	log.Printf("Loaded %d blacklist entries from database to cache", len(entries))
+	zaplogrus.Infof("Loaded %d blacklist entries from database to cache", len(entries))
 	return nil
 }
 
@@ -445,7 +445,7 @@ func (rbc *RedisBlacklistCache) CleanupExpired() int {
 		keys = append(keys, iter.Val())
 	}
 	if err := iter.Err(); err != nil {
-		log.Printf("Failed to scan blacklist keys for cleanup: %v", err)
+		zaplogrus.Warnf("Failed to scan blacklist keys for cleanup: %v", err)
 		return 0
 	}
 
@@ -472,7 +472,7 @@ func (rbc *RedisBlacklistCache) CleanupExpired() int {
 		rbc.stats.ExpiredEntries += int64(expiredCount)
 		rbc.stats.TotalEntries -= int64(expiredCount)
 		rbc.stats.LastCleanup = time.Now()
-		log.Printf("Cleaned up %d expired blacklist entries", expiredCount)
+		zaplogrus.Infof("Cleaned up %d expired blacklist entries", expiredCount)
 	}
 
 	return expiredCount
@@ -572,7 +572,7 @@ func (ibc *InMemoryBlacklistCache) Add(symbol, reason string, ttl time.Duration)
 	ibc.cache[symbol] = entry
 	ibc.stats.Adds++
 	ibc.stats.TotalEntries++
-	log.Printf("Blacklisted symbol %s for %s (TTL: %v)", symbol, reason, ttl)
+	zaplogrus.Infof("Blacklisted symbol %s for %s (TTL: %v)", symbol, reason, ttl)
 }
 
 // Remove removes a symbol from the blacklist (in-memory implementation).
@@ -587,7 +587,7 @@ func (ibc *InMemoryBlacklistCache) Remove(symbol string) {
 	if _, exists := ibc.cache[symbol]; exists {
 		delete(ibc.cache, symbol)
 		ibc.stats.TotalEntries--
-		log.Printf("Removed symbol %s from blacklist", symbol)
+		zaplogrus.Infof("Removed symbol %s from blacklist", symbol)
 	}
 }
 
@@ -599,7 +599,7 @@ func (ibc *InMemoryBlacklistCache) Clear() {
 	count := len(ibc.cache)
 	ibc.cache = make(map[string]*BlacklistCacheEntry)
 	ibc.stats.TotalEntries = 0
-	log.Printf("Cleared %d blacklisted symbols", count)
+	zaplogrus.Infof("Cleared %d blacklisted symbols", count)
 }
 
 // GetStats returns current cache statistics (in-memory implementation).
@@ -616,7 +616,7 @@ func (ibc *InMemoryBlacklistCache) GetStats() BlacklistCacheStats {
 // LogStats logs current cache statistics (in-memory implementation).
 func (ibc *InMemoryBlacklistCache) LogStats() {
 	stats := ibc.GetStats()
-	log.Printf("Blacklist Cache Stats - Total: %d, Hits: %d, Misses: %d, Adds: %d, Expired: %d",
+	zaplogrus.Infof("Blacklist Cache Stats - Total: %d, Hits: %d, Misses: %d, Adds: %d, Expired: %d",
 		stats.TotalEntries, stats.Hits, stats.Misses, stats.Adds, stats.ExpiredEntries)
 }
 

--- a/services/backend-api/internal/cache/blacklist_cache.go
+++ b/services/backend-api/internal/cache/blacklist_cache.go
@@ -1,12 +1,13 @@
 package cache
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/database"
 	"github.com/redis/go-redis/v9"

--- a/services/backend-api/internal/cache/query_result_cache.go
+++ b/services/backend-api/internal/cache/query_result_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/cache/query_result_cache.go
+++ b/services/backend-api/internal/cache/query_result_cache.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/cache/query_result_cache.go
+++ b/services/backend-api/internal/cache/query_result_cache.go
@@ -1,10 +1,10 @@
 package cache
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -60,7 +60,7 @@ func (c *QueryResultCache) Get(ctx context.Context, queryHash, tableName string)
 	}
 	if err != nil {
 		if c.enableLog {
-			log.Printf("QueryResultCache Redis error: %v", err)
+			zaplogrus.Infof("QueryResultCache Redis error: %v", err)
 		}
 		c.stats.mu.Lock()
 		c.stats.Misses++
@@ -71,7 +71,7 @@ func (c *QueryResultCache) Get(ctx context.Context, queryHash, tableName string)
 	var entry QueryResultCacheEntry
 	if err := json.Unmarshal([]byte(data), &entry); err != nil {
 		if c.enableLog {
-			log.Printf("QueryResultCache unmarshal error: %v", err)
+			zaplogrus.Infof("QueryResultCache unmarshal error: %v", err)
 		}
 		c.stats.mu.Lock()
 		c.stats.Misses++
@@ -81,7 +81,7 @@ func (c *QueryResultCache) Get(ctx context.Context, queryHash, tableName string)
 
 	if time.Now().After(entry.ExpiresAt) {
 		if c.enableLog {
-			log.Printf("QueryResultCache entry expired for %s", tableName)
+			zaplogrus.Infof("QueryResultCache entry expired for %s", tableName)
 		}
 		c.stats.mu.Lock()
 		c.stats.Misses++
@@ -127,7 +127,7 @@ func (c *QueryResultCache) Set(ctx context.Context, queryHash, tableName string,
 		if len(hashPreview) > 8 {
 			hashPreview = hashPreview[:8]
 		}
-		log.Printf("Cached query result for %s (hash: %s, rows: %d, TTL: %v)",
+		zaplogrus.Infof("Cached query result for %s (hash: %s, rows: %d, TTL: %v)",
 			tableName, hashPreview, rowCount, c.ttl)
 	}
 
@@ -151,7 +151,7 @@ func (c *QueryResultCache) Invalidate(ctx context.Context, tableName string) err
 			return fmt.Errorf("failed to invalidate cache: %w", err)
 		}
 		if c.enableLog {
-			log.Printf("Invalidated %d cache entries for table %s", len(keys), tableName)
+			zaplogrus.Warnf("Invalidated %d cache entries for table %s", len(keys), tableName)
 		}
 	}
 
@@ -175,7 +175,7 @@ func (c *QueryResultCache) InvalidateByPattern(ctx context.Context, pattern stri
 			return fmt.Errorf("failed to invalidate cache: %w", err)
 		}
 		if c.enableLog {
-			log.Printf("Invalidated %d cache entries matching pattern %s", len(keys), pattern)
+			zaplogrus.Warnf("Invalidated %d cache entries matching pattern %s", len(keys), pattern)
 		}
 	}
 
@@ -217,7 +217,7 @@ func (c *QueryResultCache) Clear(ctx context.Context) error {
 		if err := c.redis.Del(ctx, keys...).Err(); err != nil {
 			return fmt.Errorf("failed to clear cache: %w", err)
 		}
-		log.Printf("Cleared %d query cache entries", len(keys))
+		zaplogrus.Infof("Cleared %d query cache entries", len(keys))
 	}
 
 	return nil

--- a/services/backend-api/internal/cache/query_result_cache.go
+++ b/services/backend-api/internal/cache/query_result_cache.go
@@ -152,7 +152,7 @@ func (c *QueryResultCache) Invalidate(ctx context.Context, tableName string) err
 			return fmt.Errorf("failed to invalidate cache: %w", err)
 		}
 		if c.enableLog {
-			zaplogrus.Warnf("Invalidated %d cache entries for table %s", len(keys), tableName)
+			zaplogrus.Infof("Invalidated %d cache entries for table %s", len(keys), tableName)
 		}
 	}
 
@@ -176,7 +176,7 @@ func (c *QueryResultCache) InvalidateByPattern(ctx context.Context, pattern stri
 			return fmt.Errorf("failed to invalidate cache: %w", err)
 		}
 		if c.enableLog {
-			zaplogrus.Warnf("Invalidated %d cache entries matching pattern %s", len(keys), pattern)
+			zaplogrus.Infof("Invalidated %d cache entries matching pattern %s", len(keys), pattern)
 		}
 	}
 

--- a/services/backend-api/internal/cache/query_result_cache.go
+++ b/services/backend-api/internal/cache/query_result_cache.go
@@ -1,12 +1,13 @@
 package cache
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/redis/go-redis/v9"
 )

--- a/services/backend-api/internal/cache/symbol_cache.go
+++ b/services/backend-api/internal/cache/symbol_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/cache/symbol_cache.go
+++ b/services/backend-api/internal/cache/symbol_cache.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/cache/symbol_cache.go
+++ b/services/backend-api/internal/cache/symbol_cache.go
@@ -1,10 +1,10 @@
 package cache
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -83,7 +83,7 @@ func (c *RedisSymbolCache) Get(exchangeID string) ([]string, bool) {
 		return nil, false
 	}
 	if err != nil {
-		log.Printf("Redis error getting symbols for %s: %v", exchangeID, err)
+		zaplogrus.Infof("Redis error getting symbols for %s: %v", exchangeID, err)
 		c.stats.mu.Lock()
 		c.stats.Misses++
 		c.stats.mu.Unlock()
@@ -93,7 +93,7 @@ func (c *RedisSymbolCache) Get(exchangeID string) ([]string, bool) {
 	// Deserialize cached entry
 	var entry SymbolCacheEntry
 	if err := json.Unmarshal([]byte(data), &entry); err != nil {
-		log.Printf("Error deserializing cached symbols for %s: %v", exchangeID, err)
+		zaplogrus.Infof("Error deserializing cached symbols for %s: %v", exchangeID, err)
 		c.stats.mu.Lock()
 		c.stats.Misses++
 		c.stats.mu.Unlock()
@@ -104,7 +104,7 @@ func (c *RedisSymbolCache) Get(exchangeID string) ([]string, bool) {
 	if time.Now().After(entry.ExpiresAt) {
 		// Entry expired, but return it anyway to prevent API calls during runtime
 		// This matches the behavior of the original in-memory cache
-		log.Printf("Cached symbols for %s expired but returning to prevent API calls", exchangeID)
+		zaplogrus.Infof("Cached symbols for %s expired but returning to prevent API calls", exchangeID)
 	}
 
 	// Cache hit
@@ -136,14 +136,14 @@ func (c *RedisSymbolCache) Set(exchangeID string, symbols []string) {
 	// Serialize entry
 	data, err := json.Marshal(entry)
 	if err != nil {
-		log.Printf("Error serializing symbols for %s: %v", exchangeID, err)
+		zaplogrus.Infof("Error serializing symbols for %s: %v", exchangeID, err)
 		return
 	}
 
 	// Store in Redis with TTL
 	err = c.redis.Set(ctx, cacheKey, data, c.ttl).Err()
 	if err != nil {
-		log.Printf("Redis error setting symbols for %s: %v", exchangeID, err)
+		zaplogrus.Infof("Redis error setting symbols for %s: %v", exchangeID, err)
 		return
 	}
 
@@ -152,7 +152,7 @@ func (c *RedisSymbolCache) Set(exchangeID string, symbols []string) {
 	c.stats.Sets++
 	c.stats.mu.Unlock()
 
-	log.Printf("Cached %d symbols for %s (TTL: %v)", len(symbols), exchangeID, c.ttl)
+	zaplogrus.Infof("Cached %d symbols for %s (TTL: %v)", len(symbols), exchangeID, c.ttl)
 }
 
 // GetStats returns current cache statistics.
@@ -179,7 +179,7 @@ func (c *RedisSymbolCache) LogStats() {
 		hitRate = float64(stats.Hits) / float64(total) * 100
 	}
 
-	log.Printf("Redis Symbol Cache Stats - Hits: %d, Misses: %d, Sets: %d, Hit Rate: %.2f%%",
+	zaplogrus.Infof("Redis Symbol Cache Stats - Hits: %d, Misses: %d, Sets: %d, Hit Rate: %.2f%%",
 		stats.Hits, stats.Misses, stats.Sets, hitRate)
 }
 
@@ -211,7 +211,7 @@ func (c *RedisSymbolCache) Clear() error {
 		return fmt.Errorf("error clearing cache: %w", err)
 	}
 
-	log.Printf("Cleared %d symbol cache entries", len(keys))
+	zaplogrus.Infof("Cleared %d symbol cache entries", len(keys))
 	return nil
 }
 
@@ -259,26 +259,26 @@ func (c *RedisSymbolCache) GetCachedExchanges() ([]string, error) {
 //
 //	error: An error if warming fails.
 func (c *RedisSymbolCache) WarmCache(exchanges []string, symbolFetcher func(string) ([]string, error)) error {
-	log.Printf("Warming symbol cache for %d exchanges...", len(exchanges))
+	zaplogrus.Infof("Warming symbol cache for %d exchanges...", len(exchanges))
 
 	for _, exchangeID := range exchanges {
 		// Check if already cached
 		if _, exists := c.Get(exchangeID); exists {
-			log.Printf("Symbols for %s already cached, skipping", exchangeID)
+			zaplogrus.Warnf("Symbols for %s already cached, skipping", exchangeID)
 			continue
 		}
 
 		// Fetch and cache symbols
 		symbols, err := symbolFetcher(exchangeID)
 		if err != nil {
-			log.Printf("Warning: Failed to warm cache for %s: %v", exchangeID, err)
+			zaplogrus.Warnf("Warning: Failed to warm cache for %s: %v", exchangeID, err)
 			continue
 		}
 
 		c.Set(exchangeID, symbols)
-		log.Printf("Warmed cache for %s with %d symbols", exchangeID, len(symbols))
+		zaplogrus.Infof("Warmed cache for %s with %d symbols", exchangeID, len(symbols))
 	}
 
-	log.Printf("Symbol cache warming completed")
+	zaplogrus.Infof("Symbol cache warming completed")
 	return nil
 }

--- a/services/backend-api/internal/cache/symbol_cache.go
+++ b/services/backend-api/internal/cache/symbol_cache.go
@@ -1,12 +1,13 @@
 package cache
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/redis/go-redis/v9"
 )

--- a/services/backend-api/internal/ccxt/ccxt_native.go
+++ b/services/backend-api/internal/ccxt/ccxt_native.go
@@ -1,7 +1,6 @@
 package ccxt
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/config"
 	"github.com/irfndi/neuratrade/internal/models"

--- a/services/backend-api/internal/ccxt/ccxt_native.go
+++ b/services/backend-api/internal/ccxt/ccxt_native.go
@@ -1945,10 +1945,6 @@ func (s *NativeCCXTService) fetchBitgetBalance(ctx context.Context, conn *Exchan
 				freeUSDTFromCoinList += free
 				usedUSDTFromCoinList += frozen + locked
 			}
-
-			if total > 0 {
-				zaplogrus.Infof("[CCXT Native] Bitget balance: %s = %.8f (free: %.8f)", coin.Coin, total, free)
-			}
 		}
 
 		if accountSummaryUSDT > 0 && !accountHasCoinListUSDT {

--- a/services/backend-api/internal/ccxt/ccxt_native.go
+++ b/services/backend-api/internal/ccxt/ccxt_native.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"io"
 	"net/http"
 	"os"

--- a/services/backend-api/internal/ccxt/ccxt_native.go
+++ b/services/backend-api/internal/ccxt/ccxt_native.go
@@ -1,6 +1,7 @@
 package ccxt
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -9,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -33,7 +33,7 @@ func closeBody(body io.Closer) {
 		return
 	}
 	if err := body.Close(); err != nil {
-		log.Printf("[CCXT Native] failed to close response body: %v", err)
+		zaplogrus.Warnf("[CCXT Native] failed to close response body: %v", err)
 	}
 }
 
@@ -193,7 +193,7 @@ func NewNativeCCXTServiceWithConfig(timeout time.Duration, retryAttempts int, ex
 	for name, creds := range exchangeCreds {
 		baseURL, ok := s.getExchangeBaseURL(name)
 		if !ok {
-			log.Printf("[CCXT Native] Unknown exchange in config: %s", name)
+			zaplogrus.Infof("[CCXT Native] Unknown exchange in config: %s", name)
 			continue
 		}
 		s.exchanges[name] = &ExchangeConnection{
@@ -206,26 +206,26 @@ func NewNativeCCXTServiceWithConfig(timeout time.Duration, retryAttempts int, ex
 			LastUpdate: time.Now(),
 		}
 		s.credentials[name] = creds
-		log.Printf("[CCXT Native] Configured exchange: %s with API key", name)
+		zaplogrus.Infof("[CCXT Native] Configured exchange: %s with API key", name)
 	}
 	return s
 }
 
 // Initialize prepares the service for use
 func (s *NativeCCXTService) Initialize(ctx context.Context) error {
-	log.Println("[CCXT Native] Initializing native exchange connections")
+	zaplogrus.Info("[CCXT Native] Initializing native exchange connections")
 
 	// Initialize default exchanges
 	defaultExchanges := []string{"binance", "bybit", "okx", "bitget"}
 
 	for _, exchange := range defaultExchanges {
 		if err := s.initializeExchange(exchange); err != nil {
-			log.Printf("[CCXT Native] Failed to initialize %s: %v", exchange, err)
+			zaplogrus.Warnf("[CCXT Native] Failed to initialize %s: %v", exchange, err)
 			continue
 		}
 	}
 
-	log.Printf("[CCXT Native] Initialized %d exchanges", len(s.exchanges))
+	zaplogrus.Infof("[CCXT Native] Initialized %d exchanges", len(s.exchanges))
 	return nil
 }
 
@@ -255,9 +255,9 @@ func (s *NativeCCXTService) initializeExchange(exchangeID string) error {
 	s.exchanges[exchangeID] = connection
 
 	if connection.APIKey != "" && connection.Secret != "" {
-		log.Printf("[CCXT Native] Initialized exchange: %s (%s) with configured credentials", exchangeID, baseURL)
+		zaplogrus.Infof("[CCXT Native] Initialized exchange: %s (%s) with configured credentials", exchangeID, baseURL)
 	} else {
-		log.Printf("[CCXT Native] Initialized exchange: %s (%s) without API credentials", exchangeID, baseURL)
+		zaplogrus.Infof("[CCXT Native] Initialized exchange: %s (%s) without API credentials", exchangeID, baseURL)
 	}
 	return nil
 }
@@ -351,7 +351,7 @@ func (s *NativeCCXTService) Close() error {
 	defer s.mu.Unlock()
 
 	s.exchanges = make(map[string]*ExchangeConnection)
-	log.Println("[CCXT Native] Service closed")
+	zaplogrus.Info("[CCXT Native] Service closed")
 	return nil
 }
 
@@ -851,7 +851,7 @@ func (s *NativeCCXTService) processExchange(
 			*allTickers = append(*allTickers, bulkTickers...)
 			return nil
 		}
-		log.Printf("[CCXT Native] Failed bulk ticker fetch for bitget: %v", err)
+		zaplogrus.Warnf("[CCXT Native] Failed bulk ticker fetch for bitget: %v", err)
 	}
 
 	for _, symbol := range symbols {
@@ -865,7 +865,7 @@ func (s *NativeCCXTService) processExchange(
 		ticker, err := s.fetchSymbolWithTimeout(ctx, exchange, symbol, limits.perSymbolTimeout)
 		*fallbackFetches = *fallbackFetches + 1
 		if err != nil {
-			log.Printf("[CCXT Native] Failed to fetch %s:%s: %v", exchange, symbol, err)
+			zaplogrus.Warnf("[CCXT Native] Failed to fetch %s:%s: %v", exchange, symbol, err)
 			continue
 		}
 		*allTickers = append(*allTickers, ticker)
@@ -896,7 +896,7 @@ func (s *NativeCCXTService) checkFallbackLimits(
 ) error {
 	if limits.maxSymbols > 0 && fallbackFetches >= limits.maxSymbols {
 		reason := fmt.Sprintf("fallback ticker fetch budget reached (%d symbols)", limits.maxSymbols)
-		log.Printf("[CCXT Native] %s, returning partial market data", reason)
+		zaplogrus.Infof("[CCXT Native] %s, returning partial market data", reason)
 		return &PartialMarketDataError{
 			Data:   append([]MarketPriceInterface(nil), allTickers...),
 			Reason: reason,
@@ -904,7 +904,7 @@ func (s *NativeCCXTService) checkFallbackLimits(
 	}
 	if limits.cycleBudget > 0 && time.Since(limits.cycleStarted) >= limits.cycleBudget {
 		reason := fmt.Sprintf("fallback cycle budget exceeded (%s)", limits.cycleBudget)
-		log.Printf("[CCXT Native] %s, returning partial market data", reason)
+		zaplogrus.Infof("[CCXT Native] %s, returning partial market data", reason)
 		return &PartialMarketDataError{
 			Data:   append([]MarketPriceInterface(nil), allTickers...),
 			Reason: reason,
@@ -1804,7 +1804,7 @@ func (s *NativeCCXTService) FetchBalance(ctx context.Context, exchange string) (
 
 	// Check if API key is configured
 	if conn.APIKey == "" || conn.Secret == "" {
-		log.Printf("[CCXT Native] No API credentials for %s, returning empty balance", exchange)
+		zaplogrus.Infof("[CCXT Native] No API credentials for %s, returning empty balance", exchange)
 		return &BalanceResponse{
 			Exchange: exchange,
 			Total:    make(map[string]float64),
@@ -1946,7 +1946,7 @@ func (s *NativeCCXTService) fetchBitgetBalance(ctx context.Context, conn *Exchan
 			}
 
 			if total > 0 {
-				log.Printf("[CCXT Native] Bitget balance: %s = %.8f (free: %.8f)", coin.Coin, total, free)
+				zaplogrus.Infof("[CCXT Native] Bitget balance: %s = %.8f (free: %.8f)", coin.Coin, total, free)
 			}
 		}
 
@@ -1960,7 +1960,7 @@ func (s *NativeCCXTService) fetchBitgetBalance(ctx context.Context, conn *Exchan
 				freeUSDTFromSummary += accountSummaryUSDT
 				result.Free[key] += accountSummaryUSDT
 			}
-			log.Printf("[CCXT Native] Bitget balance account=%s usdt=%.8f", balanceData.AccountType, accountSummaryUSDT)
+			zaplogrus.Infof("[CCXT Native] Bitget balance account=%s usdt=%.8f", balanceData.AccountType, accountSummaryUSDT)
 		}
 	}
 	totalUSDT := totalUSDTFromCoinList + totalUSDTFromSummary
@@ -1975,7 +1975,7 @@ func (s *NativeCCXTService) fetchBitgetBalance(ctx context.Context, conn *Exchan
 		clearSummaryOnlyBalanceKey(result, "USDT")
 	}
 
-	log.Printf("[CCXT Native] Bitget balance fetched: %d assets", len(result.Total))
+	zaplogrus.Infof("[CCXT Native] Bitget balance fetched: %d assets", len(result.Total))
 	return result, nil
 }
 
@@ -2076,11 +2076,11 @@ func (s *NativeCCXTService) fetchBinanceBalance(ctx context.Context, conn *Excha
 			result.Total[balance.Asset] = total
 			result.Free[balance.Asset] = free
 			result.Used[balance.Asset] = locked
-			log.Printf("[CCXT Native] Binance balance: %s = %.8f", balance.Asset, total)
+			zaplogrus.Infof("[CCXT Native] Binance balance: %s = %.8f", balance.Asset, total)
 		}
 	}
 
-	log.Printf("[CCXT Native] Binance balance fetched: %d assets", len(result.Total))
+	zaplogrus.Infof("[CCXT Native] Binance balance fetched: %d assets", len(result.Total))
 	return result, nil
 }
 
@@ -2163,12 +2163,12 @@ func (s *NativeCCXTService) fetchBybitBalance(ctx context.Context, conn *Exchang
 				result.Total[coin.Coin] = balance
 				result.Free[coin.Coin] = available
 				result.Used[coin.Coin] = balance - available
-				log.Printf("[CCXT Native] Bybit balance: %s = %.8f", coin.Coin, balance)
+				zaplogrus.Infof("[CCXT Native] Bybit balance: %s = %.8f", coin.Coin, balance)
 			}
 		}
 	}
 
-	log.Printf("[CCXT Native] Bybit balance fetched: %d assets", len(result.Total))
+	zaplogrus.Infof("[CCXT Native] Bybit balance fetched: %d assets", len(result.Total))
 	return result, nil
 }
 
@@ -2251,12 +2251,12 @@ func (s *NativeCCXTService) fetchOKXBalance(ctx context.Context, conn *ExchangeC
 				result.Total[detail.Ccy] = balance
 				result.Free[detail.Ccy] = available
 				result.Used[detail.Ccy] = balance - available
-				log.Printf("[CCXT Native] OKX balance: %s = %.8f", detail.Ccy, balance)
+				zaplogrus.Infof("[CCXT Native] OKX balance: %s = %.8f", detail.Ccy, balance)
 			}
 		}
 	}
 
-	log.Printf("[CCXT Native] OKX balance fetched: %d assets", len(result.Total))
+	zaplogrus.Infof("[CCXT Native] OKX balance fetched: %d assets", len(result.Total))
 	return result, nil
 }
 
@@ -2575,7 +2575,7 @@ func (s *NativeCCXTService) parseBitgetFundingRate(body []byte) ([]FundingRate, 
 		rate, err := strconv.ParseFloat(strings.TrimSpace(item.FundingRate), 64)
 		if err != nil {
 			skipped++
-			log.Printf("[CCXT Native] skipping malformed bitget fundingRate row symbol=%s: %v", item.Symbol, err)
+			zaplogrus.Warnf("[CCXT Native] skipping malformed bitget fundingRate row symbol=%s: %v", item.Symbol, err)
 			continue
 		}
 
@@ -2601,7 +2601,7 @@ func (s *NativeCCXTService) parseBitgetFundingRate(body []byte) ([]FundingRate, 
 			parsed, err := strconv.ParseFloat(v, 64)
 			if err != nil {
 				skipped++
-				log.Printf("[CCXT Native] skipping malformed bitget markPrice row symbol=%s: %v", item.Symbol, err)
+				zaplogrus.Warnf("[CCXT Native] skipping malformed bitget markPrice row symbol=%s: %v", item.Symbol, err)
 				continue
 			}
 			markPrice = parsed
@@ -2612,7 +2612,7 @@ func (s *NativeCCXTService) parseBitgetFundingRate(body []byte) ([]FundingRate, 
 			parsed, err := strconv.ParseFloat(v, 64)
 			if err != nil {
 				skipped++
-				log.Printf("[CCXT Native] skipping malformed bitget indexPrice row symbol=%s: %v", item.Symbol, err)
+				zaplogrus.Warnf("[CCXT Native] skipping malformed bitget indexPrice row symbol=%s: %v", item.Symbol, err)
 				continue
 			}
 			indexPrice = parsed
@@ -2632,7 +2632,7 @@ func (s *NativeCCXTService) parseBitgetFundingRate(body []byte) ([]FundingRate, 
 		return nil, fmt.Errorf("no valid bitget funding rate rows in response")
 	}
 	if skipped > 0 {
-		log.Printf("[CCXT Native] parsed %d bitget funding rate rows, skipped %d malformed row(s)", len(rates), skipped)
+		zaplogrus.Warnf("[CCXT Native] parsed %d bitget funding rate rows, skipped %d malformed row(s)", len(rates), skipped)
 	}
 	return rates, nil
 }

--- a/services/backend-api/internal/ccxt/ccxt_native.go
+++ b/services/backend-api/internal/ccxt/ccxt_native.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"io"
 	"net/http"
 	"os"

--- a/services/backend-api/internal/ccxt/client.go
+++ b/services/backend-api/internal/ccxt/client.go
@@ -1,7 +1,6 @@
 package ccxt
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -14,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/services/backend-api/internal/ccxt/client.go
+++ b/services/backend-api/internal/ccxt/client.go
@@ -1,13 +1,13 @@
 package ccxt
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"net/http"
 	"net/url"
@@ -137,7 +137,7 @@ func NewClient(cfg *config.CCXTConfig) *Client {
 	}
 
 	// Log the actual service URL being used
-	log.Printf("CCXT Service URL from config: %s", cfg.ServiceURL)
+	zaplogrus.Infof("CCXT Service URL from config: %s", cfg.ServiceURL)
 
 	client := &Client{
 		HTTPClient: &http.Client{
@@ -158,16 +158,16 @@ func NewClient(cfg *config.CCXTConfig) *Client {
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		)
 		if err != nil {
-			log.Printf("Failed to create CCXT gRPC client at %s: %v (HTTP fallback available)", cfg.GrpcAddress, err)
+			zaplogrus.Warnf("Failed to create CCXT gRPC client at %s: %v (HTTP fallback available)", cfg.GrpcAddress, err)
 		} else {
 			client.grpcClient = pb.NewCcxtServiceClient(conn)
 			client.grpcConn = conn
 			client.grpcEnabled = true
-			log.Printf("Created CCXT gRPC client for %s (connection will be established on first use)", cfg.GrpcAddress)
+			zaplogrus.Infof("Created CCXT gRPC client for %s (connection will be established on first use)", cfg.GrpcAddress)
 		}
 	}
 
-	log.Printf("DEBUG: CCXT Client initialized with BaseURL: %s, gRPC: %v", client.BaseURL(), client.grpcEnabled)
+	zaplogrus.Infof("DEBUG: CCXT Client initialized with BaseURL: %s, gRPC: %v", client.BaseURL(), client.grpcEnabled)
 	return client
 }
 
@@ -180,14 +180,14 @@ func (c *Client) IsGRPCEnabled() bool {
 // This is useful when gRPC is consistently failing.
 func (c *Client) DisableGRPC() {
 	c.grpcEnabled = false
-	log.Printf("CCXT gRPC disabled, using HTTP-only mode")
+	zaplogrus.Warnf("CCXT gRPC disabled, using HTTP-only mode")
 }
 
 // EnableGRPC re-enables gRPC if the client was initialized with gRPC support.
 func (c *Client) EnableGRPC() {
 	if c.IsGRPCEnabled() {
 		c.grpcEnabled = true
-		log.Printf("CCXT gRPC re-enabled")
+		zaplogrus.Infof("CCXT gRPC re-enabled")
 	}
 }
 
@@ -219,9 +219,9 @@ func (c *Client) GetExchanges(ctx context.Context) (*ExchangesResponse, error) {
 			return c.convertGrpcExchangesResponse(resp), nil
 		}
 		if err != nil {
-			log.Printf("Failed to get exchanges via gRPC: %v, falling back to HTTP", err)
+			zaplogrus.Warnf("Failed to get exchanges via gRPC: %v, falling back to HTTP", err)
 		} else if resp.Error != "" {
-			log.Printf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
+			zaplogrus.Warnf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
 		}
 	}
 
@@ -242,9 +242,9 @@ func (c *Client) GetTicker(ctx context.Context, exchange, symbol string) (*Ticke
 			return c.convertGrpcTickerResponse(resp), nil
 		}
 		if err != nil {
-			log.Printf("Failed to get ticker via gRPC: %v, falling back to HTTP", err)
+			zaplogrus.Warnf("Failed to get ticker via gRPC: %v, falling back to HTTP", err)
 		} else if resp.Error != "" {
-			log.Printf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
+			zaplogrus.Warnf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
 		}
 	}
 
@@ -268,9 +268,9 @@ func (c *Client) GetTickers(ctx context.Context, req *TickersRequest) (*TickersR
 			return c.convertGrpcTickersResponse(resp), nil
 		}
 		if err != nil {
-			log.Printf("Failed to get tickers via gRPC: %v, falling back to HTTP", err)
+			zaplogrus.Warnf("Failed to get tickers via gRPC: %v, falling back to HTTP", err)
 		} else if resp.Error != "" {
-			log.Printf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
+			zaplogrus.Warnf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
 		}
 	}
 
@@ -306,9 +306,9 @@ func (c *Client) GetOrderBook(ctx context.Context, exchange, symbol string, limi
 			return c.convertGrpcOrderBookResponse(resp), nil
 		}
 		if err != nil {
-			log.Printf("Failed to get orderbook via gRPC: %v, falling back to HTTP", err)
+			zaplogrus.Warnf("Failed to get orderbook via gRPC: %v, falling back to HTTP", err)
 		} else if resp.Error != "" {
-			log.Printf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
+			zaplogrus.Warnf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
 		}
 	}
 
@@ -337,9 +337,9 @@ func (c *Client) GetTrades(ctx context.Context, exchange, symbol string, limit i
 			return c.convertGrpcTradesResponse(resp), nil
 		}
 		if err != nil {
-			log.Printf("Failed to get trades via gRPC: %v, falling back to HTTP", err)
+			zaplogrus.Warnf("Failed to get trades via gRPC: %v, falling back to HTTP", err)
 		} else if resp.Error != "" {
-			log.Printf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
+			zaplogrus.Warnf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
 		}
 	}
 
@@ -369,9 +369,9 @@ func (c *Client) GetOHLCV(ctx context.Context, exchange, symbol, timeframe strin
 			return c.convertGrpcOHLCVResponse(resp), nil
 		}
 		if err != nil {
-			log.Printf("Failed to get OHLCV via gRPC: %v, falling back to HTTP", err)
+			zaplogrus.Warnf("Failed to get OHLCV via gRPC: %v, falling back to HTTP", err)
 		} else if resp.Error != "" {
-			log.Printf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
+			zaplogrus.Warnf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
 		}
 	}
 
@@ -404,9 +404,9 @@ func (c *Client) GetMarkets(ctx context.Context, exchange string) (*MarketsRespo
 			return c.convertGrpcMarketsResponse(resp), nil
 		}
 		if err != nil {
-			log.Printf("Failed to get markets via gRPC: %v, falling back to HTTP", err)
+			zaplogrus.Warnf("Failed to get markets via gRPC: %v, falling back to HTTP", err)
 		} else if resp.Error != "" {
-			log.Printf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
+			zaplogrus.Warnf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
 		}
 	}
 
@@ -428,9 +428,9 @@ func (c *Client) GetFundingRate(ctx context.Context, exchange, symbol string) (*
 			return c.convertGrpcFundingRate(resp.Rates[0]), nil
 		}
 		if err != nil {
-			log.Printf("Failed to get funding rate via gRPC: %v, falling back to HTTP", err)
+			zaplogrus.Warnf("Failed to get funding rate via gRPC: %v, falling back to HTTP", err)
 		} else if resp.Error != "" {
-			log.Printf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
+			zaplogrus.Warnf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
 		}
 	}
 
@@ -457,9 +457,9 @@ func (c *Client) GetFundingRates(ctx context.Context, exchange string, symbols [
 			return rates, nil
 		}
 		if err != nil {
-			log.Printf("Failed to get funding rates via gRPC: %v, falling back to HTTP", err)
+			zaplogrus.Warnf("Failed to get funding rates via gRPC: %v, falling back to HTTP", err)
 		} else if resp.Error != "" {
-			log.Printf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
+			zaplogrus.Warnf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
 		}
 	}
 
@@ -500,9 +500,9 @@ func (c *Client) GetAllFundingRates(ctx context.Context, exchange string) ([]Fun
 			return rates, nil
 		}
 		if err != nil {
-			log.Printf("Failed to get all funding rates via gRPC: %v, falling back to HTTP", err)
+			zaplogrus.Warnf("Failed to get all funding rates via gRPC: %v, falling back to HTTP", err)
 		} else if resp.Error != "" {
-			log.Printf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
+			zaplogrus.Warnf("CCXT gRPC service returned error: %s, falling back to HTTP", resp.Error)
 		}
 	}
 
@@ -654,7 +654,7 @@ func (c *Client) makeRequest(ctx context.Context, method, path string, body inte
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Printf("Error closing response body: %v", err)
+			zaplogrus.Infof("Error closing response body: %v", err)
 		}
 	}()
 
@@ -807,7 +807,7 @@ func decimalFromString(s string) decimal.Decimal {
 	}
 	d, err := decimal.NewFromString(s)
 	if err != nil {
-		log.Printf("Warning: failed to parse decimal from string '%s': %v", s, err)
+		zaplogrus.Warnf("Warning: failed to parse decimal from string '%s': %v", s, err)
 		return decimal.Zero
 	}
 	return d
@@ -1001,7 +1001,7 @@ func float64FromString(s string) float64 {
 	}
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		log.Printf("Warning: failed to parse float64 from string '%s': %v", s, err)
+		zaplogrus.Warnf("Warning: failed to parse float64 from string '%s': %v", s, err)
 		return 0.0
 	}
 	return f

--- a/services/backend-api/internal/ccxt/client.go
+++ b/services/backend-api/internal/ccxt/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"io"
 	"math"
 	"net/http"

--- a/services/backend-api/internal/ccxt/client.go
+++ b/services/backend-api/internal/ccxt/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"io"
 	"math"
 	"net/http"

--- a/services/backend-api/internal/middleware/admin.go
+++ b/services/backend-api/internal/middleware/admin.go
@@ -6,13 +6,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 )
 
 // Package middleware provides HTTP middleware components for authentication,
@@ -28,7 +28,7 @@ func generateSecureKey(length int) string {
 	bytes := make([]byte, length/2)
 	if _, err := rand.Read(bytes); err != nil {
 		// Fallback to a less secure but functional key in edge cases
-		log.Printf("WARNING: Failed to generate secure random key: %v", err)
+		zaplogrus.WithError(err).Warn("Failed to generate secure random key")
 		hostname := os.Getenv("HOSTNAME")
 		if hostname == "" {
 			hostname = "unknown-host"
@@ -108,7 +108,7 @@ func NewAdminMiddleware() (*AdminMiddleware, error) {
 		}
 		// Generate temporary key for non-production environments
 		apiKey = generateSecureKey(32)
-		log.Println("INFO: Generated temporary admin key for non-production environment")
+		zaplogrus.Info("Generated temporary admin key for non-production environment")
 	}
 
 	// Prevent use of default/example keys in any environment
@@ -117,7 +117,7 @@ func NewAdminMiddleware() (*AdminMiddleware, error) {
 		if isProductionEnvironment() {
 			return nil, fmt.Errorf("ADMIN_API_KEY cannot use default/example values in production")
 		}
-		log.Printf("WARNING: Using example ADMIN_API_KEY in non-production environment")
+		zaplogrus.Warn("Using example ADMIN_API_KEY in non-production environment")
 	}
 
 	// Ensure minimum security requirements
@@ -126,7 +126,7 @@ func NewAdminMiddleware() (*AdminMiddleware, error) {
 			return nil, fmt.Errorf("ADMIN_API_KEY must be at least 32 characters long for security in production")
 		}
 		// Pad short keys in non-production
-		log.Printf("WARNING: ADMIN_API_KEY is shorter than 32 characters in non-production environment")
+		zaplogrus.Warn("ADMIN_API_KEY is shorter than 32 characters in non-production environment")
 	}
 
 	return &AdminMiddleware{
@@ -165,7 +165,7 @@ func (am *AdminMiddleware) RequireAdminAuth() gin.HandlerFunc {
 					return
 				}
 				// Log invalid Bearer token (without exposing actual keys)
-				log.Printf("WARN: Admin auth failed for %s - invalid Bearer token", requestPath)
+				zaplogrus.Warnf("Admin auth failed for %s - invalid Bearer token", requestPath)
 			}
 		}
 
@@ -179,9 +179,9 @@ func (am *AdminMiddleware) RequireAdminAuth() gin.HandlerFunc {
 
 		// Log authentication failure with helpful debugging info
 		if apiKeyHeader == "" {
-			log.Printf("WARN: Admin auth failed for %s - no X-API-Key header provided", requestPath)
+			zaplogrus.Warnf("Admin auth failed for %s - no X-API-Key header provided", requestPath)
 		} else {
-			log.Printf("WARN: Admin auth failed for %s - X-API-Key mismatch", requestPath)
+			zaplogrus.Warnf("Admin auth failed for %s - X-API-Key mismatch", requestPath)
 		}
 
 		// Query parameter authentication removed for security reasons

--- a/services/backend-api/internal/platform/actor/actor.go
+++ b/services/backend-api/internal/platform/actor/actor.go
@@ -9,13 +9,14 @@
 package actor
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 )
 
 // Errors

--- a/services/backend-api/internal/platform/actor/actor.go
+++ b/services/backend-api/internal/platform/actor/actor.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/services/backend-api/internal/platform/actor/actor.go
+++ b/services/backend-api/internal/platform/actor/actor.go
@@ -9,10 +9,10 @@
 package actor
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -370,7 +370,7 @@ func (r *Ref) Run(ctx context.Context) error {
 				if env.Message != nil {
 					msgType = env.Message.MessageType()
 				}
-				log.Printf("actor %s receive error (type=%s): %v", r.id, msgType, err)
+				zaplogrus.Infof("actor %s receive error (type=%s): %v", r.id, msgType, err)
 			}
 
 			// Stop when canceled or when actor reports an unrecoverable fatal error.

--- a/services/backend-api/internal/platform/actor/actor.go
+++ b/services/backend-api/internal/platform/actor/actor.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/services/backend-api/internal/services/ai/brain.go
+++ b/services/backend-api/internal/services/ai/brain.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"log"
 	"math/rand"
 	"os"

--- a/services/backend-api/internal/services/ai/brain.go
+++ b/services/backend-api/internal/services/ai/brain.go
@@ -1,7 +1,6 @@
 package ai
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +9,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/ai/llm"
 )

--- a/services/backend-api/internal/services/ai/brain.go
+++ b/services/backend-api/internal/services/ai/brain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"log"
 	"math/rand"
 	"os"

--- a/services/backend-api/internal/services/ai/brain.go
+++ b/services/backend-api/internal/services/ai/brain.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -272,7 +273,7 @@ func (brain *AITradingBrain) Reason(ctx context.Context, req *ReasoningRequest) 
 				ModelUsed:   brain.config.Model,
 				TokensUsed:  llmResp.Usage.TotalTokens,
 			}); err != nil {
-				log.Printf("Failed to record decision for learning: %v", err)
+				zaplogrus.Warnf("Failed to record decision for learning: %v", err)
 			}
 		}()
 	}

--- a/services/backend-api/internal/services/ai/learning_system.go
+++ b/services/backend-api/internal/services/ai/learning_system.go
@@ -1,10 +1,10 @@
 package ai
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +44,7 @@ type OptimalStrategy struct {
 func NewInMemoryLearningSystem() *InMemoryLearningSystem {
 	dataDir := resolveLearningDataDir()
 	if err := os.MkdirAll(dataDir, 0750); err != nil {
-		log.Printf("Failed to create AI learning data directory: %v", err)
+		zaplogrus.Warnf("Failed to create AI learning data directory: %v", err)
 	}
 
 	return &InMemoryLearningSystem{
@@ -64,7 +64,7 @@ func resolveLearningDataDir() string {
 	}
 	resolved, ok := sanitizeLearningDataDir(configured)
 	if !ok {
-		log.Printf("Ignoring unsafe AI learning data directory override: %q", configured)
+		zaplogrus.Infof("Ignoring unsafe AI learning data directory override: %q", configured)
 		return defaultDir
 	}
 	return resolved

--- a/services/backend-api/internal/services/ai/learning_system.go
+++ b/services/backend-api/internal/services/ai/learning_system.go
@@ -1,7 +1,6 @@
 package ai
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 )
 
 const learningDataDirEnv = "NEURATRADE_AI_LEARNING_DATA_DIR"

--- a/services/backend-api/internal/services/ai/learning_system.go
+++ b/services/backend-api/internal/services/ai/learning_system.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/services/backend-api/internal/services/ai/learning_system.go
+++ b/services/backend-api/internal/services/ai/learning_system.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/services/backend-api/internal/services/ai_fund_tracker.go
+++ b/services/backend-api/internal/services/ai_fund_tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/services/ai_fund_tracker.go
+++ b/services/backend-api/internal/services/ai_fund_tracker.go
@@ -1,10 +1,10 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -129,7 +129,7 @@ func (t *AIFundTracker) Start(ctx context.Context) error {
 	if t.config.EnableAI && t.llmClient != nil {
 		milestones, err := t.generateAIMilestones(ctx, snapshot.TotalValue)
 		if err != nil {
-			log.Printf("[AI-FUND] Failed to generate AI milestones, using defaults: %v", err)
+			zaplogrus.Warnf("[AI-FUND] Failed to generate AI milestones, using defaults: %v", err)
 			t.milestones = t.generateDefaultMilestones(snapshot.TotalValue)
 		} else {
 			t.milestones = milestones
@@ -141,7 +141,7 @@ func (t *AIFundTracker) Start(ctx context.Context) error {
 	t.wg.Add(1)
 	go t.runTrackingLoop()
 
-	log.Printf("[AI-FUND] Started tracking: start_value=%.2f, target=%.2f, milestones=%d",
+	zaplogrus.Infof("[AI-FUND] Started tracking: start_value=%.2f, target=%.2f, milestones=%d",
 		t.startValue, t.config.TargetValue, len(t.milestones))
 	return nil
 }
@@ -151,7 +151,7 @@ func (t *AIFundTracker) Stop() {
 		t.cancel()
 	}
 	t.wg.Wait()
-	log.Printf("[AI-FUND] Stopped")
+	zaplogrus.Infof("[AI-FUND] Stopped")
 }
 
 func (t *AIFundTracker) runTrackingLoop() {
@@ -166,7 +166,7 @@ func (t *AIFundTracker) runTrackingLoop() {
 			return
 		case <-ticker.C:
 			if err := t.updateFundValue(t.ctx); err != nil {
-				log.Printf("[AI-FUND] Update failed: %v", err)
+				zaplogrus.Warnf("[AI-FUND] Update failed: %v", err)
 			}
 		}
 	}
@@ -191,7 +191,7 @@ func (t *AIFundTracker) updateFundValue(ctx context.Context) error {
 		go t.analyzeProgress(ctx, snapshot)
 	}
 
-	log.Printf("[AI-FUND] Updated: value=%.2f, progress=%.1f%%",
+	zaplogrus.Infof("[AI-FUND] Updated: value=%.2f, progress=%.1f%%",
 		snapshot.TotalValue, (snapshot.TotalValue/t.config.TargetValue)*100)
 
 	return nil
@@ -227,7 +227,7 @@ func (t *AIFundTracker) checkMilestones(currentValue float64) {
 			now := time.Now()
 			t.milestones[i].Status = "achieved"
 			t.milestones[i].AchievedAt = &now
-			log.Printf("[AI-FUND] MILESTONE ACHIEVED: %s (%.2f)",
+			zaplogrus.Infof("[AI-FUND] MILESTONE ACHIEVED: %s (%.2f)",
 				t.milestones[i].Description, t.milestones[i].TargetValue)
 		}
 	}
@@ -353,11 +353,11 @@ func (t *AIFundTracker) analyzeProgress(ctx context.Context, snapshot *FundSnaps
 	t.mu.Unlock()
 
 	if performance.DailyReturn < -0.05 {
-		log.Printf("[AI-FUND] WARNING: Daily return %.2f%% below threshold", performance.DailyReturn*100)
+		zaplogrus.Warnf("[AI-FUND] WARNING: Daily return %.2f%% below threshold", performance.DailyReturn*100)
 	}
 
 	if performance.MaxDrawdown > 0.10 {
-		log.Printf("[AI-FUND] ALERT: Max drawdown %.2f%% exceeds 10%% threshold", performance.MaxDrawdown*100)
+		zaplogrus.Warnf("[AI-FUND] ALERT: Max drawdown %.2f%% exceeds 10%% threshold", performance.MaxDrawdown*100)
 	}
 }
 
@@ -446,7 +446,7 @@ func (t *AIFundTracker) AdjustTarget(ctx context.Context, newTarget float64, rea
 		t.milestones = t.generateDefaultMilestones(t.currentValue)
 	}
 
-	log.Printf("[AI-FUND] Target adjusted to %.2f (reason: %s)", newTarget, reason)
+	zaplogrus.Infof("[AI-FUND] Target adjusted to %.2f (reason: %s)", newTarget, reason)
 	return nil
 }
 

--- a/services/backend-api/internal/services/ai_fund_tracker.go
+++ b/services/backend-api/internal/services/ai_fund_tracker.go
@@ -1,12 +1,13 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/ai/llm"
 	"github.com/irfndi/neuratrade/internal/ccxt"

--- a/services/backend-api/internal/services/ai_fund_tracker.go
+++ b/services/backend-api/internal/services/ai_fund_tracker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/services/ai_memory.go
+++ b/services/backend-api/internal/services/ai_memory.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 	"time"
 

--- a/services/backend-api/internal/services/ai_memory.go
+++ b/services/backend-api/internal/services/ai_memory.go
@@ -1,11 +1,11 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -189,7 +189,7 @@ func (tm *TradeMemory) RecordDecision(ctx context.Context, record AITradeRecord)
 		return fmt.Errorf("failed to record trade decision: %w", err)
 	}
 
-	log.Printf("[AI-MEMORY] Recorded decision: %s %s on %s (confidence: %.2f)",
+	zaplogrus.Infof("[AI-MEMORY] Recorded decision: %s %s on %s (confidence: %.2f)",
 		record.Action, record.Symbol, record.Exchange, record.Confidence)
 	return nil
 }
@@ -211,7 +211,7 @@ func (tm *TradeMemory) UpdateOutcome(ctx context.Context, tradeID string, outcom
 		return fmt.Errorf("failed to update trade outcome: %w", err)
 	}
 
-	log.Printf("[AI-MEMORY] Updated trade %s: outcome=%s, pnl=%s", tradeID, outcome, pnl.String())
+	zaplogrus.Infof("[AI-MEMORY] Updated trade %s: outcome=%s, pnl=%s", tradeID, outcome, pnl.String())
 	return nil
 }
 
@@ -243,7 +243,7 @@ func (tm *TradeMemory) GetRecentTrades(ctx context.Context, limit int) ([]AITrad
 			&lessons, &entryPrice, &exitPrice,
 		)
 		if err != nil {
-			log.Printf("[AI-MEMORY] Scan error in GetRecentTrades: %v", err)
+			zaplogrus.Infof("[AI-MEMORY] Scan error in GetRecentTrades: %v", err)
 			continue
 		}
 
@@ -299,7 +299,7 @@ func (tm *TradeMemory) FindSimilarPatterns(ctx context.Context, symbol string, c
 			&lessons, &entryPrice, &exitPrice,
 		)
 		if err != nil {
-			log.Printf("[AI-MEMORY] Scan error in FindSimilarPatterns: %v", err)
+			zaplogrus.Infof("[AI-MEMORY] Scan error in FindSimilarPatterns: %v", err)
 			continue
 		}
 
@@ -858,7 +858,7 @@ func (tm *TradeMemory) RecordRecoveryPattern(ctx context.Context, pattern Recove
 	)
 
 	if err == nil {
-		log.Printf("[AI-MEMORY] Recorded recovery pattern: peak=%.2f%% recovered=%.2f%% duration=%.1fh",
+		zaplogrus.Infof("[AI-MEMORY] Recorded recovery pattern: peak=%.2f%% recovered=%.2f%% duration=%.1fh",
 			pattern.DrawdownPeak*100, pattern.DrawdownRecovered*100, pattern.RecoveryDuration.Hours())
 	}
 	return err
@@ -970,7 +970,7 @@ func (tm *TradeMemory) getLessonsByCategory(ctx context.Context, category string
 		}
 	}
 	if err := rows.Err(); err != nil {
-		log.Printf("[AI-MEMORY] failed iterating lessons for category %s: %v", category, err)
+		zaplogrus.Warnf("[AI-MEMORY] failed iterating lessons for category %s: %v", category, err)
 		return ""
 	}
 

--- a/services/backend-api/internal/services/ai_memory.go
+++ b/services/backend-api/internal/services/ai_memory.go
@@ -1,13 +1,14 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/shopspring/decimal"
 )

--- a/services/backend-api/internal/services/ai_memory.go
+++ b/services/backend-api/internal/services/ai_memory.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 	"time"
 

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 	"os"
 	"path/filepath"

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 	"os"
 	"path/filepath"

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -4131,7 +4131,7 @@ func (s *AIScalpingService) parseDecisionWithRetries(ctx context.Context, raw st
 		decision, parseErr := parseAIDecisionPayload(repaired)
 		if parseErr == nil && isValidDecisionAction(decision.Action) && validateRecoveredDecisionContract(decision) == nil {
 			applySLTPFromOriginal(decision, raw)
-			zaplogrus.Warnf("[AI-SCALPING] Structured-output retry succeeded on attempt %d", attempt)
+			zaplogrus.Infof("[AI-SCALPING] Structured-output retry succeeded on attempt %d", attempt)
 			return decision, nil
 		}
 		if inferred, inferErr := inferDecisionFromLooseText(repaired); inferErr == nil {

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"errors"
@@ -17,6 +16,8 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/ai/llm"
 	appautonomy "github.com/irfndi/neuratrade/internal/app/autonomy"

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -1,11 +1,11 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -419,7 +419,7 @@ func ResolveAIScalpingConfigFromEnv(base AIScalpingConfig) AIScalpingConfig {
 	}
 	cfg.DeterministicFallback = applyDeterministicFallbackConfigFromEnv(cfg.DeterministicFallback).Normalized()
 
-	log.Printf(
+	zaplogrus.Infof(
 		"[AI-SCALPING] Runtime config: exchange=%s model=%s leverage=%d max_tokens=%d max_capital_pct=%.2f min_confidence=%.2f timeout=%s auto_execute=%t allow_spot_fallback=%t max_pairs=%d max_candidates=%d max_bid_ask_spread=%.4f orderbook_pairs=%d auto_expand_orderbooks=%t auto_expand_threshold=%d enforce_futures=%t symbol_cooldown=%s failure_budget=%d failure_window=%s structured_retries=%d loss_streak_budget=%d loss_cooldown=%s loss_window=%s pretrade_gate=%t min_expectancy_edge=%.4f min_expectancy_samples=%d regime_low=%.1f regime_high=%.1f fallback_max_spread=%.4f fallback_min_imbalance=%.2f fallback_floor=%.2f fallback_size_fraction=%.2f",
 		cfg.Exchange,
 		cfg.Model,
@@ -584,7 +584,7 @@ func applyAIScalpingConfigFromFile(base AIScalpingConfig) AIScalpingConfig {
 
 	var fileConfig aiScalpingFileConfig
 	if err := json.Unmarshal(content, &fileConfig); err != nil {
-		log.Printf("[AI-SCALPING] Failed to parse %s: %v", configPath, err)
+		zaplogrus.Warnf("[AI-SCALPING] Failed to parse %s: %v", configPath, err)
 		return cfg
 	}
 
@@ -858,7 +858,7 @@ func (s *AIScalpingService) SetExchange(exchange string) {
 	s.exchangeMu.Lock()
 	defer s.exchangeMu.Unlock()
 	s.config.Exchange = exchange
-	log.Printf("[AI-SCALPING] Exchange set to: %s", exchange)
+	zaplogrus.Infof("[AI-SCALPING] Exchange set to: %s", exchange)
 }
 
 func (s *AIScalpingService) configuredExchange() string {
@@ -1162,7 +1162,7 @@ func (s *AIScalpingService) getLatestFailoverAttemptInfo() llm.FailoverAttemptIn
 }
 
 func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio TradingPortfolio) (decision *AITradingDecision, err error) {
-	log.Printf("[AI-SCALPING] Starting trading cycle for portfolio: %.2f USDT", walletBasis(portfolio).InexactFloat64())
+	zaplogrus.Infof("[AI-SCALPING] Starting trading cycle for portfolio: %.2f USDT", walletBasis(portfolio).InexactFloat64())
 
 	// Periodic self-learning feedback, once per completed trade-count milestone.
 	if perf := GetScalpingPerformance().GetPerformance(); s.shouldApplyPerformanceFeedback(readIntMetric(perf["total_trades"])) {
@@ -1201,7 +1201,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 	}()
 	if !walletBasis(portfolio).GreaterThan(decimal.Zero) {
 		reason := "wallet basis is zero; waiting for funded balance before autonomous execution"
-		log.Printf("[AI-SCALPING] %s", reason)
+		zaplogrus.Infof("[AI-SCALPING] %s", reason)
 		decision = strategyHoldDecision(reason, 0)
 		decision.ExecutionGate = &appautonomy.ExecutionGateSnapshot{
 			Allowed:     false,
@@ -1218,7 +1218,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 			notional.StringFixed(2),
 			effectiveExchange,
 		)
-		log.Printf("[AI-SCALPING] %s", reason)
+		zaplogrus.Infof("[AI-SCALPING] %s", reason)
 		decision = strategyHoldDecision(reason, 0)
 		decision.ExecutionGate = &appautonomy.ExecutionGateSnapshot{
 			Allowed:     false,
@@ -1230,15 +1230,15 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 
 	signals, err := s.gatherMarketSignals(ctx)
 	if err != nil {
-		log.Printf("[AI-SCALPING] Failed to gather signals: %v", err)
+		zaplogrus.Warnf("[AI-SCALPING] Failed to gather signals: %v", err)
 		return nil, fmt.Errorf("failed to gather market signals: %w", err)
 	}
-	log.Printf("[AI-SCALPING] Gathered %d market signals", len(signals))
+	zaplogrus.Infof("[AI-SCALPING] Gathered %d market signals", len(signals))
 	funnel = appautonomy.BuildCandidateFunnel(candidateSignalsFromMarketSignals(signals), policy)
 
 	decision, err = s.getAIDecision(ctx, signals, portfolio)
 	if err != nil {
-		log.Printf("[AI-SCALPING] Failed to get AI decision: %v", err)
+		zaplogrus.Warnf("[AI-SCALPING] Failed to get AI decision: %v", err)
 		return fallbackHoldDecision(err.Error(), err), nil
 	}
 
@@ -1264,10 +1264,10 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 			decision.ConfidenceKnown = true
 		}
 	}
-	log.Printf("[AI-SCALPING] AI decision: %s %s (confidence: %.2f)", decision.Action, decision.Symbol, decision.Confidence)
+	zaplogrus.Infof("[AI-SCALPING] AI decision: %s %s (confidence: %.2f)", decision.Action, decision.Symbol, decision.Confidence)
 	annotateDecisionSignalTelemetry(decision, signals)
 	if shouldPromoteGenericHoldToFallback(decision, funnel) {
-		log.Printf("[AI-SCALPING] Promoting generic hold into deterministic fallback because %d viable candidate(s) remain", funnel.CandidateViableCount)
+		zaplogrus.Warnf("[AI-SCALPING] Promoting generic hold into deterministic fallback because %d viable candidate(s) remain", funnel.CandidateViableCount)
 		s.recordMetaHoldPromotion()
 		decision = s.deterministicFallbackDecision(ctx, signals, portfolio)
 		annotateDecisionSignalTelemetry(decision, signals)
@@ -1313,7 +1313,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 		decision.Reasoning = gate.Reason
 		decision.ReasonCategory = reasonCategoryStrategyHold
 		decision.ConfidenceKnown = true
-		log.Printf(
+		zaplogrus.Infof(
 			"[AI-SCALPING] Pre-trade gate blocked %s %s (regime=%s expectancy=%.4f sample=%d): %s",
 			attemptedAction,
 			decision.Symbol,
@@ -1341,7 +1341,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 	decision.PreTradeRegime = gate.Regime
 	decision.PreTradeExpectancy = gate.NetExpectancy
 	decision.PreTradeExpectancySampleSize = gate.SampleSize
-	log.Printf(
+	zaplogrus.Infof(
 		"[AI-SCALPING] Dynamic thresholds: min_confidence=%.2f max_capital_pct=%.2f regime=%s expectancy=%.4f expectancy_n=%d phase=%s risk_drawdown=%.4f",
 		effectiveMinConfidence,
 		effectiveMaxCapital,
@@ -1364,7 +1364,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 		} else {
 			decision.ConfidenceKnown = true
 		}
-		log.Printf("[AI-SCALPING] AI decided to hold: %s", decision.Reasoning)
+		zaplogrus.Infof("[AI-SCALPING] AI decided to hold: %s", decision.Reasoning)
 		return decision, nil
 	}
 
@@ -1394,7 +1394,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 			decision.PolicyAdjustments = append(decision.PolicyAdjustments, "micro_confidence_grace")
 		} else {
 			sourceDecision := decision
-			log.Printf("[AI-SCALPING] Confidence %.2f below minimum %.2f, skipping", decision.Confidence, effectiveMinConfidence)
+			zaplogrus.Warnf("[AI-SCALPING] Confidence %.2f below minimum %.2f, skipping", decision.Confidence, effectiveMinConfidence)
 			decision = strategyHoldDecision(
 				fmt.Sprintf("confidence %.2f below dynamic threshold %.2f", decision.Confidence, effectiveMinConfidence),
 				decision.Confidence,
@@ -1436,7 +1436,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 			)
 			s.updateAutonomyGateState(scope, rolloutState, gateState, gateErr)
 			if gateErr != nil {
-				log.Printf("[AI-SCALPING] Autonomous gate evaluation failed: %v", gateErr)
+				zaplogrus.Warnf("[AI-SCALPING] Autonomous gate evaluation failed: %v", gateErr)
 				reason := fmt.Sprintf("autonomy gate evaluation failed: %v", gateErr)
 				sourceDecision := decision
 				decision = runtimeDegradedHoldDecision(reason, reasonCategoryExecutionUnavailable)
@@ -1452,13 +1452,13 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 				return decision, nil
 			}
 			if shouldAllowPaperModeAutonomyExecution(ctx, rolloutState, gateState) {
-				log.Printf("[AI-SCALPING] Paper mode permits simulated execution for %s while rollout stage is paper", scope.StrategyID)
+				zaplogrus.Infof("[AI-SCALPING] Paper mode permits simulated execution for %s while rollout stage is paper", scope.StrategyID)
 			} else if gateState != nil && !gateState.IsOpen {
 				reason := strings.Join(gateState.BlockReasons, "; ")
 				if strings.TrimSpace(reason) == "" {
 					reason = "autonomy live gate closed"
 				}
-				log.Printf("[AI-SCALPING] Autonomous live gate blocked execution for %s: %s", scope.StrategyID, reason)
+				zaplogrus.Infof("[AI-SCALPING] Autonomous live gate blocked execution for %s: %s", scope.StrategyID, reason)
 				sourceDecision := decision
 				decision = strategyHoldDecision(
 					fmt.Sprintf("autonomy live gate closed: %s", reason),
@@ -1477,7 +1477,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 			}
 		}
 		if autonomyCoordinator != nil && !strategyResolved {
-			log.Printf(
+			zaplogrus.Infof(
 				"[AI-SCALPING] Skipping autonomy gate: unresolved strategy_id (chat_id=%q)",
 				strings.TrimSpace(scope.ChatID),
 			)
@@ -1486,13 +1486,13 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 		executionErr := s.executeDecision(ctx, decision, portfolio, effectiveMaxCapital)
 		if autonomyCoordinator != nil && strategyResolved {
 			if recordErr := autonomyCoordinator.RecordExecutionResult(ctx, scope, decision, portfolio, executionErr); recordErr != nil {
-				log.Printf("[AI-SCALPING] Failed to record autonomy rollout metrics: %v", recordErr)
+				zaplogrus.Warnf("[AI-SCALPING] Failed to record autonomy rollout metrics: %v", recordErr)
 			} else if rollback := autonomyCoordinator.LastRollback(scope.StrategyID); rollback != nil {
 				s.updateAutonomyRollbackState(rollback)
 			}
 		}
 		if autonomyCoordinator != nil && !strategyResolved {
-			log.Printf(
+			zaplogrus.Infof(
 				"[AI-SCALPING] Skipping autonomy metrics update: unresolved strategy_id (chat_id=%q)",
 				strings.TrimSpace(scope.ChatID),
 			)
@@ -1516,7 +1516,7 @@ func (s *AIScalpingService) ExecuteTradingCycle(ctx context.Context, portfolio T
 					BlockReason: decision.Reasoning,
 					BlockCode:   blockCode,
 				}
-				log.Printf("[AI-SCALPING] Downgrading execution issue to HOLD: %v", executionErr)
+				zaplogrus.Infof("[AI-SCALPING] Downgrading execution issue to HOLD: %v", executionErr)
 				return decision, nil
 			}
 			return decision, fmt.Errorf("execution failed: %w", executionErr)
@@ -1553,7 +1553,7 @@ func (s *AIScalpingService) discoverTradingPairs(ctx context.Context) ([]string,
 	markets, err := s.ccxtService.FetchMarkets(ctx, exchange)
 	if err != nil {
 		if cached := s.getAnyCachedPairs(exchange); len(cached) > 0 {
-			log.Printf("[AI-SCALPING] Market discovery failed on %s (%v); reusing stale pair cache (%d symbols)", exchange, err, len(cached))
+			zaplogrus.Warnf("[AI-SCALPING] Market discovery failed on %s (%v); reusing stale pair cache (%d symbols)", exchange, err, len(cached))
 			return cached, nil
 		}
 		return nil, fmt.Errorf("failed to fetch markets: %w", err)
@@ -1607,7 +1607,7 @@ func (s *AIScalpingService) discoverTradingPairs(ctx context.Context) ([]string,
 		var partialErr *ccxt.PartialMarketDataError
 		if errors.As(err, &partialErr) && len(partialErr.Data) > 0 {
 			scored = partialErr.Data
-			log.Printf("[AI-SCALPING] Dynamic pair scoring using partial market data: %v", err)
+			zaplogrus.Infof("[AI-SCALPING] Dynamic pair scoring using partial market data: %v", err)
 		}
 	}
 	if len(scored) == 0 {
@@ -1615,7 +1615,7 @@ func (s *AIScalpingService) discoverTradingPairs(ctx context.Context) ([]string,
 		if limit > len(candidates) {
 			limit = len(candidates)
 		}
-		log.Printf("[AI-SCALPING] Dynamic pair scoring unavailable (%v), using discovered subset", err)
+		zaplogrus.Warnf("[AI-SCALPING] Dynamic pair scoring unavailable (%v), using discovered subset", err)
 		selected := candidates[:limit]
 		s.updatePairCache(exchange, selected)
 		return selected, nil
@@ -1687,7 +1687,7 @@ func (s *AIScalpingService) discoverTradingPairs(ctx context.Context) ([]string,
 			tradableCount++
 		}
 	}
-	log.Printf("[AI-SCALPING] Dynamically selected %d/%d pairs for AI analysis on %s (tradable_spread=%d)", len(selected), len(candidates), exchange, tradableCount)
+	zaplogrus.Infof("[AI-SCALPING] Dynamically selected %d/%d pairs for AI analysis on %s (tradable_spread=%d)", len(selected), len(candidates), exchange, tradableCount)
 	s.updatePairCache(exchange, selected)
 	return selected, nil
 }
@@ -1743,7 +1743,7 @@ func (s *AIScalpingService) filterFuturesSymbols(ctx context.Context, exchange s
 	rates, err := s.ccxtService.FetchAllFundingRates(ctx, exchange)
 	if err != nil || len(rates) == 0 {
 		if err != nil {
-			log.Printf("[AI-SCALPING] Futures universe unavailable on %s: %v", exchange, err)
+			zaplogrus.Warnf("[AI-SCALPING] Futures universe unavailable on %s: %v", exchange, err)
 		}
 		return nil
 	}
@@ -1774,11 +1774,11 @@ func (s *AIScalpingService) filterFuturesSymbols(ctx context.Context, exchange s
 	}
 
 	if len(filtered) == 0 {
-		log.Printf("[AI-SCALPING] Futures universe filter returned no overlap on %s; using discovered pairs", exchange)
+		zaplogrus.Infof("[AI-SCALPING] Futures universe filter returned no overlap on %s; using discovered pairs", exchange)
 		return nil
 	}
 
-	log.Printf("[AI-SCALPING] Futures universe filtered %d -> %d symbols on %s", len(symbols), len(filtered), exchange)
+	zaplogrus.Infof("[AI-SCALPING] Futures universe filtered %d -> %d symbols on %s", len(symbols), len(filtered), exchange)
 	return filtered
 }
 
@@ -1788,7 +1788,7 @@ func (s *AIScalpingService) gatherMarketSignals(ctx context.Context) ([]aiMarket
 
 	pairs, err := s.discoverTradingPairs(ctx)
 	if err != nil {
-		log.Printf("[AI-SCALPING] Failed dynamic pair discovery: %v", err)
+		zaplogrus.Warnf("[AI-SCALPING] Failed dynamic pair discovery: %v", err)
 		return nil, fmt.Errorf("dynamic pair discovery unavailable: %w", err)
 	}
 	if len(pairs) == 0 {
@@ -1802,7 +1802,7 @@ func (s *AIScalpingService) gatherMarketSignals(ctx context.Context) ([]aiMarket
 		var partialErr *ccxt.PartialMarketDataError
 		if errors.As(bulkErr, &partialErr) && len(partialErr.Data) > 0 {
 			marketData = partialErr.Data
-			log.Printf("[AI-SCALPING] Bulk ticker fetch returned partial data: %v", bulkErr)
+			zaplogrus.Infof("[AI-SCALPING] Bulk ticker fetch returned partial data: %v", bulkErr)
 		}
 	}
 	if bulkErr == nil || len(marketData) > 0 {
@@ -1818,19 +1818,19 @@ func (s *AIScalpingService) gatherMarketSignals(ctx context.Context) ([]aiMarket
 		}
 	}
 	if bulkErr != nil && len(marketData) == 0 {
-		log.Printf("[AI-SCALPING] Bulk ticker fetch unavailable: %v", bulkErr)
+		zaplogrus.Warnf("[AI-SCALPING] Bulk ticker fetch unavailable: %v", bulkErr)
 	}
 
 	orderBookPairs := s.effectiveOrderBookPairs(len(pairs))
 
-	log.Printf("[AI-SCALPING] Analyzing %d pairs on %s", len(pairs), exchange)
+	zaplogrus.Infof("[AI-SCALPING] Analyzing %d pairs on %s", len(pairs), exchange)
 	for idx, symbol := range pairs {
 		normalizedSymbol := normalizeSymbolForComparison(symbol)
 		tickerData, ok := tickerBySymbol[normalizedSymbol]
 		if !ok {
 			tickerData, err = s.ccxtService.FetchSingleTicker(ctx, exchange, symbol)
 			if err != nil {
-				log.Printf("[AI-SCALPING] Failed to fetch ticker for %s: %v", symbol, err)
+				zaplogrus.Warnf("[AI-SCALPING] Failed to fetch ticker for %s: %v", symbol, err)
 				continue
 			}
 		}
@@ -1839,7 +1839,7 @@ func (s *AIScalpingService) gatherMarketSignals(ctx context.Context) ([]aiMarket
 		if idx < orderBookPairs {
 			obResp, err = s.ccxtService.FetchOrderBook(ctx, exchange, symbol, 20)
 			if err != nil {
-				log.Printf("[AI-SCALPING] Failed to fetch orderbook for %s: %v", symbol, err)
+				zaplogrus.Warnf("[AI-SCALPING] Failed to fetch orderbook for %s: %v", symbol, err)
 			}
 		}
 
@@ -1937,9 +1937,9 @@ func (s *AIScalpingService) getAIDecision(ctx context.Context, signals []aiMarke
 	systemPrompt := s.buildSystemPrompt()
 	userPrompt := s.buildUserPrompt(ctx, signals, portfolio)
 
-	log.Printf("[AI-SCALPING] Calling LLM with %d signals", len(signals))
-	log.Printf("[AI-SCALPING] === SYSTEM PROMPT ===\n%s", systemPrompt)
-	log.Printf("[AI-SCALPING] === USER PROMPT ===\nPortfolio: %.2f USDT, Signals: %d", walletBasis(portfolio).InexactFloat64(), len(signals))
+	zaplogrus.Infof("[AI-SCALPING] Calling LLM with %d signals", len(signals))
+	zaplogrus.Infof("[AI-SCALPING] === SYSTEM PROMPT ===\n%s", systemPrompt)
+	zaplogrus.Infof("[AI-SCALPING] === USER PROMPT ===\nPortfolio: %.2f USDT, Signals: %d", walletBasis(portfolio).InexactFloat64(), len(signals))
 
 	req := &llm.CompletionRequest{
 		Model: strings.TrimSpace(s.config.Model),
@@ -1958,7 +1958,7 @@ func (s *AIScalpingService) getAIDecision(ctx context.Context, signals []aiMarke
 		req.MaxTokens = 1200
 	}
 
-	log.Printf("[AI-SCALPING] Sending LLM request...")
+	zaplogrus.Infof("[AI-SCALPING] Sending LLM request...")
 
 	inferenceCtx, cancelInference := s.withInferenceBudget(ctx)
 	defer cancelInference()
@@ -1972,18 +1972,18 @@ func (s *AIScalpingService) getAIDecision(ctx context.Context, signals []aiMarke
 			"",
 			s.getLatestFailoverAttemptInfo(),
 		)
-		log.Printf("[AI-SCALPING] LLM completion failed: %v", err)
+		zaplogrus.Warnf("[AI-SCALPING] LLM completion failed: %v", err)
 		return s.deterministicFallbackDecision(ctx, signals, portfolio), nil
 	}
 
-	log.Printf("[AI-SCALPING] === LLM RESPONSE ===\nLatency: %dms\nRaw: %s", resp.LatencyMs, resp.Message.Content)
+	zaplogrus.Infof("[AI-SCALPING] === LLM RESPONSE ===\nLatency: %dms\nRaw: %s", resp.LatencyMs, resp.Message.Content)
 
 	decision, parseErr := parseAIDecisionPayload(resp.Message.Content)
 	if parseErr != nil || !isValidDecisionAction(decision.Action) {
-		log.Printf("[AI-SCALPING] Failed to parse AI response: %s", resp.Message.Content)
+		zaplogrus.Warnf("[AI-SCALPING] Failed to parse AI response: %s", resp.Message.Content)
 		decision, err = s.parseDecisionWithRetries(ctx, resp.Message.Content)
 		if err != nil {
-			log.Printf("[AI-SCALPING] Structured-output retries exhausted: %v", err)
+			zaplogrus.Infof("[AI-SCALPING] Structured-output retries exhausted: %v", err)
 			reasonCategory := classifyReasonCategory(err, resp.Message.Content)
 			if isDecisionContractErrorText(err) {
 				reasonCategory = reasonCategoryLLMParseContract
@@ -2032,7 +2032,7 @@ func (s *AIScalpingService) getAIDecision(ctx context.Context, signals []aiMarke
 	if decision.TakeProfit != nil {
 		takeProfitFloat = decision.TakeProfit.InexactFloat64()
 	}
-	log.Printf("[AI-SCALPING] === AI DECISION PARSED ===\nAction: %s, Symbol: %s, Confidence: %.0f%%, Size: %.1f%%, SL: %.4f, TP: %.4f\nReasoning: %s",
+	zaplogrus.Infof("[AI-SCALPING] === AI DECISION PARSED ===\nAction: %s, Symbol: %s, Confidence: %.0f%%, Size: %.1f%%, SL: %.4f, TP: %.4f\nReasoning: %s",
 		decision.Action, decision.Symbol, decision.Confidence*100, decision.SizePercent,
 		stopLossFloat, takeProfitFloat, decision.Reasoning)
 
@@ -2227,7 +2227,7 @@ func (s *AIScalpingService) executeDecision(ctx context.Context, decision *AITra
 	}
 	if portfolio.MinExecutableSizePct > 0 && decision.SizePercent < portfolio.MinExecutableSizePct {
 		if minNotional := decimalValueOrZero(portfolio.MinExecutableNotionalUSDT); minNotional.GreaterThan(decimal.Zero) {
-			log.Printf(
+			zaplogrus.Infof(
 				"[AI-SCALPING] Requested size %.2f%% below executable floor %.2f%% on %s, bumping to exchange minimum %s USDT",
 				decision.SizePercent,
 				portfolio.MinExecutableSizePct,
@@ -2235,7 +2235,7 @@ func (s *AIScalpingService) executeDecision(ctx context.Context, decision *AITra
 				minNotional.StringFixed(2),
 			)
 		} else {
-			log.Printf(
+			zaplogrus.Infof(
 				"[AI-SCALPING] Requested size %.2f%% below executable floor %.2f%% on %s, bumping to executable floor",
 				decision.SizePercent,
 				portfolio.MinExecutableSizePct,
@@ -2262,12 +2262,12 @@ func (s *AIScalpingService) executeDecision(ctx context.Context, decision *AITra
 
 	openOrders, err := s.orderExecutor.GetOpenOrders(ctx, exchange, decision.Symbol)
 	if err != nil {
-		log.Printf("[AI-SCALPING] Open-order check skipped for %s: %v", decision.Symbol, err)
+		zaplogrus.Warnf("[AI-SCALPING] Open-order check skipped for %s: %v", decision.Symbol, err)
 	} else if len(openOrders) > 0 {
 		return fmt.Errorf("open position/order already exists for %s (%d open orders)", decision.Symbol, len(openOrders))
 	}
 
-	log.Printf("[AI-SCALPING] Executing: %s %s (%s USDT)", decision.Action, decision.Symbol, amount.StringFixed(2))
+	zaplogrus.Infof("[AI-SCALPING] Executing: %s %s (%s USDT)", decision.Action, decision.Symbol, amount.StringFixed(2))
 
 	// Build detailed trade info for rich notification
 	details := TradeDetails{
@@ -2298,7 +2298,7 @@ func (s *AIScalpingService) executeDecision(ctx context.Context, decision *AITra
 
 	decision.OrderID = strings.TrimSpace(orderID)
 	s.recordSymbolGuardResult(decision.Symbol, nil)
-	log.Printf("[AI-SCALPING] Order placed: %s", orderID)
+	zaplogrus.Infof("[AI-SCALPING] Order placed: %s", orderID)
 	return nil
 }
 
@@ -2485,7 +2485,7 @@ func (s *AIScalpingService) estimateNetExpectancy(ctx context.Context, symbol, a
 			0,
 			0,
 		); err != nil {
-			log.Printf(
+			zaplogrus.Infof(
 				"[AI-SCALPING] scoped expectancy unavailable for %s/%s: %v",
 				normalizedSymbol,
 				normalizedAction,
@@ -2643,7 +2643,7 @@ func (s *AIScalpingService) validateDecision(decision *AITradingDecision, signal
 		if decision.TakeProfit == nil {
 			decision.TakeProfit = &defaultTP
 		}
-		log.Printf("[AI-SCALPING] Applied default SL/TP for %s %s due to incomplete model output", decision.Action, decision.Symbol)
+		zaplogrus.Infof("[AI-SCALPING] Applied default SL/TP for %s %s due to incomplete model output", decision.Action, decision.Symbol)
 	}
 	if decision.StopLoss.LessThanOrEqual(decimal.Zero) || decision.TakeProfit.LessThanOrEqual(decimal.Zero) {
 		return fmt.Errorf("stop_loss and take_profit must be positive")
@@ -2672,7 +2672,7 @@ func (s *AIScalpingService) validateDecision(decision *AITradingDecision, signal
 		if reward/risk < minRiskRewardRatio {
 			adjustedTakeProfit := decimal.NewFromFloat(resolved.Price + risk*minRiskRewardRatio)
 			decision.TakeProfit = &adjustedTakeProfit
-			log.Printf("[AI-SCALPING] Adjusted buy TP for %s to enforce minimum risk/reward %.2f", decision.Symbol, minRiskRewardRatio)
+			zaplogrus.Infof("[AI-SCALPING] Adjusted buy TP for %s to enforce minimum risk/reward %.2f", decision.Symbol, minRiskRewardRatio)
 		}
 	case "sell":
 		if stopLoss <= resolved.Price || takeProfit >= resolved.Price {
@@ -2689,7 +2689,7 @@ func (s *AIScalpingService) validateDecision(decision *AITradingDecision, signal
 		if reward/risk < minRiskRewardRatio {
 			adjustedTakeProfit := decimal.NewFromFloat(resolved.Price - risk*minRiskRewardRatio)
 			decision.TakeProfit = &adjustedTakeProfit
-			log.Printf("[AI-SCALPING] Adjusted sell TP for %s to enforce minimum risk/reward %.2f", decision.Symbol, minRiskRewardRatio)
+			zaplogrus.Infof("[AI-SCALPING] Adjusted sell TP for %s to enforce minimum risk/reward %.2f", decision.Symbol, minRiskRewardRatio)
 		}
 	}
 	return nil
@@ -3173,7 +3173,7 @@ func (s *AIScalpingService) mirrorShadowDecisionAsync(
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		if _, err := coordinator.MirrorDecision(ctx, decisionSnapshot, portfolioSnapshot, policySnapshot); err != nil {
-			log.Printf("[AI-SCALPING] Shadow mirror decision failed: %v", err)
+			zaplogrus.Warnf("[AI-SCALPING] Shadow mirror decision failed: %v", err)
 		}
 	}()
 }
@@ -3271,7 +3271,7 @@ func (s *AIScalpingService) deterministicFallbackDecision(ctx context.Context, s
 	}
 
 	if bestDecision != nil {
-		log.Printf(
+		zaplogrus.Infof(
 			"[AI-SCALPING] Deterministic fallback selected %s %s (confidence=%.2f score=%.2f)",
 			bestDecision.Action,
 			bestDecision.Symbol,
@@ -3292,7 +3292,7 @@ func (s *AIScalpingService) deterministicFallbackDecision(ctx context.Context, s
 		}
 	}
 	if bestDecision != nil {
-		log.Printf(
+		zaplogrus.Infof(
 			"[AI-SCALPING] Relaxed deterministic fallback selected %s %s (confidence=%.2f score=%.2f)",
 			bestDecision.Action,
 			bestDecision.Symbol,
@@ -4072,7 +4072,7 @@ Do not include markdown or extra text.`
 	if content == "" {
 		return "", fmt.Errorf("empty repair response")
 	}
-	log.Printf("[AI-SCALPING] Repaired non-JSON decision payload")
+	zaplogrus.Infof("[AI-SCALPING] Repaired non-JSON decision payload")
 	return content, nil
 }
 
@@ -4098,14 +4098,14 @@ func (s *AIScalpingService) parseDecisionWithRetries(ctx context.Context, raw st
 		localDecision, parseErr := parseAIDecisionPayload(repairedLocal)
 		if parseErr == nil && isValidDecisionAction(localDecision.Action) && validateRecoveredDecisionContract(localDecision) == nil {
 			applySLTPFromOriginal(localDecision, raw)
-			log.Printf("[AI-SCALPING] Structured-output recovered via deterministic local repair")
+			zaplogrus.Infof("[AI-SCALPING] Structured-output recovered via deterministic local repair")
 			return localDecision, nil
 		}
 	}
 	if inferred, inferErr := inferDecisionFromLooseText(raw); inferErr == nil {
 		if contractErr := validateRecoveredDecisionContract(inferred); contractErr == nil {
 			applySLTPFromOriginal(inferred, raw)
-			log.Printf("[AI-SCALPING] Structured-output recovered via local decision inference")
+			zaplogrus.Infof("[AI-SCALPING] Structured-output recovered via local decision inference")
 			return inferred, nil
 		}
 	}
@@ -4130,13 +4130,13 @@ func (s *AIScalpingService) parseDecisionWithRetries(ctx context.Context, raw st
 		decision, parseErr := parseAIDecisionPayload(repaired)
 		if parseErr == nil && isValidDecisionAction(decision.Action) && validateRecoveredDecisionContract(decision) == nil {
 			applySLTPFromOriginal(decision, raw)
-			log.Printf("[AI-SCALPING] Structured-output retry succeeded on attempt %d", attempt)
+			zaplogrus.Warnf("[AI-SCALPING] Structured-output retry succeeded on attempt %d", attempt)
 			return decision, nil
 		}
 		if inferred, inferErr := inferDecisionFromLooseText(repaired); inferErr == nil {
 			if contractErr := validateRecoveredDecisionContract(inferred); contractErr == nil {
 				applySLTPFromOriginal(inferred, raw)
-				log.Printf("[AI-SCALPING] Structured-output retry recovered via local decision inference on attempt %d", attempt)
+				zaplogrus.Warnf("[AI-SCALPING] Structured-output retry recovered via local decision inference on attempt %d", attempt)
 				return inferred, nil
 			}
 		}
@@ -5228,7 +5228,7 @@ func (s *AIScalpingService) ApplyPerformanceFeedback() {
 		)
 		fallbackCfg.ConfidenceFloor = newFloor
 		fallbackCfg.SizeFraction = newSize
-		log.Printf("[AI-SCALPING] Self-learning: low win rate (%.1f%%) - tightened confidence floor to %.2f, size fraction to %.2f",
+		zaplogrus.Infof("[AI-SCALPING] Self-learning: low win rate (%.1f%%) - tightened confidence floor to %.2f, size fraction to %.2f",
 			winRate*100, newFloor, newSize)
 	} else if winRate > scalpingFeedbackHighWinRate && totalTrades >= scalpingFeedbackIntervalTrades {
 		newFloor := clampFloat(
@@ -5243,7 +5243,7 @@ func (s *AIScalpingService) ApplyPerformanceFeedback() {
 		)
 		fallbackCfg.ConfidenceFloor = newFloor
 		fallbackCfg.SizeFraction = newSize
-		log.Printf("[AI-SCALPING] Self-learning: high win rate (%.1f%%) - loosened confidence floor to %.2f, size fraction to %.2f",
+		zaplogrus.Infof("[AI-SCALPING] Self-learning: high win rate (%.1f%%) - loosened confidence floor to %.2f, size fraction to %.2f",
 			winRate*100, newFloor, newSize)
 	}
 
@@ -5260,7 +5260,7 @@ func (s *AIScalpingService) ApplyPerformanceFeedback() {
 		)
 		fallbackCfg.ConfidenceFloor = newFloor
 		fallbackCfg.SizeFraction = newSize
-		log.Printf("[AI-SCALPING] Self-learning: %d consecutive losses - tightened to confidence=%.2f, size=%.2f",
+		zaplogrus.Infof("[AI-SCALPING] Self-learning: %d consecutive losses - tightened to confidence=%.2f, size=%.2f",
 			consecutiveLosses, newFloor, newSize)
 	} else if consecutiveWins >= scalpingFeedbackConsecutiveThreshold {
 		newFloor := clampFloat(
@@ -5275,7 +5275,7 @@ func (s *AIScalpingService) ApplyPerformanceFeedback() {
 		)
 		fallbackCfg.ConfidenceFloor = newFloor
 		fallbackCfg.SizeFraction = newSize
-		log.Printf("[AI-SCALPING] Self-learning: %d consecutive wins - loosened to confidence=%.2f, size=%.2f",
+		zaplogrus.Infof("[AI-SCALPING] Self-learning: %d consecutive wins - loosened to confidence=%.2f, size=%.2f",
 			consecutiveWins, newFloor, newSize)
 	}
 
@@ -5289,7 +5289,7 @@ func getEnvInt(key string) int {
 	}
 	value, err := strconv.Atoi(raw)
 	if err != nil {
-		log.Printf("[AI-SCALPING] Invalid integer %s=%q", key, raw)
+		zaplogrus.Warnf("[AI-SCALPING] Invalid integer %s=%q", key, raw)
 		return 0
 	}
 	return value
@@ -5302,7 +5302,7 @@ func getEnvFloat(key string) (float64, bool) {
 	}
 	value, err := strconv.ParseFloat(raw, 64)
 	if err != nil {
-		log.Printf("[AI-SCALPING] Invalid float %s=%q", key, raw)
+		zaplogrus.Warnf("[AI-SCALPING] Invalid float %s=%q", key, raw)
 		return 0, false
 	}
 	return value, true
@@ -5319,7 +5319,7 @@ func getEnvBool(key string) (bool, bool) {
 	case "0", "false", "no", "off":
 		return false, true
 	default:
-		log.Printf("[AI-SCALPING] Invalid boolean %s=%q", key, raw)
+		zaplogrus.Warnf("[AI-SCALPING] Invalid boolean %s=%q", key, raw)
 		return false, false
 	}
 }

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -1939,7 +1939,7 @@ func (s *AIScalpingService) getAIDecision(ctx context.Context, signals []aiMarke
 	userPrompt := s.buildUserPrompt(ctx, signals, portfolio)
 
 	zaplogrus.Infof("[AI-SCALPING] Calling LLM with %d signals", len(signals))
-	zaplogrus.Infof("[AI-SCALPING] === SYSTEM PROMPT ===\n%s", systemPrompt)
+	zaplogrus.Infof("[AI-SCALPING] System prompt length: %d chars", len(systemPrompt))
 	zaplogrus.Infof("[AI-SCALPING] === USER PROMPT ===\nPortfolio: %.2f USDT, Signals: %d", walletBasis(portfolio).InexactFloat64(), len(signals))
 
 	req := &llm.CompletionRequest{

--- a/services/backend-api/internal/services/analytics_math.go
+++ b/services/backend-api/internal/services/analytics_math.go
@@ -1,8 +1,9 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 )
 
 func calculateMeanFloat64(values []float64) float64 {

--- a/services/backend-api/internal/services/analytics_math.go
+++ b/services/backend-api/internal/services/analytics_math.go
@@ -1,7 +1,7 @@
 package services
 
 import (
-	"log"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 )
 
@@ -118,7 +118,7 @@ func garch11Forecast(returns []float64, horizon int, omega float64, alpha float6
 	// GARCH(1,1) stationarity constraint: alpha + beta < 1
 	// If violated, use safe defaults and log warning
 	if alpha+beta >= 1 {
-		log.Printf("WARNING: GARCH parameters violate stationarity (alpha=%.4f + beta=%.4f = %.4f >= 1). Using safe defaults (alpha=0.1, beta=0.8)", alpha, beta, alpha+beta)
+		zaplogrus.Warnf("WARNING: GARCH parameters violate stationarity (alpha=%.4f + beta=%.4f = %.4f >= 1). Using safe defaults (alpha=0.1, beta=0.8)", alpha, beta, alpha+beta)
 		alpha = 0.1
 		beta = 0.8
 	}

--- a/services/backend-api/internal/services/arbitrage_execution_bridge.go
+++ b/services/backend-api/internal/services/arbitrage_execution_bridge.go
@@ -1,10 +1,11 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/models"
 	"github.com/shopspring/decimal"

--- a/services/backend-api/internal/services/arbitrage_execution_bridge.go
+++ b/services/backend-api/internal/services/arbitrage_execution_bridge.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"time"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"

--- a/services/backend-api/internal/services/arbitrage_execution_bridge.go
+++ b/services/backend-api/internal/services/arbitrage_execution_bridge.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"time"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"

--- a/services/backend-api/internal/services/arbitrage_execution_bridge.go
+++ b/services/backend-api/internal/services/arbitrage_execution_bridge.go
@@ -1,9 +1,9 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/irfndi/neuratrade/internal/models"
@@ -47,7 +47,7 @@ func (aeb *ArbitrageExecutionBridge) SetAIEvaluator(evaluator AIEvaluator) {
 type BasicLogger struct{}
 
 func (l *BasicLogger) Info(msg string) {
-	log.Printf("[ArbitrageBridge] %s", msg)
+	zaplogrus.Infof("[ArbitrageBridge] %s", msg)
 }
 
 // Start begins monitoring for arbitrage opportunities and triggering executions
@@ -64,7 +64,7 @@ func (aeb *ArbitrageExecutionBridge) Start(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			if err := aeb.processNewArbitrageOpportunities(ctx); err != nil {
-				log.Printf("Error processing arbitrage opportunities: %v", err)
+				zaplogrus.Infof("Error processing arbitrage opportunities: %v", err)
 			}
 		}
 	}
@@ -80,7 +80,7 @@ func (aeb *ArbitrageExecutionBridge) processNewArbitrageOpportunities(ctx contex
 		return nil
 	}
 
-	log.Printf("Found %d potential arbitrage opportunities", len(opportunities))
+	zaplogrus.Infof("Found %d potential arbitrage opportunities", len(opportunities))
 
 	for _, opportunity := range opportunities {
 		shouldExecute := true //nolint:ineffassign
@@ -95,11 +95,11 @@ func (aeb *ArbitrageExecutionBridge) processNewArbitrageOpportunities(ctx contex
 			var confidence float64
 			shouldExecute, confidence, reasoning, err = aeb.aiEvaluator.EvaluateOpportunity(ctx, &opportunity, contextStr)
 			if err != nil {
-				log.Printf("AI evaluation failed for opportunity %s: %v", opportunity.ID, err)
+				zaplogrus.Warnf("AI evaluation failed for opportunity %s: %v", opportunity.ID, err)
 				continue
 			}
 
-			log.Printf("AI evaluated opportunity %s: execute=%v confidence=%.2f reason=%s",
+			zaplogrus.Infof("AI evaluated opportunity %s: execute=%v confidence=%.2f reason=%s",
 				opportunity.ID, shouldExecute, confidence, reasoning)
 
 			if !shouldExecute {
@@ -108,11 +108,11 @@ func (aeb *ArbitrageExecutionBridge) processNewArbitrageOpportunities(ctx contex
 		}
 
 		if err := aeb.createArbitrageQuest(ctx, opportunity); err != nil {
-			log.Printf("Failed to create arbitrage quest for opportunity %s: %v", opportunity.ID, err)
+			zaplogrus.Warnf("Failed to create arbitrage quest for opportunity %s: %v", opportunity.ID, err)
 			continue
 		}
 
-		log.Printf("Created arbitrage execution quest for opportunity %s", opportunity.ID)
+		zaplogrus.Infof("Created arbitrage execution quest for opportunity %s", opportunity.ID)
 	}
 
 	return nil

--- a/services/backend-api/internal/services/autonomy_rollout_store.go
+++ b/services/backend-api/internal/services/autonomy_rollout_store.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -11,6 +10,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/autonomous"
 )

--- a/services/backend-api/internal/services/autonomy_rollout_store.go
+++ b/services/backend-api/internal/services/autonomy_rollout_store.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 	"time"
 

--- a/services/backend-api/internal/services/autonomy_rollout_store.go
+++ b/services/backend-api/internal/services/autonomy_rollout_store.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 	"time"
 

--- a/services/backend-api/internal/services/autonomy_rollout_store.go
+++ b/services/backend-api/internal/services/autonomy_rollout_store.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -8,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -241,7 +241,7 @@ func (s *AutonomousRolloutStore) GetRollbackHistory(ctx context.Context, strateg
 	redactedID := redactStrategyID(strategyID)
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
-			log.Printf("autonomous rollout store: failed to close rollback rows for strategy %s: %v", redactedID, closeErr)
+			zaplogrus.Warnf("autonomous rollout store: failed to close rollback rows for strategy %s: %v", redactedID, closeErr)
 		}
 	}()
 

--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"bytes"
 	"context"
 	"crypto/hmac"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	appautonomy "github.com/irfndi/neuratrade/internal/app/autonomy"
 	"github.com/shopspring/decimal"

--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"io"
 	"math"
 	"net/http"

--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"bytes"
 	"context"
 	"crypto/hmac"
@@ -9,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"net/http"
 	"strconv"
@@ -1179,7 +1179,7 @@ func (e *BitgetOrderExecutor) SyncPositionProtection(
 		if splitErr != nil {
 			return fmt.Errorf("place replacement TP/SL plan order failed: %w (split fallback failed: %v)", err, splitErr)
 		}
-		log.Printf("[BITGET-ORDER] Combined TP/SL sync rejected, split fallback applied for %s", apiSymbol)
+		zaplogrus.Warnf("[BITGET-ORDER] Combined TP/SL sync rejected, split fallback applied for %s", apiSymbol)
 	}
 	return nil
 }

--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"io"
 	"math"
 	"net/http"

--- a/services/backend-api/internal/services/collector_service.go
+++ b/services/backend-api/internal/services/collector_service.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 	"time"
@@ -420,7 +419,7 @@ func (c *CollectorService) initializeWorkersAsync() {
 	// Trigger immediate initial data collection to unblock dependent services
 	// Only fetch a few symbols initially to quickly unblock the channel
 	go func() {
-		log.Printf("Triggering immediate initial data collection for %d workers", len(c.workers))
+		zaplogrus.Infof("Triggering immediate initial data collection for %d workers", len(c.workers))
 		for _, worker := range c.workers {
 			// Fetch only first 10 symbols to quickly unblock dependent services
 			initialSymbols := worker.Symbols
@@ -433,9 +432,9 @@ func (c *CollectorService) initializeWorkersAsync() {
 				Symbols:  initialSymbols,
 			}
 			if err := c.collectTickerDataBulk(tempWorker); err != nil {
-				log.Printf("Initial collection failed for %s: %v", worker.Exchange, err)
+				zaplogrus.Warnf("Initial collection failed for %s: %v", worker.Exchange, err)
 			} else {
-				log.Printf("Initial collection succeeded for %s (%d symbols)", worker.Exchange, len(initialSymbols))
+				zaplogrus.Infof("Initial collection succeeded for %s (%d symbols)", worker.Exchange, len(initialSymbols))
 			}
 		}
 	}()

--- a/services/backend-api/internal/services/max_drawdown_halt.go
+++ b/services/backend-api/internal/services/max_drawdown_halt.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"os"
 	"strconv"
 	"strings"

--- a/services/backend-api/internal/services/max_drawdown_halt.go
+++ b/services/backend-api/internal/services/max_drawdown_halt.go
@@ -1,9 +1,9 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -506,7 +506,7 @@ func (h *MaxDrawdownHalt) ForceResumeAll(ctx context.Context) []string {
 	}
 
 	if len(resumed) > 0 {
-		log.Printf("[DRAWDOWN] Force resumed trading for %d account(s): %v", len(resumed), resumed)
+		zaplogrus.Infof("[DRAWDOWN] Force resumed trading for %d account(s): %v", len(resumed), resumed)
 	}
 
 	return resumed
@@ -542,7 +542,7 @@ func ResolveMaxDrawdownConfigFromEnv(base MaxDrawdownConfig) MaxDrawdownConfig {
 		cfg.AutoResumeEnabled = strings.ToLower(v) == "true" || v == "1" || v == "yes"
 	}
 
-	log.Printf("[DRAWDOWN] Config: warning=%.0f%% critical=%.0f%% halt=%.0f%% recovery=%.0f%% auto_resume=%v",
+	zaplogrus.Warnf("[DRAWDOWN] Config: warning=%.0f%% critical=%.0f%% halt=%.0f%% recovery=%.0f%% auto_resume=%v",
 		cfg.WarningThreshold.InexactFloat64()*100,
 		cfg.CriticalThreshold.InexactFloat64()*100,
 		cfg.HaltThreshold.InexactFloat64()*100,

--- a/services/backend-api/internal/services/max_drawdown_halt.go
+++ b/services/backend-api/internal/services/max_drawdown_halt.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
 	"os"
@@ -9,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/shopspring/decimal"
 )

--- a/services/backend-api/internal/services/max_drawdown_halt.go
+++ b/services/backend-api/internal/services/max_drawdown_halt.go
@@ -507,7 +507,7 @@ func (h *MaxDrawdownHalt) ForceResumeAll(ctx context.Context) []string {
 	}
 
 	if len(resumed) > 0 {
-		zaplogrus.Infof("[DRAWDOWN] Force resumed trading for %d account(s): %v", len(resumed), resumed)
+		zaplogrus.Infof("[DRAWDOWN] Force resumed trading for %d account(s)", len(resumed))
 	}
 
 	return resumed

--- a/services/backend-api/internal/services/max_drawdown_halt.go
+++ b/services/backend-api/internal/services/max_drawdown_halt.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"os"
 	"strconv"
 	"strings"

--- a/services/backend-api/internal/services/mode_aware_order_executor.go
+++ b/services/backend-api/internal/services/mode_aware_order_executor.go
@@ -1,10 +1,11 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
 	"strings"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/shopspring/decimal"
 )

--- a/services/backend-api/internal/services/mode_aware_order_executor.go
+++ b/services/backend-api/internal/services/mode_aware_order_executor.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"

--- a/services/backend-api/internal/services/mode_aware_order_executor.go
+++ b/services/backend-api/internal/services/mode_aware_order_executor.go
@@ -1,9 +1,9 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/shopspring/decimal"
@@ -64,7 +64,7 @@ func (e *ModeAwareOrderExecutor) resolveMode(ctx context.Context) OperationalMod
 			return normalizeOperationalMode(e.opModeService.GetMode(chatID))
 		}
 	}
-	log.Printf("[ORDER-EXECUTOR] WARNING: no operational mode in context, no mode service available; defaulting to paper mode")
+	zaplogrus.Warnf("[ORDER-EXECUTOR] WARNING: no operational mode in context, no mode service available; defaulting to paper mode")
 	return ModePaper
 }
 

--- a/services/backend-api/internal/services/mode_aware_order_executor.go
+++ b/services/backend-api/internal/services/mode_aware_order_executor.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"strings"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"

--- a/services/backend-api/internal/services/paper_scalping_close.go
+++ b/services/backend-api/internal/services/paper_scalping_close.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math/rand"
 	"os"
 	"strings"

--- a/services/backend-api/internal/services/paper_scalping_close.go
+++ b/services/backend-api/internal/services/paper_scalping_close.go
@@ -1,9 +1,9 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 	"strings"
@@ -95,7 +95,7 @@ func (h *IntegratedQuestHandlers) closeTriggeredPaperScalpingPositions(
 
 		h.updatePaperScalpingTelemetryOutcome(ctx, orderID, outcome, netPnL, position.OpenedAt, closedAt)
 		closed++
-		log.Printf(
+		zaplogrus.Infof(
 			"[SCALPING] Paper %s closed by %s at %s (entry=%s gross_pnl=%s fees=%s)",
 			position.Symbol,
 			triggerSource,
@@ -227,7 +227,7 @@ func paperScalpingTakerFeeRateFromEnv() (decimal.Decimal, bool) {
 	}
 	configured, err := decimal.NewFromString(raw)
 	if err != nil || configured.IsNegative() {
-		log.Printf("[SCALPING] Invalid paper scalping taker fee rate %q", raw)
+		zaplogrus.Warnf("[SCALPING] Invalid paper scalping taker fee rate %q", raw)
 		return decimal.Zero, false
 	}
 	return configured, true
@@ -270,6 +270,6 @@ func (h *IntegratedQuestHandlers) updatePaperScalpingTelemetryOutcome(
 	})
 	writeCancel()
 	if err != nil {
-		log.Printf("[TELEMETRY] Failed to update paper outcome for order %s: %v", orderID, err)
+		zaplogrus.Warnf("[TELEMETRY] Failed to update paper outcome for order %s: %v", orderID, err)
 	}
 }

--- a/services/backend-api/internal/services/paper_scalping_close.go
+++ b/services/backend-api/internal/services/paper_scalping_close.go
@@ -1,13 +1,14 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
 	"math/rand"
 	"os"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/ccxt"
 	"github.com/shopspring/decimal"

--- a/services/backend-api/internal/services/paper_scalping_close.go
+++ b/services/backend-api/internal/services/paper_scalping_close.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math/rand"
 	"os"
 	"strings"

--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -537,7 +537,11 @@ func (e *QuestEngine) Start() {
 
 	go e.schedulerLoop(runStopCh)
 	zaplogrus.Infof("[QUEST] Quest engine started")
-	zaplogrus.Infof("[QUEST] Initial state: %d quests loaded, running=%v", len(e.quests), e.running)
+	e.mu.RLock()
+	questCount := len(e.quests)
+	isRunning := e.running
+	e.mu.RUnlock()
+	zaplogrus.Infof("[QUEST] Initial state: %d quests loaded, running=%v", questCount, isRunning)
 	zaplogrus.Infof(
 		"[QUEST] Runtime budget: scalping_timeout=%s structured_retries=%d derived_floor=%s stale_timeout=%s execution_timeout=%s lock_ttl=%s",
 		e.runtimeBudget.ScalpingTimeout,
@@ -742,7 +746,7 @@ func (e *QuestEngine) tick() {
 	scheduledCount := 0
 	for _, quest := range e.quests {
 		if quest.Status != QuestStatusActive {
-			zaplogrus.Warnf("[QUEST] Quest %s (%s) skipped - status: %s", quest.ID, quest.Name, quest.Status)
+			zaplogrus.Infof("[QUEST] Quest %s (%s) skipped - status: %s", quest.ID, quest.Name, quest.Status)
 			continue
 		}
 		activeCount++

--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"os"
 	"sort"
 	"strconv"

--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -12,6 +11,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/google/uuid"
 	appautonomy "github.com/irfndi/neuratrade/internal/app/autonomy"

--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -1440,7 +1440,8 @@ func (e *QuestEngine) executeQuest(quest *Quest) {
 	e.mu.RUnlock()
 
 	if !ok {
-		zaplogrus.Infof("No handler registered for quest type: %s", quest.Type)
+		zaplogrus.Warnf("No handler registered for quest type: %s", quest.Type)
+		e.finalizeQuestExecution(quest, fmt.Errorf("no handler registered for quest type: %s", quest.Type))
 		return
 	}
 

--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -1,10 +1,10 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"sort"
 	"strconv"
@@ -495,7 +495,7 @@ func (e *QuestEngine) CreateQuest(definitionID string, chatID string, customTarg
 
 	if e.store != nil {
 		if err := e.store.SaveQuest(context.Background(), quest); err != nil {
-			log.Printf("Failed to persist quest %s: %v", quest.ID, err)
+			zaplogrus.Warnf("Failed to persist quest %s: %v", quest.ID, err)
 		}
 	}
 
@@ -507,7 +507,7 @@ func (e *QuestEngine) Start() {
 	e.mu.Lock()
 	if e.running {
 		e.mu.Unlock()
-		log.Println("[QUEST] Start called but already running")
+		zaplogrus.Info("[QUEST] Start called but already running")
 		return
 	}
 	if e.runCancel != nil {
@@ -535,9 +535,9 @@ func (e *QuestEngine) Start() {
 	}
 
 	go e.schedulerLoop(runStopCh)
-	log.Printf("[QUEST] Quest engine started")
-	log.Printf("[QUEST] Initial state: %d quests loaded, running=%v", len(e.quests), e.running)
-	log.Printf(
+	zaplogrus.Infof("[QUEST] Quest engine started")
+	zaplogrus.Infof("[QUEST] Initial state: %d quests loaded, running=%v", len(e.quests), e.running)
+	zaplogrus.Infof(
 		"[QUEST] Runtime budget: scalping_timeout=%s structured_retries=%d derived_floor=%s stale_timeout=%s execution_timeout=%s lock_ttl=%s",
 		e.runtimeBudget.ScalpingTimeout,
 		e.runtimeBudget.StructuredRetries,
@@ -557,7 +557,7 @@ func (e *QuestEngine) loadActiveQuests() {
 	ctx := context.Background()
 	quests, err := e.store.ListQuests(ctx, "", QuestStatusActive)
 	if err != nil {
-		log.Printf("Failed to load active quests: %v", err)
+		zaplogrus.Warnf("Failed to load active quests: %v", err)
 		return
 	}
 
@@ -575,7 +575,7 @@ func (e *QuestEngine) loadActiveQuests() {
 			quest.UpdatedAt = now
 			pausedCount++
 			if err := e.store.SaveQuest(ctx, quest); err != nil {
-				log.Printf("Failed to pause legacy active quest %s: %v", quest.ID, err)
+				zaplogrus.Warnf("Failed to pause legacy active quest %s: %v", quest.ID, err)
 			}
 			continue
 		}
@@ -586,7 +586,7 @@ func (e *QuestEngine) loadActiveQuests() {
 			quest.UpdatedAt = now
 			pausedCount++
 			if err := e.store.SaveQuest(ctx, quest); err != nil {
-				log.Printf("Failed to pause duplicate active quest %s: %v", quest.ID, err)
+				zaplogrus.Warnf("Failed to pause duplicate active quest %s: %v", quest.ID, err)
 			}
 			continue
 		}
@@ -597,9 +597,9 @@ func (e *QuestEngine) loadActiveQuests() {
 	defer e.mu.Unlock()
 	for _, quest := range selectedByChat {
 		e.quests[quest.ID] = quest
-		log.Printf("Loaded active scalping quest: %s (chat: %s)", quest.ID, quest.Metadata["chat_id"])
+		zaplogrus.Infof("Loaded active scalping quest: %s (chat: %s)", quest.ID, quest.Metadata["chat_id"])
 	}
-	log.Printf("Loaded %d active scalping quests, paused %d stale active quests", len(selectedByChat), pausedCount)
+	zaplogrus.Warnf("Loaded %d active scalping quests, paused %d stale active quests", len(selectedByChat), pausedCount)
 }
 
 // Stop stops the quest engine
@@ -621,15 +621,15 @@ func (e *QuestEngine) Stop() {
 	e.mu.Unlock()
 
 	e.clearQuestLockOwnerHeartbeatIfIdle()
-	log.Println("Quest engine stopped")
+	zaplogrus.Info("Quest engine stopped")
 }
 
 // schedulerLoop runs the periodic quest scheduling
 func (e *QuestEngine) schedulerLoop(stopCh <-chan struct{}) {
-	log.Println("[QUEST] Scheduler loop started")
+	zaplogrus.Info("[QUEST] Scheduler loop started")
 	ticker := time.NewTicker(defaultQuestSchedulerPoll)
 	defer ticker.Stop()
-	log.Printf("[QUEST] Scheduler polling interval: %s", defaultQuestSchedulerPoll)
+	zaplogrus.Infof("[QUEST] Scheduler polling interval: %s", defaultQuestSchedulerPoll)
 
 	// Run an immediate check so newly activated quests do not wait for the first interval.
 	e.evaluateAndTick(time.Now().UTC(), true)
@@ -637,7 +637,7 @@ func (e *QuestEngine) schedulerLoop(stopCh <-chan struct{}) {
 	for {
 		select {
 		case <-stopCh:
-			log.Println("[QUEST] Scheduler loop stopped")
+			zaplogrus.Info("[QUEST] Scheduler loop stopped")
 			return
 		case <-ticker.C:
 			e.evaluateAndTick(time.Now().UTC(), false)
@@ -659,7 +659,7 @@ func (e *QuestEngine) shouldRunTick(now time.Time, force bool) bool {
 	mode := e.determineCadenceModeLocked()
 	interval := cadenceIntervalForMode(mode)
 	if mode != e.cadenceMode {
-		log.Printf("[QUEST] Cadence mode changed: %s -> %s (interval=%s)", e.cadenceMode, mode, interval)
+		zaplogrus.Infof("[QUEST] Cadence mode changed: %s -> %s (interval=%s)", e.cadenceMode, mode, interval)
 		e.cadenceMode = mode
 	}
 
@@ -728,7 +728,7 @@ func (e *QuestEngine) tick() {
 				delete(e.executionStaleResetReason, id)
 				delete(e.executionStaleResetAt, id)
 				delete(e.chatIDForQuest, id)
-				log.Printf("[QUEST] Cleaned up old quest: %s (status: %s)", id, quest.Status)
+				zaplogrus.Infof("[QUEST] Cleaned up old quest: %s (status: %s)", id, quest.Status)
 			}
 		}
 	}
@@ -736,12 +736,12 @@ func (e *QuestEngine) tick() {
 
 	// Then, check quests for execution.
 	e.mu.Lock()
-	log.Printf("[QUEST] Tick: checking %d quests for execution", len(e.quests))
+	zaplogrus.Infof("[QUEST] Tick: checking %d quests for execution", len(e.quests))
 	activeCount := 0
 	scheduledCount := 0
 	for _, quest := range e.quests {
 		if quest.Status != QuestStatusActive {
-			log.Printf("[QUEST] Quest %s (%s) skipped - status: %s", quest.ID, quest.Name, quest.Status)
+			zaplogrus.Warnf("[QUEST] Quest %s (%s) skipped - status: %s", quest.ID, quest.Name, quest.Status)
 			continue
 		}
 		activeCount++
@@ -786,7 +786,7 @@ func (e *QuestEngine) tick() {
 					e.executionLockCheckedAt[quest.ID] = now.UTC()
 					e.executionStaleResetReason[quest.ID] = fmt.Sprintf("stale_reset_lock_check_failed:%v", lockCheckErr)
 					e.executionStaleResetAt[quest.ID] = now.UTC()
-					log.Printf(
+					zaplogrus.Infof(
 						"[QUEST] Quest %s (%s) stale reset after lock check failure (%v)",
 						quest.ID,
 						quest.Name,
@@ -800,7 +800,7 @@ func (e *QuestEngine) tick() {
 				if lockHeld {
 					e.executionStaleResetReason[quest.ID] = fmt.Sprintf("stale_detected_but_lock_active(ttl=%s)", lockTTL.Round(time.Second))
 					e.executionStaleResetAt[quest.ID] = now.UTC()
-					log.Printf(
+					zaplogrus.Infof(
 						"[QUEST] Quest %s (%s) stale marker retained because lock is still active (ttl=%s progress_age=%s start_age=%s stage=%s)",
 						quest.ID,
 						quest.Name,
@@ -812,7 +812,7 @@ func (e *QuestEngine) tick() {
 					continue
 				}
 
-				log.Printf(
+				zaplogrus.Infof(
 					"[QUEST] Quest %s (%s) execution stale after progress_age=%s (start_age=%s stage=%s reset_after=%s), resetting in-progress marker",
 					quest.ID,
 					quest.Name,
@@ -828,7 +828,7 @@ func (e *QuestEngine) tick() {
 				e.executionStaleResetReason[quest.ID] = fmt.Sprintf("stale_reset_progress_age=%s", progressAge.Round(time.Second))
 				e.executionStaleResetAt[quest.ID] = now.UTC()
 			} else {
-				log.Printf(
+				zaplogrus.Infof(
 					"[QUEST] Quest %s (%s) skipped - execution already in progress for %s (stage=%s last_progress=%s ago)",
 					quest.ID,
 					quest.Name,
@@ -849,7 +849,7 @@ func (e *QuestEngine) tick() {
 			quest.Checkpoint["runtime_entry_blocked_by_risk_lock"] = true
 			quest.Checkpoint["runtime_entry_blocked_at"] = now.UTC().Format(time.RFC3339)
 			quest.Checkpoint["runtime_entry_gate_reason"] = "risk lock active: drawdown/exposure guardrail blocking new entries"
-			log.Printf("[QUEST] Entry decisions for quest %s are gated by risk lock", quest.ID)
+			zaplogrus.Infof("[QUEST] Entry decisions for quest %s are gated by risk lock", quest.ID)
 		} else if quest.Checkpoint != nil {
 			delete(quest.Checkpoint, "runtime_entry_blocked_by_risk_lock")
 		}
@@ -865,7 +865,7 @@ func (e *QuestEngine) tick() {
 			if strings.TrimSpace(readQuestMetricString(quest.Checkpoint["runtime_entry_gate_reason"])) == "" {
 				quest.Checkpoint["runtime_entry_gate_reason"] = "state drift detected: reconcile/repair pending"
 			}
-			log.Printf("[QUEST] Entry decisions for quest %s are gated by state drift", quest.ID)
+			zaplogrus.Warnf("[QUEST] Entry decisions for quest %s are gated by state drift", quest.ID)
 		} else if quest.Checkpoint != nil {
 			delete(quest.Checkpoint, "runtime_entry_blocked_by_state_drift")
 			if !readQuestMetricBool(quest.Checkpoint["runtime_entry_blocked_by_risk_lock"]) {
@@ -876,7 +876,7 @@ func (e *QuestEngine) tick() {
 
 		// Check if quest should execute based on cadence
 		if e.shouldExecute(quest, now) {
-			log.Printf("[QUEST] Executing quest: %s (type: %s, def: %s, chat: %s)", quest.ID, quest.Type, quest.Metadata["definition_id"], quest.Metadata["chat_id"])
+			zaplogrus.Infof("[QUEST] Executing quest: %s (type: %s, def: %s, chat: %s)", quest.ID, quest.Type, quest.Metadata["definition_id"], quest.Metadata["chat_id"])
 			e.executing[quest.ID] = true
 			e.executionStarts[quest.ID] = now
 			e.executionLastProgress[quest.ID] = now
@@ -884,10 +884,10 @@ func (e *QuestEngine) tick() {
 			scheduledCount++
 			go e.executeQuest(quest)
 		} else {
-			log.Printf("[QUEST] Quest %s not ready (cadence: %s, last: %v)", quest.ID, quest.Cadence, quest.LastExecutedAt)
+			zaplogrus.Infof("[QUEST] Quest %s not ready (cadence: %s, last: %v)", quest.ID, quest.Cadence, quest.LastExecutedAt)
 		}
 	}
-	log.Printf("[QUEST] Tick complete: %d active quests, %d sent for execution", activeCount, scheduledCount)
+	zaplogrus.Infof("[QUEST] Tick complete: %d active quests, %d sent for execution", activeCount, scheduledCount)
 	e.mu.Unlock()
 }
 
@@ -954,12 +954,12 @@ func cadenceFromEnv(envKey string, fallback time.Duration) time.Duration {
 	}
 	seconds, err := strconv.Atoi(raw)
 	if err != nil || seconds <= 0 {
-		log.Printf("[QUEST] Invalid %s=%q, using default %s", envKey, raw, fallback)
+		zaplogrus.Warnf("[QUEST] Invalid %s=%q, using default %s", envKey, raw, fallback)
 		return fallback
 	}
 	interval := time.Duration(seconds) * time.Second
 	if interval < minQuestCadenceInterval {
-		log.Printf("[QUEST] %s too low (%ds), clamping to %s", envKey, seconds, minQuestCadenceInterval)
+		zaplogrus.Infof("[QUEST] %s too low (%ds), clamping to %s", envKey, seconds, minQuestCadenceInterval)
 		return minQuestCadenceInterval
 	}
 	return interval
@@ -1287,7 +1287,7 @@ func (e *QuestEngine) refreshQuestLockOwnerHeartbeatCycle(runCtx context.Context
 	if !running && executing == 0 {
 		if err := redisClient.Del(ctx, questLockOwnerHeartbeatKey(ownerID)).Err(); err != nil {
 			if e.shouldLogRedisError() {
-				log.Printf("[QUEST] Failed to clear quest lock owner heartbeat: %v", err)
+				zaplogrus.Warnf("[QUEST] Failed to clear quest lock owner heartbeat: %v", err)
 			}
 		}
 		return true
@@ -1295,7 +1295,7 @@ func (e *QuestEngine) refreshQuestLockOwnerHeartbeatCycle(runCtx context.Context
 
 	if err := redisClient.Set(ctx, questLockOwnerHeartbeatKey(ownerID), time.Now().UTC().Format(time.RFC3339), questLockOwnerHeartbeatTTL).Err(); err != nil {
 		if e.shouldLogRedisError() {
-			log.Printf("[QUEST] Failed to refresh quest lock owner heartbeat: %v", err)
+			zaplogrus.Warnf("[QUEST] Failed to refresh quest lock owner heartbeat: %v", err)
 		}
 	}
 
@@ -1318,7 +1318,7 @@ func (e *QuestEngine) clearQuestLockOwnerHeartbeatIfIdle() {
 	defer cancel()
 	if err := redisClient.Del(ctx, questLockOwnerHeartbeatKey(ownerID)).Err(); err != nil {
 		if e.shouldLogRedisError() {
-			log.Printf("[QUEST] Failed to clear quest lock owner heartbeat: %v", err)
+			zaplogrus.Warnf("[QUEST] Failed to clear quest lock owner heartbeat: %v", err)
 		}
 	}
 }
@@ -1423,7 +1423,7 @@ func (e *QuestEngine) reclaimStaleLock(ctx context.Context, key string, ttl time
 		return false, err
 	}
 	if replaced == 1 {
-		log.Printf("[QUEST] Reclaimed stale quest lock %s from inactive owner %s", key, currentOwner)
+		zaplogrus.Warnf("[QUEST] Reclaimed stale quest lock %s from inactive owner %s", key, currentOwner)
 		return true, nil
 	}
 	return false, nil
@@ -1439,7 +1439,7 @@ func (e *QuestEngine) executeQuest(quest *Quest) {
 	e.mu.RUnlock()
 
 	if !ok {
-		log.Printf("No handler registered for quest type: %s", quest.Type)
+		zaplogrus.Infof("No handler registered for quest type: %s", quest.Type)
 		return
 	}
 
@@ -1456,7 +1456,7 @@ func (e *QuestEngine) executeQuest(quest *Quest) {
 		e.executionStaleResetReason[quest.ID] = "lock_acquire_failed_already_owned"
 		e.executionStaleResetAt[quest.ID] = time.Now().UTC()
 		e.mu.Unlock()
-		log.Printf("Quest %s skipped: could not acquire lock (another instance may be running)", quest.ID)
+		zaplogrus.Warnf("Quest %s skipped: could not acquire lock (another instance may be running)", quest.ID)
 		return
 	}
 	e.recordExecutionLockState(quest.ID, true, e.runtimeBudget.LockTTL, time.Now().UTC())
@@ -1472,11 +1472,11 @@ func (e *QuestEngine) executeQuest(quest *Quest) {
 	stopHeartbeat := e.startExecutionHeartbeat(ctx, quest.ID)
 	defer stopHeartbeat()
 	if err := handler(ctx, quest); err != nil {
-		log.Printf("Quest %s (%s) failed: %v", quest.ID, quest.Name, err)
+		zaplogrus.Warnf("Quest %s (%s) failed: %v", quest.ID, quest.Name, err)
 		e.markQuestExecutionProgress(quest.ID, questExecutionStagePersist)
 		e.finalizeQuestExecution(quest, err)
 	} else {
-		log.Printf("Quest %s (%s) completed successfully", quest.ID, quest.Name)
+		zaplogrus.Infof("Quest %s (%s) completed successfully", quest.ID, quest.Name)
 		e.markQuestExecutionProgress(quest.ID, questExecutionStagePersist)
 		e.finalizeQuestExecution(quest, nil)
 	}
@@ -1521,7 +1521,7 @@ func (e *QuestEngine) finalizeQuestExecution(quest *Quest, execErr error) {
 		saveCtx, cancel := context.WithTimeout(context.Background(), defaultQuestStoreWriteTimeout)
 		defer cancel()
 		if err := e.store.SaveQuest(saveCtx, snapshot); err != nil {
-			log.Printf("Failed to persist final quest snapshot %s: %v", quest.ID, err)
+			zaplogrus.Warnf("Failed to persist final quest snapshot %s: %v", quest.ID, err)
 		}
 	}
 }
@@ -1561,13 +1561,13 @@ func (e *QuestEngine) acquireLock(ctx context.Context, key string, ttl time.Dura
 	}
 	if err := e.refreshQuestLockOwnerHeartbeat(ctx); err != nil {
 		if e.shouldLogRedisError() {
-			log.Printf("Failed to refresh quest lock owner heartbeat: %v", err)
+			zaplogrus.Warnf("Failed to refresh quest lock owner heartbeat: %v", err)
 		}
 		return false
 	}
 	ok, err := e.redis.SetNX(ctx, key, e.lockOwnerID, ttl).Result()
 	if err != nil {
-		log.Printf("Failed to acquire lock %s: %v", key, err)
+		zaplogrus.Warnf("Failed to acquire lock %s: %v", key, err)
 		return false
 	}
 	if ok {
@@ -1575,7 +1575,7 @@ func (e *QuestEngine) acquireLock(ctx context.Context, key string, ttl time.Dura
 	}
 	reclaimed, err := e.reclaimStaleLock(ctx, key, ttl)
 	if err != nil {
-		log.Printf("Failed to reclaim stale lock %s: %v", key, err)
+		zaplogrus.Warnf("Failed to reclaim stale lock %s: %v", key, err)
 		return false
 	}
 	if reclaimed {
@@ -1602,7 +1602,7 @@ func (e *QuestEngine) releaseLock(ctx context.Context, key string) {
 		return
 	}
 	if _, err := releaseQuestLockIfOwnedScript.Run(ctx, e.redis, []string{key}, e.lockOwnerID).Int(); err != nil && err != redis.Nil {
-		log.Printf("Failed to release lock %s: %v", key, err)
+		zaplogrus.Warnf("Failed to release lock %s: %v", key, err)
 	}
 }
 
@@ -1619,7 +1619,7 @@ func (e *QuestEngine) BeginAutonomous(chatID string) (*AutonomousState, error) {
 			q.UpdatedAt = time.Now()
 			if e.store != nil {
 				if err := e.store.SaveQuest(context.Background(), q); err != nil {
-					log.Printf("Failed to persist paused quest %s: %v", q.ID, err)
+					zaplogrus.Warnf("Failed to persist paused quest %s: %v", q.ID, err)
 				}
 			}
 		}
@@ -1637,7 +1637,7 @@ func (e *QuestEngine) BeginAutonomous(chatID string) (*AutonomousState, error) {
 	for _, defID := range defaultQuests {
 		quest, err := e.ensureQuestForChatInternal(defID, chatID)
 		if err != nil {
-			log.Printf("Failed to create quest %s: %v", defID, err)
+			zaplogrus.Warnf("Failed to create quest %s: %v", defID, err)
 			continue
 		}
 		currentMode := e.resolveBeginAutonomousMode(chatID, quest)
@@ -1648,7 +1648,7 @@ func (e *QuestEngine) BeginAutonomous(chatID string) (*AutonomousState, error) {
 		quest.Metadata["dry_run"] = strconv.FormatBool(isDryRun)
 		quest.Metadata["paper_trading"] = strconv.FormatBool(currentMode == ModePaper)
 		quest.Metadata["execution_mode"] = string(currentMode)
-		log.Printf(
+		zaplogrus.Infof(
 			"[QUEST] Created quest %s with execution_mode=%s dry_run=%t paper_trading=%t",
 			quest.ID,
 			currentMode,
@@ -1660,7 +1660,7 @@ func (e *QuestEngine) BeginAutonomous(chatID string) (*AutonomousState, error) {
 		quest.UpdatedAt = time.Now()
 		if e.store != nil {
 			if err := e.store.SaveQuest(context.Background(), quest); err != nil {
-				log.Printf("Failed to persist active quest %s: %v", quest.ID, err)
+				zaplogrus.Warnf("Failed to persist active quest %s: %v", quest.ID, err)
 			}
 		}
 		state.ActiveQuests = append(state.ActiveQuests, quest.ID)
@@ -1670,7 +1670,7 @@ func (e *QuestEngine) BeginAutonomous(chatID string) (*AutonomousState, error) {
 
 	if e.store != nil {
 		if err := e.store.SaveAutonomousState(context.Background(), state); err != nil {
-			log.Printf("Failed to persist autonomous state: %v", err)
+			zaplogrus.Warnf("Failed to persist autonomous state: %v", err)
 		}
 	}
 
@@ -1745,7 +1745,7 @@ func (e *QuestEngine) PauseAutonomous(chatID string) (*AutonomousState, error) {
 
 	if e.store != nil {
 		if err := e.store.SaveAutonomousState(context.Background(), state); err != nil {
-			log.Printf("Failed to persist autonomous state: %v", err)
+			zaplogrus.Warnf("Failed to persist autonomous state: %v", err)
 		}
 	}
 
@@ -2842,7 +2842,7 @@ func (e *QuestEngine) createQuestInternal(definitionID string, chatID string) (*
 
 	if e.store != nil {
 		if err := e.store.SaveQuest(context.Background(), quest); err != nil {
-			log.Printf("Failed to persist quest %s: %v", quest.ID, err)
+			zaplogrus.Warnf("Failed to persist quest %s: %v", quest.ID, err)
 		}
 	}
 
@@ -2875,7 +2875,7 @@ func (e *QuestEngine) UpdateQuestProgress(questID string, current int, checkpoin
 
 	if e.store != nil {
 		if err := e.store.SaveQuest(context.Background(), quest); err != nil {
-			log.Printf("Failed to persist quest %s: %v", quest.ID, err)
+			zaplogrus.Warnf("Failed to persist quest %s: %v", quest.ID, err)
 		}
 	}
 
@@ -2896,7 +2896,7 @@ func (e *QuestEngine) UpdateQuestProgress(questID string, current int, checkpoin
 		}
 		go func() {
 			if err := e.notificationService.NotifyQuestProgress(context.Background(), chatID, progressNotif); err != nil {
-				log.Printf("Failed to send quest progress notification for %s: %v", questID, err)
+				zaplogrus.Warnf("Failed to send quest progress notification for %s: %v", questID, err)
 			}
 		}()
 	}

--- a/services/backend-api/internal/services/quest_engine.go
+++ b/services/backend-api/internal/services/quest_engine.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"os"
 	"sort"
 	"strconv"

--- a/services/backend-api/internal/services/quest_event_triggers.go
+++ b/services/backend-api/internal/services/quest_event_triggers.go
@@ -1,8 +1,8 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 )
@@ -98,7 +98,7 @@ func (s *EventDrivenQuestSystem) EmitEvent(event *QuestEvent) {
 	select {
 	case s.events <- event:
 	default:
-		log.Printf("Event queue full, dropping event: %s", event.ID)
+		zaplogrus.Infof("Event queue full, dropping event: %s", event.ID)
 	}
 }
 
@@ -123,7 +123,7 @@ func (s *EventDrivenQuestSystem) Start() {
 	s.mu.Unlock()
 
 	go s.eventLoop()
-	log.Println("Event-driven quest system started")
+	zaplogrus.Info("Event-driven quest system started")
 }
 
 func (s *EventDrivenQuestSystem) Stop() {
@@ -134,7 +134,7 @@ func (s *EventDrivenQuestSystem) Stop() {
 	}
 	close(s.stopCh)
 	s.running = false
-	log.Println("Event-driven quest system stopped")
+	zaplogrus.Info("Event-driven quest system stopped")
 }
 
 func (s *EventDrivenQuestSystem) eventLoop() {
@@ -180,7 +180,7 @@ func (s *EventDrivenQuestSystem) processEvent(event *QuestEvent) {
 
 		quest, err := s.engine.CreateQuest(definitionID, chatID)
 		if err != nil {
-			log.Printf("Failed to create quest from trigger %s: %v", triggerID, err)
+			zaplogrus.Warnf("Failed to create quest from trigger %s: %v", triggerID, err)
 			s.mu.Lock()
 			continue
 		}
@@ -190,7 +190,7 @@ func (s *EventDrivenQuestSystem) processEvent(event *QuestEvent) {
 		quest.Metadata["event_type"] = string(event.Type)
 		quest.Metadata["trigger_id"] = triggerID
 
-		log.Printf("Quest %s triggered by event %s (type: %s)", quest.ID, event.ID, event.Type)
+		zaplogrus.Infof("Quest %s triggered by event %s (type: %s)", quest.ID, event.ID, event.Type)
 
 		s.mu.Lock()
 	}

--- a/services/backend-api/internal/services/quest_event_triggers.go
+++ b/services/backend-api/internal/services/quest_event_triggers.go
@@ -1,10 +1,11 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"fmt"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 )
 
 type QuestEventType string

--- a/services/backend-api/internal/services/quest_event_triggers.go
+++ b/services/backend-api/internal/services/quest_event_triggers.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/services/quest_event_triggers.go
+++ b/services/backend-api/internal/services/quest_event_triggers.go
@@ -99,7 +99,7 @@ func (s *EventDrivenQuestSystem) EmitEvent(event *QuestEvent) {
 	select {
 	case s.events <- event:
 	default:
-		zaplogrus.Infof("Event queue full, dropping event: %s", event.ID)
+		zaplogrus.Warnf("Event queue full, dropping event: %s", event.ID)
 	}
 }
 

--- a/services/backend-api/internal/services/quest_event_triggers.go
+++ b/services/backend-api/internal/services/quest_event_triggers.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
+	"github.com/irfndi/neuratrade/internal/utils"
 
 	"github.com/irfndi/neuratrade/internal/ai/llm"
 	appautonomy "github.com/irfndi/neuratrade/internal/app/autonomy"
@@ -840,7 +841,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 
 	// Get user's preferred exchange from database or default to bitget
 	userExchange := h.getUserExchange(chatID)
-	zaplogrus.Infof("[SCALPING] Using exchange: %s for chat: %s", userExchange, chatID)
+	zaplogrus.Infof("[SCALPING] Using exchange: %s for chat: %s", userExchange, utils.MaskString(chatID, utils.DefaultMaskingConfig))
 	currentMode := h.resolveOperationalMode(chatID, quest)
 	isDryRun := currentMode != OpModeLive
 	ctx = WithOperationalMode(ctx, currentMode)

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/ai/llm"
 	appautonomy "github.com/irfndi/neuratrade/internal/app/autonomy"

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"log"
 	"math"
 	"os"

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -185,7 +186,7 @@ func (h *IntegratedQuestHandlers) SetDB(db *sql.DB) {
 	}
 	h.tradeJournalMu.Unlock()
 	if err := h.ensureTradeJournalSchema(); err != nil {
-		log.Printf("[SCALPING] Failed to initialize legacy trade journal schema: %v", err)
+		zaplogrus.Warnf("[SCALPING] Failed to initialize legacy trade journal schema: %v", err)
 	}
 }
 
@@ -301,7 +302,7 @@ func (h *IntegratedQuestHandlers) AutonomyCoordinator() *ScalpingAutonomyCoordin
 func (h *IntegratedQuestHandlers) SetAIScalping(llmClient llm.Client, skillRegistry *skill.Registry) {
 	ccxtSvc, ok := h.ccxtService.(ccxt.CCXTService)
 	if !ok {
-		log.Printf("[SCALPING] Warning: CCXT service does not support CCXTService interface for AI scalping")
+		zaplogrus.Warnf("[SCALPING] Warning: CCXT service does not support CCXTService interface for AI scalping")
 		return
 	}
 
@@ -325,7 +326,7 @@ func (h *IntegratedQuestHandlers) SetAIScalping(llmClient llm.Client, skillRegis
 	h.aiScalpingService = svc
 	h.aiScalpingMu.Unlock()
 	h.configureScalpingAutonomy()
-	log.Printf("[SCALPING] AI-driven scalping service initialized")
+	zaplogrus.Infof("[SCALPING] AI-driven scalping service initialized")
 }
 
 func (h *IntegratedQuestHandlers) SetShadowEvaluationCoordinator(coordinator *ShadowEvaluationCoordinator) {
@@ -653,7 +654,7 @@ func (h *IntegratedQuestHandlers) handleFundGrowthGoal(_ context.Context, quest 
 
 // handleMarketScanWithTA scans markets using technical analysis
 func (h *IntegratedQuestHandlers) handleMarketScanWithTA(ctx context.Context, quest *Quest) error {
-	log.Printf("Executing market scan with TA: %s", quest.Name)
+	zaplogrus.Infof("Executing market scan with TA: %s", quest.Name)
 
 	startTime := time.Now()
 	symbolsScanned := 0
@@ -689,13 +690,13 @@ func (h *IntegratedQuestHandlers) handleMarketScanWithTA(ctx context.Context, qu
 	quest.Checkpoint["scan_duration_ms"] = time.Since(startTime).Milliseconds()
 	quest.Checkpoint["chat_id"] = chatID
 
-	log.Printf("Market scan complete: scanned %d symbols, %d with strong signals", symbolsScanned, symbolsWithSignals)
+	zaplogrus.Infof("Market scan complete: scanned %d symbols, %d with strong signals", symbolsScanned, symbolsWithSignals)
 	return nil
 }
 
 // handleFundingRateScan scans funding rates for arbitrage
 func (h *IntegratedQuestHandlers) handleFundingRateScan(ctx context.Context, quest *Quest) error {
-	log.Printf("Executing funding rate scan: %s", quest.Name)
+	zaplogrus.Infof("Executing funding rate scan: %s", quest.Name)
 
 	startTime := time.Now()
 	ratesCollected := 0
@@ -728,13 +729,13 @@ func (h *IntegratedQuestHandlers) handleFundingRateScan(ctx context.Context, que
 	quest.Checkpoint["scan_duration_ms"] = time.Since(startTime).Milliseconds()
 	quest.Checkpoint["chat_id"] = chatID
 
-	log.Printf("Funding rate scan complete: %d exchanges, %d rates", len(exchanges), ratesCollected)
+	zaplogrus.Infof("Funding rate scan complete: %d exchanges, %d rates", len(exchanges), ratesCollected)
 	return nil
 }
 
 // handlePortfolioHealthWithRisk checks portfolio health with risk management
 func (h *IntegratedQuestHandlers) handlePortfolioHealthWithRisk(ctx context.Context, quest *Quest) error {
-	log.Printf("Executing portfolio health check with risk: %s", quest.Name)
+	zaplogrus.Infof("Executing portfolio health check with risk: %s", quest.Name)
 
 	startTime := time.Now()
 
@@ -780,13 +781,13 @@ func (h *IntegratedQuestHandlers) handlePortfolioHealthWithRisk(ctx context.Cont
 	quest.Checkpoint["check_duration_ms"] = time.Since(startTime).Milliseconds()
 	quest.Checkpoint["chat_id"] = chatID
 
-	log.Printf("Portfolio health check complete: status=%s, checks=%d/%d passed", healthStatus, checksPassed, checksPassed+checksFailed)
+	zaplogrus.Warnf("Portfolio health check complete: status=%s, checks=%d/%d passed", healthStatus, checksPassed, checksPassed+checksFailed)
 	return nil
 }
 
 // handleScalpingExecution executes scalping trades using integrated services
 func (h *IntegratedQuestHandlers) handleScalpingExecution(ctx context.Context, quest *Quest) error {
-	log.Printf("[SCALPING] === START AI-DRIVEN SCALPING QUEST ===")
+	zaplogrus.Infof("[SCALPING] === START AI-DRIVEN SCALPING QUEST ===")
 
 	if quest.Checkpoint == nil {
 		quest.Checkpoint = make(map[string]interface{})
@@ -801,7 +802,7 @@ func (h *IntegratedQuestHandlers) handleScalpingExecution(ctx context.Context, q
 		return h.executeAIScalping(ctx, quest, chatID, aiSvc)
 	}
 
-	log.Printf("[SCALPING] AI scalping service not available, using fallback")
+	zaplogrus.Warnf("[SCALPING] AI scalping service not available, using fallback")
 	return h.executeFallbackScalping(ctx, quest, chatID)
 }
 
@@ -830,7 +831,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 	})
 	if !ok {
 		err := fmt.Errorf("CCXT service does not implement FetchBalance")
-		log.Printf("[SCALPING] ERROR: %v", err)
+		zaplogrus.Errorf("[SCALPING] ERROR: %v", err)
 		quest.Checkpoint["status"] = "balance_unavailable"
 		quest.Checkpoint["error"] = err.Error()
 		return err
@@ -838,7 +839,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 
 	// Get user's preferred exchange from database or default to bitget
 	userExchange := h.getUserExchange(chatID)
-	log.Printf("[SCALPING] Using exchange: %s for chat: %s", userExchange, chatID)
+	zaplogrus.Infof("[SCALPING] Using exchange: %s for chat: %s", userExchange, chatID)
 	currentMode := h.resolveOperationalMode(chatID, quest)
 	isDryRun := currentMode != OpModeLive
 	ctx = WithOperationalMode(ctx, currentMode)
@@ -854,7 +855,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		Exchange:   userExchange,
 	})
 	if err := h.syncScalpingStrategyMode(ctx, chatID, currentMode); err != nil {
-		log.Printf("[SCALPING] Failed to sync rollout mode for chat %s (%s): %v", chatID, currentMode, err)
+		zaplogrus.Warnf("[SCALPING] Failed to sync rollout mode for chat %s (%s): %v", chatID, currentMode, err)
 		quest.Checkpoint["autonomy_mode_sync_error"] = err.Error()
 		quest.Checkpoint["status"] = "hold"
 		quest.Checkpoint["runtime_entry_gate_reason"] = "failed to synchronize scalping rollout mode"
@@ -865,7 +866,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 	if h.protectionManager != nil {
 		protectionSummary, protectErr := h.protectionManager.ReconcileOpenPositions(ctx, chatID, userExchange)
 		if protectErr != nil {
-			log.Printf("[SCALPING] Dynamic protection reconciliation failed: %v", protectErr)
+			zaplogrus.Warnf("[SCALPING] Dynamic protection reconciliation failed: %v", protectErr)
 			quest.Checkpoint["protection_reconcile_error"] = protectErr.Error()
 		} else {
 			quest.Checkpoint["protection_positions_evaluated"] = protectionSummary.PositionsEvaluated
@@ -874,7 +875,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			quest.Checkpoint["protection_missing_recovered"] = protectionSummary.RecoveredProtection
 			quest.Checkpoint["protection_errors"] = protectionSummary.Errors
 			if protectionSummary.ProtectionsUpdated > 0 {
-				log.Printf(
+				zaplogrus.Infof(
 					"[SCALPING] Dynamic protection updates applied: positions=%d updates=%d",
 					protectionSummary.PositionsEvaluated,
 					protectionSummary.ProtectionsUpdated,
@@ -897,7 +898,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 	// In dry-run mode, use virtual balance instead of requiring real exchange API keys
 	if isDryRun {
 		usdtBalance = 1000.0 // Virtual balance for paper trading
-		log.Printf("[SCALPING] DRY-RUN MODE: Using virtual balance of %.2f USDT", usdtBalance)
+		zaplogrus.Infof("[SCALPING] DRY-RUN MODE: Using virtual balance of %.2f USDT", usdtBalance)
 		quest.Checkpoint["dry_run"] = true
 		quest.Checkpoint["virtual_balance"] = usdtBalance
 	} else {
@@ -907,7 +908,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 
 		balanceSnapshot, err = balanceFetcher.FetchBalance(balanceCtx, userExchange)
 		if err != nil {
-			log.Printf("[SCALPING] Failed to fetch balance from %s: %v, skipping this cycle", userExchange, err)
+			zaplogrus.Warnf("[SCALPING] Failed to fetch balance from %s: %v, skipping this cycle", userExchange, err)
 			quest.Checkpoint["balance_warning"] = err.Error()
 			quest.Checkpoint["status"] = "hold"
 			return nil
@@ -917,13 +918,13 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			quest.Checkpoint["wallet_basis_source"] = resolveScalpingWalletBasisSource(balanceSnapshot)
 			quest.Checkpoint["wallet_basis_usdt"] = usdtBalance
 			if strings.HasPrefix(checkpointString(quest.Checkpoint["wallet_basis_source"]), "summary:") {
-				log.Printf("[SCALPING] Futures wallet basis for %s is summary-only; available funds unknown, skipping this cycle", userExchange)
+				zaplogrus.Warnf("[SCALPING] Futures wallet basis for %s is summary-only; available funds unknown, skipping this cycle", userExchange)
 				quest.Checkpoint["balance_warning"] = "summary-only futures wallet balance lacks free-funds breakdown"
 				quest.Checkpoint["status"] = "hold"
 				return nil
 			}
 			if usdtBalance <= 0 {
-				log.Printf("[SCALPING] USDT balance is zero, using minimum balance for trading")
+				zaplogrus.Infof("[SCALPING] USDT balance is zero, using minimum balance for trading")
 				usdtBalance = 100.0 // Minimum balance
 				usingFallbackBalance = true
 				quest.Checkpoint["fallback_balance"] = true
@@ -936,7 +937,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			spotClosed, spotErr := h.autoDeriskSpotInventory(ctx, quest, chatID, userExchange, balanceSnapshot)
 			quest.Checkpoint["spot_unwind_checked_at"] = time.Now().UTC().Format(time.RFC3339)
 			if spotErr != nil {
-				log.Printf("[SCALPING] Spot unwind pass failed: %v", spotErr)
+				zaplogrus.Warnf("[SCALPING] Spot unwind pass failed: %v", spotErr)
 				quest.Checkpoint["spot_unwind_error"] = spotErr.Error()
 			} else if spotClosed > 0 {
 				quest.Checkpoint["spot_unwind_closed_positions"] = spotClosed
@@ -960,7 +961,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		} else {
 			deriskClosed, exposureRatio, guardErr := h.autoDeriskIfExposureTooHigh(ctx, quest, chatID, userExchange, usdtBalance)
 			if guardErr != nil {
-				log.Printf("[SCALPING] Exposure guard check failed: %v", guardErr)
+				zaplogrus.Warnf("[SCALPING] Exposure guard check failed: %v", guardErr)
 				quest.Checkpoint["exposure_guard_error"] = guardErr.Error()
 			} else {
 				quest.Checkpoint["exposure_ratio"] = fmt.Sprintf("%.4f", exposureRatio)
@@ -985,7 +986,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 
 	driftState, driftErr := h.refreshStateDriftGate(ctx, quest, chatID, userExchange)
 	if driftErr != nil {
-		log.Printf("[SCALPING] State drift refresh failed: %v", driftErr)
+		zaplogrus.Warnf("[SCALPING] State drift refresh failed: %v", driftErr)
 		quest.Checkpoint["state_drift_error"] = driftErr.Error()
 	}
 	quest.Checkpoint["state_drift_active"] = driftState.Active
@@ -1023,12 +1024,12 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 	}
 	h.recordScalpingPortfolioSnapshot(ctx, chatID, userExchange, portfolio)
 
-	log.Printf("[SCALPING] Portfolio: %.2f USDT available", usdtBalance)
+	zaplogrus.Infof("[SCALPING] Portfolio: %.2f USDT available", usdtBalance)
 
 	if currentMode == ModePaper {
 		paperClosed, paperCloseErr := h.closeTriggeredPaperScalpingPositions(ctx, quest, chatID, userExchange)
 		if paperCloseErr != nil {
-			log.Printf("[SCALPING] Paper close check failed: %v", paperCloseErr)
+			zaplogrus.Warnf("[SCALPING] Paper close check failed: %v", paperCloseErr)
 			quest.Checkpoint["paper_close_error"] = paperCloseErr.Error()
 		} else if paperClosed > 0 {
 			quest.Checkpoint["status"] = "paper_close"
@@ -1050,7 +1051,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 	if !isDryRun {
 		timeStopClosed, timeStopErr := h.enforceAdaptiveTimeStop(ctx, quest, chatID, userExchange, portfolio.StrategyPhase)
 		if timeStopErr != nil {
-			log.Printf("[SCALPING] Adaptive time-stop check failed: %v", timeStopErr)
+			zaplogrus.Warnf("[SCALPING] Adaptive time-stop check failed: %v", timeStopErr)
 			quest.Checkpoint["time_stop_error"] = timeStopErr.Error()
 		} else if timeStopClosed > 0 {
 			quest.Checkpoint["status"] = "risk_reduction"
@@ -1076,7 +1077,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		h.updateHoldStateCheckpoint(quest, true)
 		unlockClosed, unlockErr := h.maybeApplyRiskUnlock(gateCtx, quest, chatID, userExchange, portfolio.RiskDrawdown)
 		if unlockErr != nil {
-			log.Printf("[SCALPING] Risk unlock check failed during risk lock: %v", unlockErr)
+			zaplogrus.Warnf("[SCALPING] Risk unlock check failed during risk lock: %v", unlockErr)
 			quest.Checkpoint["risk_unlock_error"] = unlockErr.Error()
 		}
 
@@ -1265,7 +1266,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		}
 		unlockClosed, unlockErr := h.maybeApplyRiskUnlock(gateCtx, quest, chatID, userExchange, portfolio.RiskDrawdown)
 		if unlockErr != nil {
-			log.Printf("[SCALPING] Risk unlock check failed during derisk-only mode: %v", unlockErr)
+			zaplogrus.Warnf("[SCALPING] Risk unlock check failed during derisk-only mode: %v", unlockErr)
 			quest.Checkpoint["risk_unlock_error"] = unlockErr.Error()
 		} else if unlockClosed > 0 {
 			reasons = append(reasons, fmt.Sprintf("Risk unlock trimmed %d position(s) by 35%%", unlockClosed))
@@ -1425,12 +1426,12 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		if decision != nil {
 			rejectionJSON, marshalErr := json.Marshal(decision.CandidateFunnel.RejectionCounts)
 			if marshalErr != nil {
-				log.Printf("[TELEMETRY] Failed to marshal rejection counts: %v", marshalErr)
+				zaplogrus.Warnf("[TELEMETRY] Failed to marshal rejection counts: %v", marshalErr)
 				rejectionJSON = []byte("{}")
 			}
 			policyJSON, marshalErr := json.Marshal(decision.PolicyAdjustments)
 			if marshalErr != nil {
-				log.Printf("[TELEMETRY] Failed to marshal policy adjustments: %v", marshalErr)
+				zaplogrus.Warnf("[TELEMETRY] Failed to marshal policy adjustments: %v", marshalErr)
 				policyJSON = []byte("[]")
 			}
 			gateBlockCode := ""
@@ -1461,7 +1462,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		persistedCycleID, insertErr := h.telemetryStore.InsertCycleRecord(writeCtx, cycleRec)
 		writeCancel()
 		if insertErr != nil {
-			log.Printf("[TELEMETRY] Failed to insert cycle record: %v", insertErr)
+			zaplogrus.Warnf("[TELEMETRY] Failed to insert cycle record: %v", insertErr)
 		} else {
 			if strings.TrimSpace(persistedCycleID) != "" {
 				cycleID = strings.TrimSpace(persistedCycleID)
@@ -1474,13 +1475,13 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 	}
 	if err != nil {
 		h.updateRecoveryCleanCycles(quest, false, "runtime_error")
-		log.Printf("[SCALPING] AI decision error: %v", err)
+		zaplogrus.Infof("[SCALPING] AI decision error: %v", err)
 		reasonCategory := classifyAIRuntimeReason(err.Error(), aiReasonExecutionUnavailable)
 		deriskClosed := 0
 		if strings.Contains(strings.ToLower(err.Error()), "portfolio safety blocked") {
 			closed, deriskErr := h.autoDeriskBlockedExposure(ctx, quest, chatID, userExchange, err.Error())
 			if deriskErr != nil {
-				log.Printf("[SCALPING] Auto de-risk attempt failed: %v", deriskErr)
+				zaplogrus.Warnf("[SCALPING] Auto de-risk attempt failed: %v", deriskErr)
 				quest.Checkpoint["auto_derisk_error"] = deriskErr.Error()
 			} else if closed > 0 {
 				deriskClosed = closed
@@ -1517,7 +1518,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 	// Safety check: decision should not be nil
 	if decision == nil {
 		h.updateRecoveryCleanCycles(quest, false, "decision_nil")
-		log.Printf("[SCALPING] AI returned nil decision - treating as hold")
+		zaplogrus.Infof("[SCALPING] AI returned nil decision - treating as hold")
 		streak, cooldown := h.recordScalpingFailure(quest, "decision payload was nil")
 		quest.Checkpoint["status"] = "hold"
 		quest.Checkpoint["ai_action"] = "hold"
@@ -1550,7 +1551,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		h.updateHoldStateCheckpoint(quest, true)
 		unlockClosed, unlockErr := h.maybeApplyRiskUnlock(ctx, quest, chatID, userExchange, portfolio.RiskDrawdown)
 		if unlockErr != nil {
-			log.Printf("[SCALPING] Risk unlock check failed: %v", unlockErr)
+			zaplogrus.Warnf("[SCALPING] Risk unlock check failed: %v", unlockErr)
 			quest.Checkpoint["risk_unlock_error"] = unlockErr.Error()
 		}
 
@@ -1590,7 +1591,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 			h.resetScalpingFailureState(quest)
 			recordAIRuntimeEvent(quest, time.Now().UTC(), reasonCategory, true, h.getAIScalpingRuntimeSnapshot())
 		}
-		log.Printf("[SCALPING] AI decided to hold: %s", decision.Reasoning)
+		zaplogrus.Infof("[SCALPING] AI decided to hold: %s", decision.Reasoning)
 		quest.Checkpoint["status"] = "hold"
 		reasons := []string{decision.Reasoning}
 		if unlockClosed > 0 {
@@ -1679,7 +1680,7 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		h.assertPostEntryProtectionAsync(chatID, userExchange, decision.OrderID, decision.Symbol, decision.Action)
 	}
 
-	log.Printf("[SCALPING] AI decision executed: %s %s (%.0f%% confidence)",
+	zaplogrus.Infof("[SCALPING] AI decision executed: %s %s (%.0f%% confidence)",
 		decision.Action, decision.Symbol, decision.Confidence*100)
 
 	if currentMode == OpModeLive {
@@ -1729,12 +1730,12 @@ func (h *IntegratedQuestHandlers) persistScalpingExecutionLifecycle(
 			}); ok {
 				if ticker, err := tickerSource.FetchSingleTicker(ctx, userExchange, decision.Symbol); err == nil && ticker != nil && ticker.GetPrice() > 0 {
 					entryPrice = decimal.NewFromFloat(ticker.GetPrice())
-					log.Printf("[SCALPING] Fetched fallback entry price for %s: %s", decision.Symbol, entryPrice.String())
+					zaplogrus.Warnf("[SCALPING] Fetched fallback entry price for %s: %s", decision.Symbol, entryPrice.String())
 				}
 			}
 		}
 		if entryPrice.LessThanOrEqual(decimal.Zero) {
-			log.Printf("[SCALPING] SKIPPING lifecycle persistence for %s: entry price is zero (cannot calculate PnL or TP/SL)", decision.Symbol)
+			zaplogrus.Warnf("[SCALPING] SKIPPING lifecycle persistence for %s: entry price is zero (cannot calculate PnL or TP/SL)", decision.Symbol)
 		} else {
 			// Auto-derive SL/TP from entry price if AI didn't provide them
 			stopLoss := decimalValueOrZero(decision.StopLoss)
@@ -1746,7 +1747,7 @@ func (h *IntegratedQuestHandlers) persistScalpingExecutionLifecycle(
 				} else {
 					stopLoss = entryPrice.Mul(decimal.NewFromInt(1).Add(slPct))
 				}
-				log.Printf("[SCALPING] Auto-derived stop-loss for %s at %s (entry=%s)", decision.Symbol, stopLoss.String(), entryPrice.String())
+				zaplogrus.Infof("[SCALPING] Auto-derived stop-loss for %s at %s (entry=%s)", decision.Symbol, stopLoss.String(), entryPrice.String())
 			}
 			if takeProfit.LessThanOrEqual(decimal.Zero) {
 				tpPct := decimal.NewFromFloat(0.002) // 0.2% default scalping TP
@@ -1755,7 +1756,7 @@ func (h *IntegratedQuestHandlers) persistScalpingExecutionLifecycle(
 				} else {
 					takeProfit = entryPrice.Mul(decimal.NewFromInt(1).Sub(tpPct))
 				}
-				log.Printf("[SCALPING] Auto-derived take-profit for %s at %s (entry=%s)", decision.Symbol, takeProfit.String(), entryPrice.String())
+				zaplogrus.Infof("[SCALPING] Auto-derived take-profit for %s at %s (entry=%s)", decision.Symbol, takeProfit.String(), entryPrice.String())
 			}
 			if err := h.lifecycleStore.RecordOrderExecution(ctx, LifecycleExecutionRecord{
 				OrderID:    decision.OrderID,
@@ -1772,7 +1773,7 @@ func (h *IntegratedQuestHandlers) persistScalpingExecutionLifecycle(
 				Source:     scalpingExecutionLifecycleSource(currentMode),
 				OpenedAt:   time.Now().UTC(),
 			}); err != nil {
-				log.Printf("[SCALPING] Failed to persist execution lifecycle for %s: %v", decision.OrderID, err)
+				zaplogrus.Warnf("[SCALPING] Failed to persist execution lifecycle for %s: %v", decision.OrderID, err)
 			} else {
 				lifecyclePersisted = true
 			}
@@ -1789,7 +1790,7 @@ func (h *IntegratedQuestHandlers) persistScalpingExecutionLifecycle(
 	err := h.telemetryStore.LinkOrderToCycle(writeCtx, cycleID, strings.TrimSpace(decision.OrderID))
 	writeCancel()
 	if err != nil {
-		log.Printf("[TELEMETRY] Failed to link order %s to cycle: %v", decision.OrderID, err)
+		zaplogrus.Warnf("[TELEMETRY] Failed to link order %s to cycle: %v", decision.OrderID, err)
 	}
 }
 
@@ -1877,12 +1878,12 @@ func (h *IntegratedQuestHandlers) autoDeriskBlockedExposure(
 		}
 		placeCancel()
 		if placeErr != nil {
-			log.Printf("[SCALPING] Auto de-risk failed for %s %s: %v", pos.Symbol, pos.Side, placeErr)
+			zaplogrus.Warnf("[SCALPING] Auto de-risk failed for %s %s: %v", pos.Symbol, pos.Side, placeErr)
 			continue
 		}
 
 		closed++
-		log.Printf("[SCALPING] Auto de-risk order placed: close %s %s (size=%s, notional=%s)", pos.Side, pos.Symbol, size.String(), notional.StringFixed(4))
+		zaplogrus.Infof("[SCALPING] Auto de-risk order placed: close %s %s (size=%s, notional=%s)", pos.Side, pos.Symbol, size.String(), notional.StringFixed(4))
 	}
 
 	if closed > 0 {
@@ -2094,12 +2095,12 @@ func (h *IntegratedQuestHandlers) autoDeriskSpotInventory(
 		}
 		cancel()
 		if placeErr != nil {
-			log.Printf("[SCALPING] Spot unwind failed for %s on %s: %v", symbol, exchange, placeErr)
+			zaplogrus.Warnf("[SCALPING] Spot unwind failed for %s on %s: %v", symbol, exchange, placeErr)
 			continue
 		}
 
 		closed++
-		log.Printf("[SCALPING] Spot unwind order placed: sell %s (notional=%s, chat=%s)", symbol, notional.StringFixed(4), chatID)
+		zaplogrus.Infof("[SCALPING] Spot unwind order placed: sell %s (notional=%s, chat=%s)", symbol, notional.StringFixed(4), chatID)
 	}
 
 	if closed > 0 && quest != nil {
@@ -2602,7 +2603,7 @@ func (h *IntegratedQuestHandlers) enrichPortfolioControlPlane(
 		if cleaned, err := h.lifecycleStore.CloseClosedOrderBackedGhostPositions(ctx, chatID, exchange); err == nil {
 			ghostCleaned = cleaned
 		} else {
-			log.Printf("[SCALPING] Ghost lifecycle cleanup failed for chat %s exchange %s: %v", chatID, exchange, err)
+			zaplogrus.Warnf("[SCALPING] Ghost lifecycle cleanup failed for chat %s exchange %s: %v", chatID, exchange, err)
 		}
 		positions, err := h.lifecycleStore.ListManagedOpenPositions(ctx, chatID, exchange, 100)
 		if err == nil {
@@ -2694,13 +2695,13 @@ func (h *IntegratedQuestHandlers) enrichPortfolioControlPlane(
 		peakValue := decimal.NewFromFloat(peakEquity)
 		if state, exists := h.drawdownHalt.GetState(chatID); !exists || state.PeakValue.LessThan(peakValue) {
 			if err := h.drawdownHalt.ResetPeak(ctx, chatID, peakValue); err != nil {
-				log.Printf("[SCALPING] Drawdown halt peak reset failed for chat %s: %v", chatID, err)
+				zaplogrus.Warnf("[SCALPING] Drawdown halt peak reset failed for chat %s: %v", chatID, err)
 			}
 		}
 		marketValue := decimal.NewFromFloat(rawEquity)
 		state, err := h.drawdownHalt.CheckDrawdown(ctx, chatID, marketValue)
 		if err != nil {
-			log.Printf("[SCALPING] Drawdown halt check failed for chat %s: %v", chatID, err)
+			zaplogrus.Warnf("[SCALPING] Drawdown halt check failed for chat %s: %v", chatID, err)
 		} else if state != nil {
 			portfolio.CurrentDrawdown = state.CurrentDrawdown.InexactFloat64()
 			if portfolio.CurrentDrawdown < 0 {
@@ -2812,7 +2813,7 @@ func (h *IntegratedQuestHandlers) recordScalpingPortfolioSnapshot(
 		NoFillMinutes:           finiteDecimalFromFloat(portfolio.NoFillMinutes),
 	})
 	if err != nil {
-		log.Printf("[SCALPING] Portfolio snapshot persist failed for chat %s exchange %s: %v", chatID, exchange, err)
+		zaplogrus.Warnf("[SCALPING] Portfolio snapshot persist failed for chat %s exchange %s: %v", chatID, exchange, err)
 	}
 }
 
@@ -2841,7 +2842,7 @@ func (h *IntegratedQuestHandlers) recordScalpingGateCycle(
 	rejectionJSON := "{}"
 	policyJSON, marshalErr := json.Marshal([]string{gateBlockCode})
 	if marshalErr != nil {
-		log.Printf("[TELEMETRY] Failed to marshal gate policy adjustments: %v", marshalErr)
+		zaplogrus.Warnf("[TELEMETRY] Failed to marshal gate policy adjustments: %v", marshalErr)
 		policyJSON = []byte("[]")
 	}
 	cycleRec := CycleRecord{
@@ -2867,7 +2868,7 @@ func (h *IntegratedQuestHandlers) recordScalpingGateCycle(
 	writeCtx, writeCancel := withBoundedTimeoutContext(baseCtx, 2*time.Second)
 	defer writeCancel()
 	if _, err := h.telemetryStore.InsertCycleRecord(writeCtx, cycleRec); err != nil {
-		log.Printf("[TELEMETRY] Failed to insert gated scalping cycle: %v", err)
+		zaplogrus.Warnf("[TELEMETRY] Failed to insert gated scalping cycle: %v", err)
 	}
 }
 
@@ -2919,7 +2920,7 @@ func oppositeCloseSide(positionSide string) string {
 }
 
 func (h *IntegratedQuestHandlers) executeFallbackScalping(ctx context.Context, quest *Quest, chatID string) error {
-	log.Printf("[SCALPING] AI scalping service unavailable; static fallback execution disabled")
+	zaplogrus.Warnf("[SCALPING] AI scalping service unavailable; static fallback execution disabled")
 	quest.Checkpoint["status"] = "ai_unavailable_hold"
 	quest.Checkpoint["fallback_mode"] = "observe_only"
 	quest.Checkpoint["note"] = "No rule-based orders are placed when AI service is unavailable"
@@ -2947,7 +2948,7 @@ func (h *IntegratedQuestHandlers) executeFallbackScalping(ctx context.Context, q
 }
 
 func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, quest *Quest) error {
-	log.Printf("[ARBITRAGE] Executing arbitrage quest: %s", quest.Name)
+	zaplogrus.Infof("[ARBITRAGE] Executing arbitrage quest: %s", quest.Name)
 
 	if quest.Checkpoint == nil {
 		quest.Checkpoint = make(map[string]interface{})
@@ -2955,7 +2956,7 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 
 	if h.ccxtService == nil {
 		err := fmt.Errorf("CCXT service not available for arbitrage")
-		log.Printf("[ARBITRAGE] ERROR: %v", err)
+		zaplogrus.Errorf("[ARBITRAGE] ERROR: %v", err)
 		quest.Checkpoint["status"] = "ccxt_unavailable"
 		quest.Checkpoint["error"] = err.Error()
 		return err
@@ -2970,7 +2971,7 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 	symbol, ok := quest.Checkpoint["symbol"].(string)
 	if !ok {
 		err := fmt.Errorf("symbol not found in arbitrage quest checkpoint")
-		log.Printf("[ARBITRAGE] ERROR: %v", err)
+		zaplogrus.Errorf("[ARBITRAGE] ERROR: %v", err)
 		quest.Checkpoint["error"] = err.Error()
 		return err
 	}
@@ -2978,7 +2979,7 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 	buyExchange, ok := quest.Checkpoint["buy_exchange"].(string)
 	if !ok {
 		err := fmt.Errorf("buy exchange not found in arbitrage quest checkpoint")
-		log.Printf("[ARBITRAGE] ERROR: %v", err)
+		zaplogrus.Errorf("[ARBITRAGE] ERROR: %v", err)
 		quest.Checkpoint["error"] = err.Error()
 		return err
 	}
@@ -2986,7 +2987,7 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 	sellExchange, ok := quest.Checkpoint["sell_exchange"].(string)
 	if !ok {
 		err := fmt.Errorf("sell exchange not found in arbitrage quest checkpoint")
-		log.Printf("[ARBITRAGE] ERROR: %v", err)
+		zaplogrus.Errorf("[ARBITRAGE] ERROR: %v", err)
 		quest.Checkpoint["error"] = err.Error()
 		return err
 	}
@@ -2994,7 +2995,7 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 	buyPriceStr, ok := quest.Checkpoint["buy_price"].(string)
 	if !ok {
 		err := fmt.Errorf("buy price not found in arbitrage quest checkpoint")
-		log.Printf("[ARBITRAGE] ERROR: %v", err)
+		zaplogrus.Errorf("[ARBITRAGE] ERROR: %v", err)
 		quest.Checkpoint["error"] = err.Error()
 		return err
 	}
@@ -3002,7 +3003,7 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 	sellPriceStr, ok := quest.Checkpoint["sell_price"].(string)
 	if !ok {
 		err := fmt.Errorf("sell price not found in arbitrage quest checkpoint")
-		log.Printf("[ARBITRAGE] ERROR: %v", err)
+		zaplogrus.Errorf("[ARBITRAGE] ERROR: %v", err)
 		quest.Checkpoint["error"] = err.Error()
 		return err
 	}
@@ -3010,7 +3011,7 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 	buyPrice, err := decimal.NewFromString(buyPriceStr)
 	if err != nil {
 		err := fmt.Errorf("invalid buy price format: %v", err)
-		log.Printf("[ARBITRAGE] ERROR: %v", err)
+		zaplogrus.Errorf("[ARBITRAGE] ERROR: %v", err)
 		quest.Checkpoint["error"] = err.Error()
 		return err
 	}
@@ -3018,7 +3019,7 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 	sellPrice, err := decimal.NewFromString(sellPriceStr)
 	if err != nil {
 		err := fmt.Errorf("invalid sell price format: %v", err)
-		log.Printf("[ARBITRAGE] ERROR: %v", err)
+		zaplogrus.Errorf("[ARBITRAGE] ERROR: %v", err)
 		quest.Checkpoint["error"] = err.Error()
 		return err
 	}
@@ -3027,19 +3028,19 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 	profitPctStr, ok := quest.Checkpoint["profit_pct"].(string)
 	if !ok {
 		err := fmt.Errorf("profit percentage not found in arbitrage quest checkpoint")
-		log.Printf("[ARBITRAGE] ERROR: %v", err)
+		zaplogrus.Errorf("[ARBITRAGE] ERROR: %v", err)
 		quest.Checkpoint["error"] = err.Error()
 		return err
 	}
 	profitPct, err := decimal.NewFromString(profitPctStr)
 	if err != nil {
 		err := fmt.Errorf("invalid profit percentage format: %v", err)
-		log.Printf("[ARBITRAGE] ERROR: %v", err)
+		zaplogrus.Errorf("[ARBITRAGE] ERROR: %v", err)
 		quest.Checkpoint["error"] = err.Error()
 		return err
 	}
 
-	log.Printf("[ARBITRAGE] Opportunity: %s - Buy on %s at %.4f, Sell on %s at %.4f, Profit: %.2f%%",
+	zaplogrus.Infof("[ARBITRAGE] Opportunity: %s - Buy on %s at %.4f, Sell on %s at %.4f, Profit: %.2f%%",
 		symbol, buyExchange, buyPrice.InexactFloat64(), sellExchange, sellPrice.InexactFloat64(), profitPct.InexactFloat64())
 
 	// Check if we have an order executor for arbitrage trades
@@ -3048,39 +3049,39 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 		// First, buy on the cheaper exchange
 		amount := decimal.NewFromFloat(10.0) // Use a conservative amount for testing
 
-		log.Printf("[ARBITRAGE] Placing BUY order: %s on %s at %.4f, amount: %.2f",
+		zaplogrus.Infof("[ARBITRAGE] Placing BUY order: %s on %s at %.4f, amount: %.2f",
 			symbol, buyExchange, buyPrice.InexactFloat64(), amount.InexactFloat64())
 
 		// Place buy order
 		buyOrderID, err := h.orderExecutor.PlaceOrder(ctx, buyExchange, symbol, "buy", "market", amount, &buyPrice)
 		if err != nil {
-			log.Printf("[ARBITRAGE] BUY ORDER FAILED: %v", err)
+			zaplogrus.Errorf("[ARBITRAGE] BUY ORDER FAILED: %v", err)
 			quest.Checkpoint["buy_execution_error"] = err.Error()
 			quest.Checkpoint["buy_execution_status"] = "failed"
 			return fmt.Errorf("buy order execution failed: %w", err)
 		}
 
-		log.Printf("[ARBITRAGE] BUY ORDER PLACED: %s %s %s, orderID: %s", "buy", buyExchange, symbol, buyOrderID)
+		zaplogrus.Infof("[ARBITRAGE] BUY ORDER PLACED: %s %s %s, orderID: %s", "buy", buyExchange, symbol, buyOrderID)
 		quest.Checkpoint["buy_order_id"] = buyOrderID
 		quest.Checkpoint["buy_execution_status"] = "placed"
 
 		// Then, sell on the more expensive exchange
-		log.Printf("[ARBITRAGE] Placing SELL order: %s on %s at %.4f, amount: %.2f",
+		zaplogrus.Infof("[ARBITRAGE] Placing SELL order: %s on %s at %.4f, amount: %.2f",
 			symbol, sellExchange, sellPrice.InexactFloat64(), amount.InexactFloat64())
 
 		sellOrderID, err := h.orderExecutor.PlaceOrder(ctx, sellExchange, symbol, "sell", "market", amount, &sellPrice)
 		if err != nil {
-			log.Printf("[ARBITRAGE] SELL ORDER FAILED: %v", err)
+			zaplogrus.Errorf("[ARBITRAGE] SELL ORDER FAILED: %v", err)
 			quest.Checkpoint["sell_execution_error"] = err.Error()
 			quest.Checkpoint["sell_execution_status"] = "failed"
 			return fmt.Errorf("sell order execution failed: %w", err)
 		}
 
-		log.Printf("[ARBITRAGE] SELL ORDER PLACED: %s %s %s, orderID: %s", "sell", sellExchange, symbol, sellOrderID)
+		zaplogrus.Infof("[ARBITRAGE] SELL ORDER PLACED: %s %s %s, orderID: %s", "sell", sellExchange, symbol, sellOrderID)
 		quest.Checkpoint["sell_order_id"] = sellOrderID
 		quest.Checkpoint["sell_execution_status"] = "placed"
 
-		log.Printf("[ARBITRAGE] ARBITRAGE EXECUTED: Buy %s on %s, Sell %s on %s, Expected profit: %s%%",
+		zaplogrus.Infof("[ARBITRAGE] ARBITRAGE EXECUTED: Buy %s on %s, Sell %s on %s, Expected profit: %s%%",
 			symbol, buyExchange, symbol, sellExchange, profitPct.String())
 
 		quest.Checkpoint["status"] = "executed_both_legs"
@@ -3093,7 +3094,7 @@ func (h *IntegratedQuestHandlers) handleArbitrageExecution(ctx context.Context, 
 		quest.Checkpoint["profit_percentage"] = profitPct.String()
 		quest.Checkpoint["amount"] = amount.String()
 	} else {
-		log.Printf("[ARBITRAGE] WARNING: Order executor not configured - arbitrage opportunity not executed")
+		zaplogrus.Warnf("[ARBITRAGE] WARNING: Order executor not configured - arbitrage opportunity not executed")
 		quest.Checkpoint["execution_status"] = "no_executor"
 		return fmt.Errorf("order executor not configured for arbitrage")
 	}
@@ -3280,7 +3281,7 @@ func (h *IntegratedQuestHandlers) notifyScalpingDecision(ctx context.Context, ch
 	}
 	notif = normalizeAINotificationSemantics(notif)
 	if !shouldSendScalpingDecisionNotification(notif) {
-		log.Printf(
+		zaplogrus.Infof(
 			"[NOTIFICATION] Suppressed non-actionable scalping update (type=%s action=%s)",
 			notif.DecisionType,
 			notif.Action,
@@ -3294,7 +3295,7 @@ func (h *IntegratedQuestHandlers) notifyScalpingDecision(ctx context.Context, ch
 	notifyCtx, cancelNotify := withBoundedTimeoutContext(ctx, questNotificationTimeout())
 	defer cancelNotify()
 	if err := h.notificationService.NotifyAIReasoning(notifyCtx, chatIDInt, notif); err != nil {
-		log.Printf("[NOTIFICATION] Failed to send scalping status notification: %v", err)
+		zaplogrus.Warnf("[NOTIFICATION] Failed to send scalping status notification: %v", err)
 	}
 }
 
@@ -3744,7 +3745,7 @@ func (h *IntegratedQuestHandlers) scopedScalpingPerformance(
 	defer cancel()
 	summary, err := h.lifecycleStore.GetRecentLossStreak(queryCtx, chatID, exchange, since)
 	if err != nil {
-		log.Printf(
+		zaplogrus.Infof(
 			"[SCALPING] Failed to read scoped recent loss streak (chat=%s exchange=%s): %v",
 			chatID,
 			exchange,
@@ -3949,7 +3950,7 @@ func (h *IntegratedQuestHandlers) assertPostEntryProtectionAsync(chatID, exchang
 
 			positions, err := h.lifecycleStore.ListManagedOpenPositions(ctx, chatID, exchange, 100)
 			if err != nil {
-				log.Printf("[SCALPING] Post-entry protection assertion failed to list positions: %v", err)
+				zaplogrus.Warnf("[SCALPING] Post-entry protection assertion failed to list positions: %v", err)
 				return
 			}
 			targets := filterManagedPositionsForEntryProtection(positions, orderID, symbol, side)
@@ -3963,7 +3964,7 @@ func (h *IntegratedQuestHandlers) assertPostEntryProtectionAsync(chatID, exchang
 			h.ensureDynamicProtectionManager()
 			if h.protectionManager != nil {
 				if _, err := h.protectionManager.ReconcileOpenPositions(ctx, chatID, exchange); err != nil {
-					log.Printf("[SCALPING] Post-entry protection reconcile warning: %v", err)
+					zaplogrus.Warnf("[SCALPING] Post-entry protection reconcile warning: %v", err)
 				}
 			}
 
@@ -3972,7 +3973,7 @@ func (h *IntegratedQuestHandlers) assertPostEntryProtectionAsync(chatID, exchang
 				for _, pos := range targets {
 					trimmed, trimErr := h.trimManagedPosition(ctx, pos, decimal.NewFromInt(1), "post_entry_protection_assertion")
 					if trimErr != nil {
-						log.Printf("[SCALPING] Post-entry protection forced close failed for %s: %v", pos.PositionID, trimErr)
+						zaplogrus.Warnf("[SCALPING] Post-entry protection forced close failed for %s: %v", pos.PositionID, trimErr)
 						continue
 					}
 					closed += trimmed
@@ -4061,7 +4062,7 @@ func allManagedPositionsProtected(positions []ManagedOpenPosition) bool {
 // Returns the first connected exchange, or "bitget" as default
 func (h *IntegratedQuestHandlers) getUserExchange(chatID string) string {
 	if h.db == nil {
-		log.Printf("[SCALPING] No database available, using default exchange: bitget")
+		zaplogrus.Infof("[SCALPING] No database available, using default exchange: bitget")
 		return "bitget"
 	}
 
@@ -4072,11 +4073,11 @@ func (h *IntegratedQuestHandlers) getUserExchange(chatID string) string {
 
 	err := h.db.QueryRow(query, chatID).Scan(&exchange)
 	if err != nil {
-		log.Printf("[SCALPING] No exchange found for chat %s, using default: bitget (%v)", chatID, err)
+		zaplogrus.Infof("[SCALPING] No exchange found for chat %s, using default: bitget (%v)", chatID, err)
 		return "bitget"
 	}
 
-	log.Printf("[SCALPING] Found user exchange: %s for chat: %s", exchange, chatID)
+	zaplogrus.Infof("[SCALPING] Found user exchange: %s for chat: %s", exchange, chatID)
 	return exchange
 }
 
@@ -4397,7 +4398,7 @@ func (h *IntegratedQuestHandlers) recordTradeDecision(
 			),
 		}
 		if err := h.tradeMemory.RecordDecision(ctx, record); err != nil {
-			log.Printf("[AI-MEMORY] Failed to record decision %s: %v", tradeID, err)
+			zaplogrus.Warnf("[AI-MEMORY] Failed to record decision %s: %v", tradeID, err)
 		}
 	}
 
@@ -4425,7 +4426,7 @@ func (h *IntegratedQuestHandlers) persistLegacyTradeEntry(
 		return
 	}
 	if err := h.ensureTradeJournalSchema(); err != nil {
-		log.Printf("[SCALPING] Legacy trade journal schema unavailable: %v", err)
+		zaplogrus.Warnf("[SCALPING] Legacy trade journal schema unavailable: %v", err)
 		return
 	}
 
@@ -4433,7 +4434,7 @@ func (h *IntegratedQuestHandlers) persistLegacyTradeEntry(
 	strategyID := ScalpingStrategyID(chatID)
 	side := normalizeLifecycleSide(decision.Action)
 	if side == "" {
-		log.Printf("[SCALPING] Skipping legacy trade journal entry %s with unsupported side %q", tradeID, decision.Action)
+		zaplogrus.Warnf("[SCALPING] Skipping legacy trade journal entry %s with unsupported side %q", tradeID, decision.Action)
 		return
 	}
 	entryPrice := decimal.Zero
@@ -4475,7 +4476,7 @@ func (h *IntegratedQuestHandlers) persistLegacyTradeEntry(
 		costBasis.InexactFloat64(),
 		now,
 	); err != nil {
-		log.Printf("[SCALPING] Failed to persist legacy trade journal entry %s: %v", tradeID, err)
+		zaplogrus.Warnf("[SCALPING] Failed to persist legacy trade journal entry %s: %v", tradeID, err)
 	}
 }
 
@@ -4598,7 +4599,7 @@ func (h *IntegratedQuestHandlers) persistLegacyTradeClose(
 		return
 	}
 	if err := h.ensureTradeJournalSchema(); err != nil {
-		log.Printf("[SCALPING] Legacy trade journal schema unavailable: %v", err)
+		zaplogrus.Warnf("[SCALPING] Legacy trade journal schema unavailable: %v", err)
 		return
 	}
 
@@ -4651,7 +4652,7 @@ func (h *IntegratedQuestHandlers) persistLegacyTradeClose(
 		closedAt,
 		closedAt,
 	); err != nil {
-		log.Printf("[SCALPING] Failed to persist legacy trade journal close %s: %v", orderID, err)
+		zaplogrus.Warnf("[SCALPING] Failed to persist legacy trade journal close %s: %v", orderID, err)
 	}
 }
 
@@ -4665,7 +4666,7 @@ func (h *IntegratedQuestHandlers) ingestClosedOrderFeedback(ctx context.Context,
 
 	closedOrders, err := h.orderExecutor.GetClosedOrders(ctx, exchange, symbol, 20)
 	if err != nil {
-		log.Printf("[SCALPING] Failed to fetch closed orders for feedback (%s %s): %v", exchange, symbol, err)
+		zaplogrus.Warnf("[SCALPING] Failed to fetch closed orders for feedback (%s %s): %v", exchange, symbol, err)
 		return
 	}
 
@@ -4680,7 +4681,7 @@ func (h *IntegratedQuestHandlers) ingestClosedOrderFeedback(ctx context.Context,
 	if h.lifecycleStore != nil {
 		positions, listErr := h.lifecycleStore.ListManagedOpenPositions(ctx, quest.Metadata["chat_id"], exchange, 200)
 		if listErr != nil {
-			log.Printf("[SCALPING] Failed to load managed open positions for closed-order filter (%s): %v", exchange, listErr)
+			zaplogrus.Warnf("[SCALPING] Failed to load managed open positions for closed-order filter (%s): %v", exchange, listErr)
 		} else {
 			for _, pos := range positions {
 				key := normalizeSymbolForComparison(pos.Symbol) + ":" + normalizeLifecycleSide(pos.Side)
@@ -4700,7 +4701,7 @@ func (h *IntegratedQuestHandlers) ingestClosedOrderFeedback(ctx context.Context,
 		pnl, ok := decimalFromOrder(order, "totalProfits", "totalProfit", "pnl", "profit", "realizedPnl", "achievedProfits")
 		if !ok {
 			quest.Checkpoint["closed_order_feedback_missing_pnl"] = checkpointInt(quest.Checkpoint["closed_order_feedback_missing_pnl"]) + 1
-			log.Printf("[SCALPING] Skipped closed-order feedback due to missing pnl: order=%s symbol=%s keys=%v",
+			zaplogrus.Warnf("[SCALPING] Skipped closed-order feedback due to missing pnl: order=%s symbol=%s keys=%v",
 				orderID,
 				symbol,
 				sortedOrderKeys(order),
@@ -4716,7 +4717,7 @@ func (h *IntegratedQuestHandlers) ingestClosedOrderFeedback(ctx context.Context,
 			processed[orderID] = true
 			updatedProcessed = true
 			quest.Checkpoint["closed_order_feedback_skipped_zero_pnl"] = checkpointInt(quest.Checkpoint["closed_order_feedback_skipped_zero_pnl"]) + 1
-			log.Printf("[SCALPING] Skipped closed-order feedback as probable entry fill: order=%s symbol=%s side=%s pnl=%s tradeSide=%s reduceOnly=%s",
+			zaplogrus.Warnf("[SCALPING] Skipped closed-order feedback as probable entry fill: order=%s symbol=%s side=%s pnl=%s tradeSide=%s reduceOnly=%s",
 				orderID,
 				symbol,
 				side,
@@ -4789,7 +4790,7 @@ func (h *IntegratedQuestHandlers) ingestClosedOrderFeedback(ctx context.Context,
 				outcome = "loss"
 			}
 			if err := h.tradeMemory.UpdateOutcome(ctx, orderID, outcome, exitPrice.InexactFloat64(), pnl); err != nil {
-				log.Printf("[AI-MEMORY] Failed to update outcome for %s: %v", orderID, err)
+				zaplogrus.Warnf("[AI-MEMORY] Failed to update outcome for %s: %v", orderID, err)
 			}
 		}
 
@@ -4819,7 +4820,7 @@ func (h *IntegratedQuestHandlers) ingestClosedOrderFeedback(ctx context.Context,
 				Source:      "exchange_reconciliation",
 				ClosedAt:    closedAt,
 			}); err != nil {
-				log.Printf("[SCALPING] Failed to persist closed-order lifecycle for %s: %v", orderID, err)
+				zaplogrus.Warnf("[SCALPING] Failed to persist closed-order lifecycle for %s: %v", orderID, err)
 			}
 		}
 		if h.telemetryStore != nil {
@@ -4857,7 +4858,7 @@ func (h *IntegratedQuestHandlers) ingestClosedOrderFeedback(ctx context.Context,
 			})
 			writeCancel()
 			if err != nil {
-				log.Printf("[TELEMETRY] Failed to update outcome for order %s: %v", orderID, err)
+				zaplogrus.Warnf("[TELEMETRY] Failed to update outcome for order %s: %v", orderID, err)
 			}
 		}
 	}
@@ -5198,14 +5199,14 @@ func (h *IntegratedQuestHandlers) bootstrapLifecycleState(ctx context.Context, q
 		snapshot.OpenOrders = openOrders.Orders
 		snapshot.OrdersFresh = true
 	} else if err != nil {
-		log.Printf("[SCALPING] Bootstrap open-order sync failed on %s: %v", exchange, err)
+		zaplogrus.Warnf("[SCALPING] Bootstrap open-order sync failed on %s: %v", exchange, err)
 	}
 
 	if positions, err := ccxtSvc.FetchPositions(bootstrapCtx, exchange); err == nil && positions != nil {
 		snapshot.Positions = positions.Positions
 		snapshot.PositionsFresh = true
 	} else if err != nil {
-		log.Printf("[SCALPING] Bootstrap position sync failed on %s: %v", exchange, err)
+		zaplogrus.Warnf("[SCALPING] Bootstrap position sync failed on %s: %v", exchange, err)
 	}
 
 	reconcileSummary, err := h.lifecycleStore.ReconcileExchangeSnapshot(
@@ -5216,7 +5217,7 @@ func (h *IntegratedQuestHandlers) bootstrapLifecycleState(ctx context.Context, q
 		"bootstrap_reconciliation",
 	)
 	if err != nil {
-		log.Printf("[SCALPING] Bootstrap lifecycle reconciliation failed on %s: %v", exchange, err)
+		zaplogrus.Warnf("[SCALPING] Bootstrap lifecycle reconciliation failed on %s: %v", exchange, err)
 		quest.Checkpoint["runtime_bootstrap_error"] = err.Error()
 	}
 
@@ -5229,12 +5230,12 @@ func (h *IntegratedQuestHandlers) bootstrapLifecycleState(ctx context.Context, q
 			"startup_drift_repair_exchange_missing",
 		)
 		if repairErr != nil {
-			log.Printf("[SCALPING] Startup drift repair failed on %s: %v", exchange, repairErr)
+			zaplogrus.Warnf("[SCALPING] Startup drift repair failed on %s: %v", exchange, repairErr)
 			quest.Checkpoint["runtime_startup_drift_repair_error"] = repairErr.Error()
 		} else if repaired > 0 {
 			quest.Checkpoint["runtime_startup_drift_repair_closed"] = repaired
 			quest.Checkpoint["state_drift_last_repair_at"] = time.Now().UTC().Format(time.RFC3339)
-			log.Printf("[SCALPING] Startup drift repair closed %d stale lifecycle position(s) on %s", repaired, exchange)
+			zaplogrus.Warnf("[SCALPING] Startup drift repair closed %d stale lifecycle position(s) on %s", repaired, exchange)
 		}
 	}
 
@@ -5760,7 +5761,7 @@ func (h *IntegratedQuestHandlers) trimManagedPosition(
 	}
 	now := time.Now().UTC()
 	if h.shouldSkipStalePositionRetry(position, now) {
-		log.Printf(
+		zaplogrus.Infof(
 			"[SCALPING] Skipping stale position retry due to cooldown: %s %s %s",
 			position.Exchange,
 			position.Symbol,
@@ -5820,7 +5821,7 @@ func (h *IntegratedQuestHandlers) trimManagedPosition(
 			if isExchangePositionMissingError(err) {
 				h.markStalePositionRetry(position, now)
 				if closeErr := h.reconcileMissingManagedPosition(ctx, position, source, err); closeErr != nil {
-					log.Printf("[SCALPING] Failed to close stale lifecycle row for %s: %v", position.PositionID, closeErr)
+					zaplogrus.Warnf("[SCALPING] Failed to close stale lifecycle row for %s: %v", position.PositionID, closeErr)
 				}
 				return 0, nil
 			}
@@ -5832,7 +5833,7 @@ func (h *IntegratedQuestHandlers) trimManagedPosition(
 		if isExchangePositionMissingError(err) {
 			h.markStalePositionRetry(position, now)
 			if closeErr := h.reconcileMissingManagedPosition(ctx, position, source, err); closeErr != nil {
-				log.Printf("[SCALPING] Failed to close stale lifecycle row for %s: %v", position.PositionID, closeErr)
+				zaplogrus.Warnf("[SCALPING] Failed to close stale lifecycle row for %s: %v", position.PositionID, closeErr)
 			}
 			return 0, nil
 		}
@@ -5917,7 +5918,7 @@ func (h *IntegratedQuestHandlers) reconcileMissingManagedPosition(
 		return err
 	}
 
-	log.Printf(
+	zaplogrus.Infof(
 		"[SCALPING] Reconciled stale managed position %s (%s %s) as closed after exchange reported missing position: %v",
 		position.PositionID,
 		position.Exchange,

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"log"
 	"math"
 	"os"

--- a/services/backend-api/internal/services/scalping_autonomy.go
+++ b/services/backend-api/internal/services/scalping_autonomy.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
@@ -9,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/autonomous"
 	"github.com/shopspring/decimal"

--- a/services/backend-api/internal/services/scalping_autonomy.go
+++ b/services/backend-api/internal/services/scalping_autonomy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"os"
 	"strings"
 	"sync"

--- a/services/backend-api/internal/services/scalping_autonomy.go
+++ b/services/backend-api/internal/services/scalping_autonomy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"os"
 	"strings"
 	"sync"

--- a/services/backend-api/internal/services/scalping_autonomy.go
+++ b/services/backend-api/internal/services/scalping_autonomy.go
@@ -1,10 +1,10 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"sync"
@@ -200,7 +200,7 @@ func (e *scalpingExchangeConnector) IsConnected(ctx context.Context, exchange st
 }
 
 func (e *scalpingExchangeConnector) CancelAllOrders(ctx context.Context, strategyID, exchange string) error {
-	log.Printf(
+	zaplogrus.Infof(
 		"[AUTONOMY] rollback cancel-all-orders is not wired for strategy=%s exchange=%s; continuing best-effort rollback",
 		strings.TrimSpace(strategyID),
 		strings.TrimSpace(exchange),
@@ -209,7 +209,7 @@ func (e *scalpingExchangeConnector) CancelAllOrders(ctx context.Context, strateg
 }
 
 func (e *scalpingExchangeConnector) FlattenPositions(ctx context.Context, strategyID, exchange string) error {
-	log.Printf(
+	zaplogrus.Infof(
 		"[AUTONOMY] rollback flatten-positions is not wired for strategy=%s exchange=%s; continuing best-effort rollback",
 		strings.TrimSpace(strategyID),
 		strings.TrimSpace(exchange),

--- a/services/backend-api/internal/services/scalping_backtest.go
+++ b/services/backend-api/internal/services/scalping_backtest.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 	"sort"
 	"strings"

--- a/services/backend-api/internal/services/scalping_backtest.go
+++ b/services/backend-api/internal/services/scalping_backtest.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 	"sort"
 	"strings"

--- a/services/backend-api/internal/services/scalping_backtest.go
+++ b/services/backend-api/internal/services/scalping_backtest.go
@@ -1,13 +1,14 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
 	"math"
 	"sort"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/google/uuid"
 	appautonomy "github.com/irfndi/neuratrade/internal/app/autonomy"

--- a/services/backend-api/internal/services/scalping_backtest.go
+++ b/services/backend-api/internal/services/scalping_backtest.go
@@ -1,9 +1,9 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
-	"log"
 	"math"
 	"sort"
 	"strings"
@@ -400,7 +400,7 @@ func (e *ScalpingBacktestEngine) loadHistoricalSignals(ctx context.Context, star
 
 	signals, err := e.loadSignalsFromOHLCV(ctx, startTime, endTime, symbolFilter)
 	if err != nil {
-		log.Printf("[BACKTEST] OHLCV signal load failed (falling back to market_data): %v", err)
+		zaplogrus.Warnf("[BACKTEST] OHLCV signal load failed (falling back to market_data): %v", err)
 	}
 	if err == nil && len(signals) > 0 {
 		return signals, nil

--- a/services/backend-api/internal/services/scalping_performance.go
+++ b/services/backend-api/internal/services/scalping_performance.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/services/scalping_performance.go
+++ b/services/backend-api/internal/services/scalping_performance.go
@@ -1,8 +1,8 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
-	"log"
 	"sync"
 	"time"
 
@@ -85,7 +85,7 @@ func (sp *ScalpingPerformance) RecordTrade(record TradeRecord) {
 		sp.history = sp.history[len(sp.history)-100:]
 	}
 
-	log.Printf("Scalping performance: trades=%d, win_rate=%.2f%%, pnl=%s, consecutive=%d/%d",
+	zaplogrus.Infof("Scalping performance: trades=%d, win_rate=%.2f%%, pnl=%s, consecutive=%d/%d",
 		sp.totalTrades, sp.winRate*100, sp.totalPnL.String(), sp.consecutiveWins, sp.consecutiveLosses)
 }
 
@@ -149,14 +149,14 @@ func (sp *ScalpingPerformance) GetAdjustedParameters() ScalpingConfig {
 	if sp.consecutiveLosses >= 3 {
 		adjusted.MinProfitPercent = sp.parameters.MinProfitPercent * 1.5
 		adjusted.MaxCapitalPercent = sp.parameters.MaxCapitalPercent * 0.5
-		log.Printf("Self-learning: Consecutive losses detected - tightening parameters")
+		zaplogrus.Infof("Self-learning: Consecutive losses detected - tightening parameters")
 	} else if sp.consecutiveWins >= 3 {
 		adjusted.MinProfitPercent = sp.parameters.MinProfitPercent * 0.8
 		adjusted.MaxCapitalPercent = sp.parameters.MaxCapitalPercent * 1.2
 		if adjusted.MaxCapitalPercent > 20 {
 			adjusted.MaxCapitalPercent = 20
 		}
-		log.Printf("Self-learning: Consecutive wins detected - loosening parameters")
+		zaplogrus.Infof("Self-learning: Consecutive wins detected - loosening parameters")
 	}
 
 	if sp.winRate < 0.3 && sp.totalTrades >= 20 {
@@ -165,11 +165,11 @@ func (sp *ScalpingPerformance) GetAdjustedParameters() ScalpingConfig {
 		if adjusted.MaxConcurrentPositions < 1 {
 			adjusted.MaxConcurrentPositions = 1
 		}
-		log.Printf("Self-learning: Low win rate (%.1f%%) - dramatically tightening parameters", sp.winRate*100)
+		zaplogrus.Infof("Self-learning: Low win rate (%.1f%%) - dramatically tightening parameters", sp.winRate*100)
 	} else if sp.winRate > 0.6 && sp.totalTrades >= 20 {
 		adjusted.MinProfitPercent = sp.parameters.MinProfitPercent * 0.7
 		adjusted.MaxConcurrentPositions = sp.parameters.MaxConcurrentPositions + 1
-		log.Printf("Self-learning: High win rate (%.1f%%) - more aggressive parameters", sp.winRate*100)
+		zaplogrus.Infof("Self-learning: High win rate (%.1f%%) - more aggressive parameters", sp.winRate*100)
 	}
 
 	sp.parameters = adjusted

--- a/services/backend-api/internal/services/scalping_performance.go
+++ b/services/backend-api/internal/services/scalping_performance.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/services/scalping_performance.go
+++ b/services/backend-api/internal/services/scalping_performance.go
@@ -1,10 +1,11 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/shopspring/decimal"
 )

--- a/services/backend-api/internal/services/smart_order_executor.go
+++ b/services/backend-api/internal/services/smart_order_executor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 	"strings"
 	"time"

--- a/services/backend-api/internal/services/smart_order_executor.go
+++ b/services/backend-api/internal/services/smart_order_executor.go
@@ -1,10 +1,10 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"strings"
 	"time"
@@ -163,7 +163,7 @@ func (e *SmartOrderExecutor) PlaceOrderSmart(ctx context.Context, req SmartOrder
 }
 
 func (e *SmartOrderExecutor) executeFOK(ctx context.Context, req SmartOrderRequest, startTime time.Time) (*SmartOrderResult, error) {
-	log.Printf("[SMART-EXEC] Executing FOK order: %s %s %s", req.Side, req.Amount.String(), req.Symbol)
+	zaplogrus.Infof("[SMART-EXEC] Executing FOK order: %s %s %s", req.Side, req.Amount.String(), req.Symbol)
 
 	orderID, err := e.config.BaseExecutor.PlaceOrder(ctx, req.Exchange, req.Symbol, req.Side, "limit", req.Amount, req.Price)
 	if err != nil {
@@ -225,7 +225,7 @@ func (e *SmartOrderExecutor) executeFOK(ctx context.Context, req SmartOrderReque
 }
 
 func (e *SmartOrderExecutor) executeIOC(ctx context.Context, req SmartOrderRequest, startTime time.Time) (*SmartOrderResult, error) {
-	log.Printf("[SMART-EXEC] Executing IOC order: %s %s %s", req.Side, req.Amount.String(), req.Symbol)
+	zaplogrus.Infof("[SMART-EXEC] Executing IOC order: %s %s %s", req.Side, req.Amount.String(), req.Symbol)
 
 	orderID, err := e.config.BaseExecutor.PlaceOrder(ctx, req.Exchange, req.Symbol, req.Side, "limit", req.Amount, req.Price)
 	if err != nil {
@@ -315,7 +315,7 @@ func (e *SmartOrderExecutor) executeWithRetry(ctx context.Context, req SmartOrde
 			}, nil
 		}
 
-		log.Printf("[SMART-EXEC] Attempt %d/%d: %s %s %s", attempt, maxRetries, req.Side, orderAmount.String(), req.Symbol)
+		zaplogrus.Infof("[SMART-EXEC] Attempt %d/%d: %s %s %s", attempt, maxRetries, req.Side, orderAmount.String(), req.Symbol)
 
 		orderType := string(req.OrderType)
 		if orderType == "" {
@@ -326,11 +326,11 @@ func (e *SmartOrderExecutor) executeWithRetry(ctx context.Context, req SmartOrde
 		if err != nil {
 			lastErr = err
 			lastOrderID = orderID
-			log.Printf("[SMART-EXEC] Attempt %d failed: %v", attempt, err)
+			zaplogrus.Warnf("[SMART-EXEC] Attempt %d failed: %v", attempt, err)
 
 			if attempt < maxRetries && e.isRetryableError(err) {
 				delay := e.calcBackoff(attempt)
-				log.Printf("[SMART-EXEC] Retrying in %v (attempt %d/%d)", delay, attempt+1, maxRetries)
+				zaplogrus.Warnf("[SMART-EXEC] Retrying in %v (attempt %d/%d)", delay, attempt+1, maxRetries)
 
 				select {
 				case <-ctx.Done():
@@ -357,7 +357,7 @@ func (e *SmartOrderExecutor) executeWithRetry(ctx context.Context, req SmartOrde
 					slippage := e.calcSlippage(req, fillPrice)
 					if slippage > req.MaxSlippage {
 						lastErr = fmt.Errorf("slippage %.2f%% exceeds maximum %.2f%%", slippage, req.MaxSlippage)
-						log.Printf("[SMART-EXEC] Slippage protection triggered: %.2f%% > %.2f%%", slippage, req.MaxSlippage)
+						zaplogrus.Infof("[SMART-EXEC] Slippage protection triggered: %.2f%% > %.2f%%", slippage, req.MaxSlippage)
 
 						if attempt < maxRetries {
 							continue
@@ -404,7 +404,7 @@ func (e *SmartOrderExecutor) executeWithRetry(ctx context.Context, req SmartOrde
 			fillPercent := filled.Div(orderAmount).Mul(decimal.NewFromInt(100)).InexactFloat64()
 			if fillPercent < 100 && fillPercent < e.config.MinPartialFillPercent {
 				lastErr = fmt.Errorf("partial fill %.1f%% below minimum %.1f%%", fillPercent, e.config.MinPartialFillPercent)
-				log.Printf("[SMART-EXEC] Partial fill below minimum: %.1f%% < %.1f%%", fillPercent, e.config.MinPartialFillPercent)
+				zaplogrus.Infof("[SMART-EXEC] Partial fill below minimum: %.1f%% < %.1f%%", fillPercent, e.config.MinPartialFillPercent)
 
 				if attempt < maxRetries {
 					totalFilled = totalFilled.Add(filled)

--- a/services/backend-api/internal/services/smart_order_executor.go
+++ b/services/backend-api/internal/services/smart_order_executor.go
@@ -1,13 +1,14 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"errors"
 	"fmt"
 	"math"
 	"strings"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/shopspring/decimal"
 )

--- a/services/backend-api/internal/services/smart_order_executor.go
+++ b/services/backend-api/internal/services/smart_order_executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"math"
 	"strings"
 	"time"

--- a/services/backend-api/internal/services/wallet_validator.go
+++ b/services/backend-api/internal/services/wallet_validator.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/services/wallet_validator.go
+++ b/services/backend-api/internal/services/wallet_validator.go
@@ -1,9 +1,9 @@
 package services
 
 import (
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -262,7 +262,7 @@ func (wv *WalletValidator) getWalletBalances(ctx context.Context, chatID string)
 		  AND status = 'connected'
 	`, chatID)
 	if err != nil {
-		log.Printf("[WalletValidator] Failed to query exchanges: %v", err)
+		zaplogrus.Warnf("[WalletValidator] Failed to query exchanges: %v", err)
 		return balances, nil // Return empty rather than error for backward compatibility
 	}
 	defer rows.Close()
@@ -277,7 +277,7 @@ func (wv *WalletValidator) getWalletBalances(ctx context.Context, chatID string)
 	}
 
 	if len(exchanges) == 0 {
-		log.Printf("[WalletValidator] No connected exchanges for chat %s", chatID)
+		zaplogrus.Infof("[WalletValidator] No connected exchanges for chat %s", chatID)
 		return balances, nil
 	}
 
@@ -286,7 +286,7 @@ func (wv *WalletValidator) getWalletBalances(ctx context.Context, chatID string)
 		for _, exchange := range exchanges {
 			balanceResp, err := wv.ccxtService.FetchBalance(ctx, exchange)
 			if err != nil {
-				log.Printf("[WalletValidator] Failed to fetch balance from %s: %v", exchange, err)
+				zaplogrus.Warnf("[WalletValidator] Failed to fetch balance from %s: %v", exchange, err)
 				continue
 			}
 
@@ -303,9 +303,9 @@ func (wv *WalletValidator) getWalletBalances(ctx context.Context, chatID string)
 			wv.metrics.IncrementChecksByExchange(exchange)
 		}
 
-		log.Printf("[WalletValidator] Fetched balances from %d exchanges: %d assets", len(exchanges), len(balances))
+		zaplogrus.Infof("[WalletValidator] Fetched balances from %d exchanges: %d assets", len(exchanges), len(balances))
 	} else {
-		log.Printf("[WalletValidator] CCXT service not available, returning empty balances")
+		zaplogrus.Infof("[WalletValidator] CCXT service not available, returning empty balances")
 	}
 
 	return balances, nil

--- a/services/backend-api/internal/services/wallet_validator.go
+++ b/services/backend-api/internal/services/wallet_validator.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"sync"
 	"time"
 

--- a/services/backend-api/internal/services/wallet_validator.go
+++ b/services/backend-api/internal/services/wallet_validator.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
+	"github.com/irfndi/neuratrade/internal/utils"
 
 	"github.com/irfndi/neuratrade/internal/ccxt"
 	"github.com/shopspring/decimal"
@@ -278,7 +279,7 @@ func (wv *WalletValidator) getWalletBalances(ctx context.Context, chatID string)
 	}
 
 	if len(exchanges) == 0 {
-		zaplogrus.Infof("[WalletValidator] No connected exchanges for chat %s", chatID)
+		zaplogrus.Infof("[WalletValidator] No connected exchanges for chat %s", utils.MaskString(chatID, utils.DefaultMaskingConfig))
 		return balances, nil
 	}
 

--- a/services/backend-api/internal/services/wallet_validator.go
+++ b/services/backend-api/internal/services/wallet_validator.go
@@ -1,11 +1,12 @@
 package services
 
 import (
-	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 	"context"
 	"fmt"
 	"sync"
 	"time"
+
+	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/irfndi/neuratrade/internal/ccxt"
 	"github.com/shopspring/decimal"


### PR DESCRIPTION
## Summary
- Bulk-replace all remaining `log.Printf`/`log.Println` calls with `zaplogrus` structured logging equivalents across 44 files in `internal/`.
- Adjust log levels heuristically:
  - `Infof`/`Info` for normal operational messages
  - `Warnf`/`Warn` for failures, warnings, invalid states, and fallbacks
  - `Errorf`/`Error` for critical `[ERROR]` markers and order failures
- Removes the deprecated `"log"` import from all touched files.

## Verification
- [x] `go build ./internal/...` passes
- [x] All tests pass (`go test ./internal/...`)
- [x] Coverage remains above threshold (78.0% >= 77%)

## Test plan
- [ ] Review bot approvals (CodeRabbit, Sourcery, Kilo Code, etc.)
- [ ] CI/CD passes
- [ ] Address any PR comments before merge

🤖 Generated with [Claude Code](https://claude.com/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized internal logging infrastructure across backend services using structured logging for improved consistency and debuggability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/NeuraTrade/pull/423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->