### PR TITLE
feat: wire LiveReadinessReconciler into production startup

### DIFF
--- a/services/backend-api/cmd/server/main.go
+++ b/services/backend-api/cmd/server/main.go
@@ -477,6 +477,31 @@ func run() error {
 	// Create operational mode service
 	opModeService := services.NewOperationalModeService(db, services.DefaultOperationalModeConfig(), logger.WithComponent("operational_mode"))
 
+	// Start live-readiness reconciler when enabled and DB is available.
+	if cfg.LiveReadiness.Enabled && db != nil {
+		reconcilerStore := services.NewLiveReadinessManifestStore(db)
+		reconcilerCfg := services.DefaultLiveReadinessReconcilerConfig()
+		if cfg.LiveReadiness.IntervalHours > 0 {
+			reconcilerCfg.Interval = time.Duration(cfg.LiveReadiness.IntervalHours) * time.Hour
+		}
+		if cfg.LiveReadiness.LookbackHours > 0 {
+			reconcilerCfg.LookbackWindow = time.Duration(cfg.LiveReadiness.LookbackHours) * time.Hour
+		}
+		reconciler := services.NewLiveReadinessReconciler(db, reconcilerStore, &reconcilerLoggerAdapter{log: logger.WithComponent("live_readiness_reconciler")}, reconcilerCfg)
+		if err := reconciler.Start(ctx); err != nil {
+			logger.WithError(err).Warn("Failed to start live readiness reconciler")
+		} else {
+			defer reconciler.Stop()
+			logger.Info("Live readiness reconciler started")
+		}
+	} else {
+		if !cfg.LiveReadiness.Enabled {
+			logger.Info("Live readiness reconciler disabled by configuration")
+		} else {
+			logger.Info("Live readiness reconciler skipped: no database available")
+		}
+	}
+
 	// Setup routes and get cleanup function
 	cleanupRoutes, err := api.SetupRoutes(router, db, redisClient, ccxtService, collectorService, cleanupService, cacheAnalyticsService, signalAggregator, analyticsService, &cfg.Telegram, &cfg.AI, &cfg.Features, authMiddleware, walletValidator, opModeService, technicalAnalysisService)
 	if err != nil {
@@ -536,6 +561,19 @@ func (a *positionTrackerHeartbeatAdapter) SyncPositions(ctx context.Context) err
 	}
 	return a.tracker.SyncWithExchange(ctx)
 }
+
+// reconcilerLoggerAdapter wraps logging.Logger to satisfy services.Logger.
+type reconcilerLoggerAdapter struct {
+	log logging.Logger
+}
+
+func (a *reconcilerLoggerAdapter) WithFields(_ map[string]interface{}) services.Logger {
+	return a
+}
+
+func (a *reconcilerLoggerAdapter) Info(msg string)  { a.log.Info(msg) }
+func (a *reconcilerLoggerAdapter) Warn(msg string)  { a.log.Warn(msg) }
+func (a *reconcilerLoggerAdapter) Error(msg string) { a.log.Error(msg) }
 
 type stopLossHeartbeatAdapter struct {
 	service *services.StopLossService

--- a/services/backend-api/cmd/server/main.go
+++ b/services/backend-api/cmd/server/main.go
@@ -480,6 +480,11 @@ func run() error {
 	// Start live-readiness reconciler when enabled and DB is available.
 	if cfg.LiveReadiness.Enabled && db != nil {
 		reconcilerStore := services.NewLiveReadinessManifestStore(db)
+		initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := reconcilerStore.InitSchema(initCtx); err != nil {
+			logger.WithError(err).Warn("Failed to initialize live readiness manifest schema, reconciler may not persist manifests")
+		}
+		initCancel()
 		reconcilerCfg := services.DefaultLiveReadinessReconcilerConfig()
 		if cfg.LiveReadiness.IntervalHours > 0 {
 			reconcilerCfg.Interval = time.Duration(cfg.LiveReadiness.IntervalHours) * time.Hour
@@ -567,8 +572,8 @@ type reconcilerLoggerAdapter struct {
 	log logging.Logger
 }
 
-func (a *reconcilerLoggerAdapter) WithFields(_ map[string]interface{}) services.Logger {
-	return a
+func (a *reconcilerLoggerAdapter) WithFields(fields map[string]interface{}) services.Logger {
+	return &reconcilerLoggerAdapter{log: a.log.WithFields(fields)}
 }
 
 func (a *reconcilerLoggerAdapter) Info(msg string)  { a.log.Info(msg) }

--- a/services/backend-api/internal/config/config.go
+++ b/services/backend-api/internal/config/config.go
@@ -54,6 +54,8 @@ type Config struct {
 	AI AIConfig `mapstructure:"ai"`
 	// Features holds feature flags.
 	Features FeaturesConfig `mapstructure:"features"`
+	// LiveReadiness holds configuration for the live-readiness reconciler.
+	LiveReadiness LiveReadinessConfig `mapstructure:"live_readiness"`
 }
 
 // ServerConfig defines the HTTP server settings.
@@ -384,6 +386,16 @@ type FeaturesConfig struct {
 	EnableAIArbitrage bool `mapstructure:"enable_ai_arbitrage"`
 }
 
+// LiveReadinessConfig holds configuration for the live-readiness reconciler.
+type LiveReadinessConfig struct {
+	// Enabled controls whether the background reconciler runs.
+	Enabled bool `mapstructure:"enabled"`
+	// IntervalHours is the tick interval between reconciliations.
+	IntervalHours int `mapstructure:"interval_hours"`
+	// LookbackHours is how far back the reconciler looks for evidence.
+	LookbackHours int `mapstructure:"lookback_hours"`
+}
+
 func Load() (*Config, error) {
 	// First: add user-local NeuraTrade config path.
 	if dir := neuratradeHomeDir(); dir != "" {
@@ -638,6 +650,11 @@ func setDefaults() {
 	viper.SetDefault("features.enable_ai_scalping", true)
 	viper.SetDefault("features.enable_ai_signals", false)
 	viper.SetDefault("features.enable_ai_arbitrage", false)
+
+	// Live readiness reconciler defaults
+	viper.SetDefault("live_readiness.enabled", true)
+	viper.SetDefault("live_readiness.interval_hours", 1)
+	viper.SetDefault("live_readiness.lookback_hours", 168)
 }
 
 func neuratradeHomeDir() string {

--- a/services/backend-api/internal/config/config.go
+++ b/services/backend-api/internal/config/config.go
@@ -733,5 +733,14 @@ func validateConfig(config *Config) error {
 
 	}
 
+	if config.LiveReadiness.Enabled {
+		if config.LiveReadiness.IntervalHours <= 0 {
+			return fmt.Errorf("live_readiness.interval_hours must be > 0 when live_readiness.enabled=true")
+		}
+		if config.LiveReadiness.LookbackHours <= 0 {
+			return fmt.Errorf("live_readiness.lookback_hours must be > 0 when live_readiness.enabled=true")
+		}
+	}
+
 	return nil
 }

--- a/services/backend-api/internal/config/config_test.go
+++ b/services/backend-api/internal/config/config_test.go
@@ -63,6 +63,11 @@ func TestConfig_Struct(t *testing.T) {
 			VolatilityHighThreshold: 0.03,
 			VolatilityLowThreshold:  0.005,
 		},
+		LiveReadiness: LiveReadinessConfig{
+			Enabled:       true,
+			IntervalHours: 2,
+			LookbackHours: 72,
+		},
 	}
 
 	assert.Equal(t, "test", config.Environment)
@@ -95,6 +100,9 @@ func TestConfig_Struct(t *testing.T) {
 	assert.Equal(t, 0.0008, config.Fees.DefaultMakerFee)
 	assert.True(t, config.Analytics.EnableForecasting)
 	assert.Equal(t, 120, config.Analytics.ForecastLookback)
+	assert.True(t, config.LiveReadiness.Enabled)
+	assert.Equal(t, 2, config.LiveReadiness.IntervalHours)
+	assert.Equal(t, 72, config.LiveReadiness.LookbackHours)
 }
 
 func TestServerConfig_Struct(t *testing.T) {


### PR DESCRIPTION
## Summary
Wires the `LiveReadinessReconciler` into the production server startup so that paper-trading readiness manifests are periodically regenerated and auto-persisted to the database when acceptance criteria pass.

## Changes
- Added `LiveReadinessConfig` to the config package with `enabled`, `interval_hours`, and `lookback_hours` fields.
- Started the reconciler in `main.go` when enabled and a database is available.
- Added `reconcilerLoggerAdapter` to bridge `logging.Logger` to `services.Logger`.
- Added config test coverage for the new fields.

## Test plan
- [x] `go build ./cmd/server/...` compiles
- [x] `go test ./...` passes (4925+ tests)
- [x] Config struct test validates new fields

🤖 Generated with [Claude Code](https://claude.com/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced live-readiness reconciliation capability with configurable interval and lookback hours (enabled by default)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->