### PR TITLE
feat: real-money readiness - drawdown DB persistence + CCXT retry

### DIFF
--- a/services/backend-api/cmd/server/main.go
+++ b/services/backend-api/cmd/server/main.go
@@ -508,7 +508,7 @@ func run() error {
 	}
 
 	// Setup routes and get cleanup function
-	cleanupRoutes, err := api.SetupRoutes(router, db, redisClient, ccxtService, collectorService, cleanupService, cacheAnalyticsService, signalAggregator, analyticsService, &cfg.Telegram, &cfg.AI, &cfg.Features, authMiddleware, walletValidator, opModeService, technicalAnalysisService)
+	cleanupRoutes, err := api.SetupRoutes(router, db, redisClient, ccxtService, collectorService, cleanupService, cacheAnalyticsService, signalAggregator, analyticsService, &cfg.Telegram, &cfg.AI, &cfg.Features, authMiddleware, walletValidator, opModeService, technicalAnalysisService, &cfg.Security)
 	if err != nil {
 		return fmt.Errorf("failed to setup routes: %w", err)
 	}

--- a/services/backend-api/database/migrations/082_create_drawdown_states.sql
+++ b/services/backend-api/database/migrations/082_create_drawdown_states.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS drawdown_states (
+    chat_id TEXT PRIMARY KEY,
+    peak_value TEXT NOT NULL DEFAULT '0',
+    current_value TEXT NOT NULL DEFAULT '0',
+    current_drawdown TEXT NOT NULL DEFAULT '0',
+    max_drawdown_seen TEXT NOT NULL DEFAULT '0',
+    status TEXT NOT NULL DEFAULT 'normal',
+    trading_halted BOOLEAN NOT NULL DEFAULT FALSE,
+    halted_at TIMESTAMP,
+    recovered_at TIMESTAMP,
+    last_checked TIMESTAMP NOT NULL,
+    warning_count INTEGER NOT NULL DEFAULT 0,
+    halt_count INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_drawdown_states_trading_halted
+    ON drawdown_states(trading_halted, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_drawdown_states_status
+    ON drawdown_states(status, updated_at DESC);

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -602,8 +602,7 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		if err := drawdownHalt.InitSchema(initCtx); err != nil {
 			zaplogrus.Warnf("Failed to initialize drawdown halt schema: %v", err)
-		}
-		if err := drawdownHalt.LoadStates(initCtx); err != nil {
+		} else if err := drawdownHalt.LoadStates(initCtx); err != nil {
 			zaplogrus.Warnf("Failed to load drawdown states: %v", err)
 		}
 		initCancel()

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -435,7 +435,7 @@ func riskLockSourcePriority(source string) int {
 // It returns a cleanup function that should be called on shutdown to stop background resources (for example, the WebSocket handler).
 //
 //nolint:staticcheck // SA1019: SignalAggregator and TechnicalAnalysisService are deprecated but required for backward compatibility until scalping composer migration completes.
-func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, ccxtService ccxt.CCXTService, collectorService *services.CollectorService, cleanupService *services.CleanupService, cacheAnalyticsService *services.CacheAnalyticsService, signalAggregator *services.SignalAggregator, analyticsService *services.AnalyticsService, telegramConfig *config.TelegramConfig, aiConfig *config.AIConfig, featuresConfig *config.FeaturesConfig, authMiddleware *middleware.AuthMiddleware, walletValidator *services.WalletValidator, opModeService *services.OperationalModeService, technicalAnalysisService *services.TechnicalAnalysisService) (func(), error) {
+func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, ccxtService ccxt.CCXTService, collectorService *services.CollectorService, cleanupService *services.CleanupService, cacheAnalyticsService *services.CacheAnalyticsService, signalAggregator *services.SignalAggregator, analyticsService *services.AnalyticsService, telegramConfig *config.TelegramConfig, aiConfig *config.AIConfig, featuresConfig *config.FeaturesConfig, authMiddleware *middleware.AuthMiddleware, walletValidator *services.WalletValidator, opModeService *services.OperationalModeService, technicalAnalysisService *services.TechnicalAnalysisService, securityConfig *config.SecurityConfig) (func(), error) {
 	configureLiveReadinessGuard(opModeService, db)
 
 	// Apply CORS middleware globally
@@ -496,6 +496,17 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		zaplogrus.Warnf("[TELEGRAM] WARNING: telegramConfig is nil, notification service will run with default settings")
 		notificationService = services.NewNotificationService(db, redis, "http://telegram-service:3002", "telegram-service:50052", "")
 	}
+
+	// Initialize API key service for encrypted exchange credential storage
+	var apiKeyService *services.APIKeyService
+	if securityConfig != nil && securityConfig.EncryptionKey != "" {
+		var err error
+		apiKeyService, err = services.NewAPIKeyService(db, securityConfig.EncryptionKey)
+		if err != nil {
+			zaplogrus.Warnf("[APIKEY] Failed to initialize API key service: %v", err)
+		}
+	}
+	_ = apiKeyService // wired for future handler injection
 
 	// Initialize handlers
 	marketHandler := handlers.NewMarketHandler(db, ccxtService, collectorService, redis, cacheAnalyticsService)

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -587,6 +587,16 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	riskConfig := risk.DefaultRiskManagerConfig()
 	riskManager := risk.NewRiskManagerAgent(riskConfig)
 	drawdownHalt := services.NewMaxDrawdownHalt(db, services.ResolveMaxDrawdownConfigFromEnv(services.DefaultMaxDrawdownConfig()))
+	if db != nil {
+		initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := drawdownHalt.InitSchema(initCtx); err != nil {
+			zaplogrus.Warnf("Failed to initialize drawdown halt schema: %v", err)
+		}
+		if err := drawdownHalt.LoadStates(initCtx); err != nil {
+			zaplogrus.Warnf("Failed to load drawdown states: %v", err)
+		}
+		initCancel()
+	}
 
 	var dailyLossTracker *risk.DailyLossTracker
 	var positionThrottle *risk.PositionSizeThrottle

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -601,9 +601,12 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 	if db != nil {
 		initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		if err := drawdownHalt.InitSchema(initCtx); err != nil {
-			zaplogrus.Warnf("Failed to initialize drawdown halt schema: %v", err)
-		} else if err := drawdownHalt.LoadStates(initCtx); err != nil {
-			zaplogrus.Warnf("Failed to load drawdown states: %v", err)
+			initCancel()
+			return nil, fmt.Errorf("failed to initialize drawdown halt schema: %w", err)
+		}
+		if err := drawdownHalt.LoadStates(initCtx); err != nil {
+			initCancel()
+			return nil, fmt.Errorf("failed to load drawdown states: %w", err)
 		}
 		initCancel()
 	}

--- a/services/backend-api/internal/api/routes_regression_test.go
+++ b/services/backend-api/internal/api/routes_regression_test.go
@@ -60,7 +60,7 @@ func TestSetupRoutes_HealthEndpointContractRegression(t *testing.T) {
 	cacheAnalyticsService := services.NewCacheAnalyticsService(nil)
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
 
-	teardown, err := SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, cacheAnalyticsService, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil)
+	teardown, err := SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, cacheAnalyticsService, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer teardown()
 

--- a/services/backend-api/internal/api/routes_test.go
+++ b/services/backend-api/internal/api/routes_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/irfndi/neuratrade/internal/config"
 	"github.com/irfndi/neuratrade/internal/database"
 	"github.com/irfndi/neuratrade/internal/middleware"
-	"github.com/pashagolub/pgxmock/v4"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,65 +28,13 @@ func (m mockRouteDB) HealthCheck(ctx context.Context) error {
 	return nil
 }
 
-// setupMockDB creates a mock database pool with all expected initialization queries
+// setupMockDB creates a real SQLite in-memory database for route tests.
+// Using a real database avoids fragile pgxmock expectations for schema init SQL.
 func setupMockDB(t *testing.T) mockRouteDB {
 	t.Helper()
-	mock, err := pgxmock.NewPool()
-	require.NoError(t, err, "Failed to create mock pool")
-
-	mock.ExpectExec("CREATE TABLE IF NOT EXISTS trading_orders").
-		WillReturnResult(pgxmock.NewResult("CREATE TABLE", 0))
-	mock.ExpectExec("CREATE TABLE IF NOT EXISTS trading_positions").
-		WillReturnResult(pgxmock.NewResult("CREATE TABLE", 0))
-	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_trading_orders_position_id").
-		WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
-	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_trading_positions_symbol_status").
-		WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
-
-	// Lifecycle store initialization
-	mock.ExpectExec("CREATE TABLE IF NOT EXISTS trading_orders").
-		WillReturnResult(pgxmock.NewResult("CREATE TABLE", 0))
-	mock.ExpectExec("CREATE TABLE IF NOT EXISTS trading_positions").
-		WillReturnResult(pgxmock.NewResult("CREATE TABLE", 0))
-	mock.ExpectExec("CREATE TABLE IF NOT EXISTS realized_pnl_journal").
-		WillReturnResult(pgxmock.NewResult("CREATE TABLE", 0))
-	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_trading_orders_position_id").
-		WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
-	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_trading_orders_chat_status").
-		WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
-	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_trading_positions_symbol_status").
-		WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
-	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_trading_positions_chat_status").
-		WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
-	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_realized_pnl_journal_chat_closed").
-		WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
-	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_realized_pnl_journal_symbol_closed").
-		WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
-
-	mock.ExpectExec("ALTER TABLE trading_orders ADD COLUMN chat_id TEXT").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-	mock.ExpectExec("ALTER TABLE trading_orders ADD COLUMN market_type TEXT").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-	mock.ExpectExec("ALTER TABLE trading_orders ADD COLUMN filled_amount NUMERIC").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-	mock.ExpectExec("ALTER TABLE trading_orders ADD COLUMN source TEXT").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-	mock.ExpectExec("ALTER TABLE trading_orders ADD COLUMN closed_at TIMESTAMP").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-	mock.ExpectExec("ALTER TABLE trading_positions ADD COLUMN chat_id TEXT").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-	mock.ExpectExec("ALTER TABLE trading_positions ADD COLUMN market_type TEXT").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-	mock.ExpectExec("ALTER TABLE trading_positions ADD COLUMN close_price NUMERIC").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-	mock.ExpectExec("ALTER TABLE trading_positions ADD COLUMN realized_pnl NUMERIC").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-	mock.ExpectExec("ALTER TABLE trading_positions ADD COLUMN source TEXT").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-	mock.ExpectExec("ALTER TABLE trading_positions ADD COLUMN closed_at TIMESTAMP").
-		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
-
-	return mockRouteDB{DBPool: database.NewMockDBPool(mock)}
+	db, err := database.NewSQLiteConnection(":memory:")
+	require.NoError(t, err, "Failed to create SQLite database")
+	return mockRouteDB{DBPool: db}
 }
 
 // Helper functions for environment variable management with proper error handling

--- a/services/backend-api/internal/api/routes_test.go
+++ b/services/backend-api/internal/api/routes_test.go
@@ -385,7 +385,7 @@ func TestSetupRoutes_PanicHandling(t *testing.T) {
 	assert.NotNil(t, router)
 
 	assert.Panics(t, func() {
-		_, _ = SetupRoutes(router, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		_, _ = SetupRoutes(router, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	}, "SetupRoutes should panic with nil dependencies")
 }
 
@@ -429,7 +429,7 @@ func TestSetupRoutes_RouteRegistration(t *testing.T) {
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
 
 	assert.NotPanics(t, func() {
-		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil)
+		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil)
 	}, "SetupRoutes should handle minimal dependencies gracefully")
 
 	// Verify routes were registered
@@ -487,7 +487,7 @@ func TestSetupRoutes_RouteGroups(t *testing.T) {
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil)
 
 	// Get all routes
 	routes := router.Routes()
@@ -552,7 +552,7 @@ func TestSetupRoutes_HttpMethods(t *testing.T) {
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil)
 
 	// Get all routes
 	routes := router.Routes()
@@ -620,7 +620,7 @@ func TestSetupRoutes_Middleware(t *testing.T) {
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil)
 
 	// Test that router has middleware configured
 	// Gin router should have middleware registered
@@ -676,7 +676,7 @@ func TestSetupRoutes_MissingAdminKey(t *testing.T) {
 			}),
 		}
 		mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil)
+		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil)
 	}, "SetupRoutes should handle missing admin key gracefully")
 }
 
@@ -720,7 +720,7 @@ func TestSetupRoutes_MissingTelegramConfig(t *testing.T) {
 			}),
 		}
 		mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil)
+		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil)
 	}, "SetupRoutes should not panic when telegram config is missing")
 
 	// Verify routes were still registered
@@ -758,7 +758,7 @@ func TestSetupRoutes_AIUserRoutesRequireAuth(t *testing.T) {
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/ai/status/user-123", nil)
 	rec := httptest.NewRecorder()
@@ -798,7 +798,7 @@ func TestSetupRoutes_TelegramInternalRequiresAdminAuth(t *testing.T) {
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/telegram/internal/quests", nil)
 	rec := httptest.NewRecorder()
@@ -838,7 +838,7 @@ func TestSetupRoutes_TelegramLegacyInternalAliasesRequireAdminAuth(t *testing.T)
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil)
 
 	legacyPaths := []struct {
 		method string

--- a/services/backend-api/internal/config/config.go
+++ b/services/backend-api/internal/config/config.go
@@ -731,6 +731,16 @@ func validateConfig(config *Config) error {
 			}
 		}
 
+		// Require encryption key for API key storage in production
+		if strings.TrimSpace(config.Security.EncryptionKey) == "" {
+			return fmt.Errorf("SECURITY_ENCRYPTION_KEY cannot be empty in %s environment. Exchange API keys must be encrypted", config.Environment)
+		}
+
+		// Validate encryption key length (must be at least 32 bytes for AES-256-GCM)
+		if len(config.Security.EncryptionKey) < 32 {
+			return fmt.Errorf("SECURITY_ENCRYPTION_KEY must be at least 32 characters long in %s environment", config.Environment)
+		}
+
 	}
 
 	if config.LiveReadiness.Enabled {

--- a/services/backend-api/internal/config/config.go
+++ b/services/backend-api/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -736,9 +737,13 @@ func validateConfig(config *Config) error {
 			return fmt.Errorf("SECURITY_ENCRYPTION_KEY cannot be empty in %s environment. Exchange API keys must be encrypted", config.Environment)
 		}
 
-		// Validate encryption key length (must be at least 32 bytes for AES-256-GCM)
-		if len(config.Security.EncryptionKey) < 32 {
-			return fmt.Errorf("SECURITY_ENCRYPTION_KEY must be at least 32 characters long in %s environment", config.Environment)
+		// Validate encryption key decodes to at least 32 bytes for AES-256-GCM
+		decodedKey, decodeErr := base64.StdEncoding.DecodeString(config.Security.EncryptionKey)
+		if decodeErr != nil {
+			return fmt.Errorf("SECURITY_ENCRYPTION_KEY must be valid base64 in %s environment: %w", config.Environment, decodeErr)
+		}
+		if len(decodedKey) < 32 {
+			return fmt.Errorf("SECURITY_ENCRYPTION_KEY must decode to at least 32 bytes for AES-256-GCM in %s environment (got %d bytes)", config.Environment, len(decodedKey))
 		}
 
 	}

--- a/services/backend-api/internal/config/config_test.go
+++ b/services/backend-api/internal/config/config_test.go
@@ -352,6 +352,19 @@ func TestLoad_ProductionRejectsShortEncryptionKey(t *testing.T) {
 	assert.ErrorContains(t, err, "SECURITY_ENCRYPTION_KEY must decode to at least 32 bytes")
 }
 
+func TestLoad_ProductionRejectsInvalidBase64EncryptionKey(t *testing.T) {
+	os.Clearenv()
+	t.Setenv("ENVIRONMENT", "production")
+	t.Setenv("DATABASE_DRIVER", "postgres")
+	t.Setenv("AUTH_JWT_SECRET", "ci-test-secret-key-should-be-32-chars!!")
+	// Not valid base64 — contains characters outside base64 alphabet and wrong padding
+	t.Setenv("SECURITY_ENCRYPTION_KEY", "not-valid-base64!!!")
+
+	config, err := Load()
+	assert.Nil(t, config)
+	assert.ErrorContains(t, err, "SECURITY_ENCRYPTION_KEY must be valid base64")
+}
+
 func TestLoad_SQLiteDriverRejectsWhitespacePath(t *testing.T) {
 	os.Clearenv()
 	t.Setenv("DATABASE_DRIVER", "sqlite")

--- a/services/backend-api/internal/config/config_test.go
+++ b/services/backend-api/internal/config/config_test.go
@@ -251,7 +251,7 @@ func TestLoad_WithEnvironmentVariables(t *testing.T) {
 	t.Setenv("TELEGRAM_BOT_TOKEN", "prod_bot_token")
 	t.Setenv("TELEGRAM_WEBHOOK_URL", "https://prod-api.example.com/webhook")
 	t.Setenv("AUTH_JWT_SECRET", "ci-test-secret-key-should-be-32-chars!!")
-	t.Setenv("SECURITY_ENCRYPTION_KEY", "ci-test-encryption-key-must-be-32-bytes!")
+	t.Setenv("SECURITY_ENCRYPTION_KEY", "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=")
 
 	config, err := Load()
 	require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestLoad_WithEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, "prod_bot_token", config.Telegram.BotToken)
 	assert.Equal(t, "https://prod-api.example.com/webhook", config.Telegram.WebhookURL)
 	assert.Equal(t, "ci-test-secret-key-should-be-32-chars!!", config.Auth.JWTSecret)
-	assert.Equal(t, "ci-test-encryption-key-must-be-32-bytes!", config.Security.EncryptionKey)
+	assert.Equal(t, "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=", config.Security.EncryptionKey)
 }
 
 func TestCCXTConfig_GetServiceURL(t *testing.T) {
@@ -344,11 +344,12 @@ func TestLoad_ProductionRejectsShortEncryptionKey(t *testing.T) {
 	t.Setenv("ENVIRONMENT", "production")
 	t.Setenv("DATABASE_DRIVER", "postgres")
 	t.Setenv("AUTH_JWT_SECRET", "ci-test-secret-key-should-be-32-chars!!")
-	t.Setenv("SECURITY_ENCRYPTION_KEY", "too-short")
+	// Base64-encoded string that decodes to fewer than 32 bytes
+	t.Setenv("SECURITY_ENCRYPTION_KEY", "dG9vLXNob3J0")
 
 	config, err := Load()
 	assert.Nil(t, config)
-	assert.ErrorContains(t, err, "SECURITY_ENCRYPTION_KEY must be at least 32 characters long")
+	assert.ErrorContains(t, err, "SECURITY_ENCRYPTION_KEY must decode to at least 32 bytes")
 }
 
 func TestLoad_SQLiteDriverRejectsWhitespacePath(t *testing.T) {

--- a/services/backend-api/internal/config/config_test.go
+++ b/services/backend-api/internal/config/config_test.go
@@ -251,6 +251,7 @@ func TestLoad_WithEnvironmentVariables(t *testing.T) {
 	t.Setenv("TELEGRAM_BOT_TOKEN", "prod_bot_token")
 	t.Setenv("TELEGRAM_WEBHOOK_URL", "https://prod-api.example.com/webhook")
 	t.Setenv("AUTH_JWT_SECRET", "ci-test-secret-key-should-be-32-chars!!")
+	t.Setenv("SECURITY_ENCRYPTION_KEY", "ci-test-encryption-key-must-be-32-bytes!")
 
 	config, err := Load()
 	require.NoError(t, err)
@@ -278,6 +279,7 @@ func TestLoad_WithEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, "prod_bot_token", config.Telegram.BotToken)
 	assert.Equal(t, "https://prod-api.example.com/webhook", config.Telegram.WebhookURL)
 	assert.Equal(t, "ci-test-secret-key-should-be-32-chars!!", config.Auth.JWTSecret)
+	assert.Equal(t, "ci-test-encryption-key-must-be-32-bytes!", config.Security.EncryptionKey)
 }
 
 func TestCCXTConfig_GetServiceURL(t *testing.T) {
@@ -323,6 +325,30 @@ func TestLoad_WithInvalidDatabaseDriver(t *testing.T) {
 	config, err := Load()
 	assert.Nil(t, config)
 	assert.ErrorContains(t, err, "database.driver must be one of")
+}
+
+func TestLoad_ProductionRequiresEncryptionKey(t *testing.T) {
+	os.Clearenv()
+	t.Setenv("ENVIRONMENT", "production")
+	t.Setenv("DATABASE_DRIVER", "postgres")
+	t.Setenv("AUTH_JWT_SECRET", "ci-test-secret-key-should-be-32-chars!!")
+	// Intentionally omit SECURITY_ENCRYPTION_KEY
+
+	config, err := Load()
+	assert.Nil(t, config)
+	assert.ErrorContains(t, err, "SECURITY_ENCRYPTION_KEY cannot be empty in production environment")
+}
+
+func TestLoad_ProductionRejectsShortEncryptionKey(t *testing.T) {
+	os.Clearenv()
+	t.Setenv("ENVIRONMENT", "production")
+	t.Setenv("DATABASE_DRIVER", "postgres")
+	t.Setenv("AUTH_JWT_SECRET", "ci-test-secret-key-should-be-32-chars!!")
+	t.Setenv("SECURITY_ENCRYPTION_KEY", "too-short")
+
+	config, err := Load()
+	assert.Nil(t, config)
+	assert.ErrorContains(t, err, "SECURITY_ENCRYPTION_KEY must be at least 32 characters long")
 }
 
 func TestLoad_SQLiteDriverRejectsWhitespacePath(t *testing.T) {

--- a/services/backend-api/internal/services/api_key_service.go
+++ b/services/backend-api/internal/services/api_key_service.go
@@ -26,8 +26,8 @@ type APIKeyService struct {
 }
 
 func NewAPIKeyService(db database.DBPool, encryptionKey string) (*APIKeyService, error) {
-	if encryptionKey == "" {
-		return &APIKeyService{db: db, encryptor: nil}, nil
+	if strings.TrimSpace(encryptionKey) == "" {
+		return nil, ErrEncryptionKeyNotConfigured
 	}
 
 	key, err := utils.ParseKey(encryptionKey)

--- a/services/backend-api/internal/services/api_key_service_test.go
+++ b/services/backend-api/internal/services/api_key_service_test.go
@@ -1,0 +1,31 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAPIKeyService_EmptyKeyReturnsError(t *testing.T) {
+	svc, err := NewAPIKeyService(nil, "")
+	require.Error(t, err)
+	assert.Nil(t, svc)
+	assert.ErrorIs(t, err, ErrEncryptionKeyNotConfigured)
+}
+
+func TestNewAPIKeyService_WhitespaceKeyReturnsError(t *testing.T) {
+	svc, err := NewAPIKeyService(nil, "   ")
+	require.Error(t, err)
+	assert.Nil(t, svc)
+	assert.ErrorIs(t, err, ErrEncryptionKeyNotConfigured)
+}
+
+func TestNewAPIKeyService_ValidKey(t *testing.T) {
+	// Base64-encoded 32-byte key for AES-256-GCM
+	key := "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE="
+	svc, err := NewAPIKeyService(nil, key)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+	assert.True(t, svc.IsEncryptionEnabled())
+}

--- a/services/backend-api/internal/services/ccxt_order_executor.go
+++ b/services/backend-api/internal/services/ccxt_order_executor.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 )
 
@@ -76,7 +78,8 @@ func (e *CCXTOrderExecutor) doWithRetry(ctx context.Context, makeReq func() (*ht
 			return resp, nil
 		}
 		if err == nil {
-			// 5xx response; drain and close body before retry.
+			// 5xx response; drain and close body before retry to allow connection reuse.
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 		}
 	}
@@ -105,12 +108,15 @@ func (e *CCXTOrderExecutor) PlaceOrder(ctx context.Context, exchange, symbol, si
 		return "", fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	idempotencyKey := uuid.New().String()
+
 	resp, err := e.doWithRetry(ctx, func() (*http.Request, error) {
 		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", e.serviceURL+"/api/order", bytes.NewBuffer(jsonBody))
 		if reqErr != nil {
 			return nil, reqErr
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("X-Idempotency-Key", idempotencyKey)
 		if e.apiKey != "" {
 			httpReq.Header.Set("X-API-Key", e.apiKey)
 		}

--- a/services/backend-api/internal/services/ccxt_order_executor.go
+++ b/services/backend-api/internal/services/ccxt_order_executor.go
@@ -87,7 +87,9 @@ func (e *CCXTOrderExecutor) doWithRetry(ctx context.Context, makeReq func() (*ht
 	if err != nil {
 		return nil, fmt.Errorf("request failed after %d retries: %w", e.maxRetries, err)
 	}
-	return resp, fmt.Errorf("request failed with status %d after %d retries", resp.StatusCode, e.maxRetries)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	return nil, fmt.Errorf("request failed with status %d after %d retries", resp.StatusCode, e.maxRetries)
 }
 
 func (e *CCXTOrderExecutor) PlaceOrder(ctx context.Context, exchange, symbol, side, orderType string, amount decimal.Decimal, price *decimal.Decimal) (string, error) {

--- a/services/backend-api/internal/services/ccxt_order_executor.go
+++ b/services/backend-api/internal/services/ccxt_order_executor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"time"
@@ -16,12 +17,14 @@ type CCXTOrderExecutorConfig struct {
 	ServiceURL string
 	APIKey     string
 	Timeout    time.Duration
+	MaxRetries int
 }
 
 func DefaultCCXTOrderExecutorConfig() CCXTOrderExecutorConfig {
 	return CCXTOrderExecutorConfig{
 		ServiceURL: "http://localhost:3001",
 		Timeout:    30 * time.Second,
+		MaxRetries: 3,
 	}
 }
 
@@ -29,16 +32,59 @@ type CCXTOrderExecutor struct {
 	serviceURL string
 	apiKey     string
 	httpClient *http.Client
+	maxRetries int
 }
 
 func NewCCXTOrderExecutor(cfg CCXTOrderExecutorConfig) *CCXTOrderExecutor {
+	maxRetries := cfg.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
 	return &CCXTOrderExecutor{
 		serviceURL: cfg.ServiceURL,
 		apiKey:     cfg.APIKey,
 		httpClient: &http.Client{
 			Timeout: cfg.Timeout,
 		},
+		maxRetries: maxRetries,
 	}
+}
+
+func (e *CCXTOrderExecutor) doWithRetry(ctx context.Context, makeReq func() (*http.Request, error)) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt <= e.maxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(200*attempt+rand.Intn(100)) * time.Millisecond
+			if attempt > 1 {
+				backoff = time.Duration(200*(1<<(attempt-1))+rand.Intn(100)) * time.Millisecond
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		req, reqErr := makeReq()
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		resp, err = e.httpClient.Do(req)
+		if err == nil && resp.StatusCode < http.StatusInternalServerError {
+			return resp, nil
+		}
+		if err == nil {
+			// 5xx response; drain and close body before retry.
+			_ = resp.Body.Close()
+		}
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("request failed after %d retries: %w", e.maxRetries, err)
+	}
+	return resp, fmt.Errorf("request failed with status %d after %d retries", resp.StatusCode, e.maxRetries)
 }
 
 func (e *CCXTOrderExecutor) PlaceOrder(ctx context.Context, exchange, symbol, side, orderType string, amount decimal.Decimal, price *decimal.Decimal) (string, error) {
@@ -59,19 +105,19 @@ func (e *CCXTOrderExecutor) PlaceOrder(ctx context.Context, exchange, symbol, si
 		return "", fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", e.serviceURL+"/api/order", bytes.NewBuffer(jsonBody))
+	resp, err := e.doWithRetry(ctx, func() (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "POST", e.serviceURL+"/api/order", bytes.NewBuffer(jsonBody))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		if e.apiKey != "" {
+			httpReq.Header.Set("X-API-Key", e.apiKey)
+		}
+		return httpReq, nil
+	})
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	if e.apiKey != "" {
-		httpReq.Header.Set("X-API-Key", e.apiKey)
-	}
-
-	resp, err := e.httpClient.Do(httpReq)
-	if err != nil {
-		return "", fmt.Errorf("request failed: %w", err)
+		return "", fmt.Errorf("place order failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -93,41 +139,40 @@ func (e *CCXTOrderExecutor) PlaceOrder(ctx context.Context, exchange, symbol, si
 }
 
 func (e *CCXTOrderExecutor) CancelOrder(ctx context.Context, exchange, orderID string) error {
-	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("%s/api/order/%s/%s", e.serviceURL, exchange, orderID), nil)
+	resp, err := e.doWithRetry(ctx, func() (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("%s/api/order/%s/%s", e.serviceURL, exchange, orderID), nil)
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		if e.apiKey != "" {
+			httpReq.Header.Set("X-API-Key", e.apiKey)
+		}
+		return httpReq, nil
+	})
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	if e.apiKey != "" {
-		httpReq.Header.Set("X-API-Key", e.apiKey)
-	}
-
-	resp, err := e.httpClient.Do(httpReq)
-	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return fmt.Errorf("cancel order failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("order cancellation failed with status: %d", resp.StatusCode)
 	}
-
 	return nil
 }
 
 func (e *CCXTOrderExecutor) GetOrder(ctx context.Context, exchange, orderID string) (map[string]interface{}, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/api/order/%s/%s", e.serviceURL, exchange, orderID), nil)
+	resp, err := e.doWithRetry(ctx, func() (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/api/order/%s/%s", e.serviceURL, exchange, orderID), nil)
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		if e.apiKey != "" {
+			httpReq.Header.Set("X-API-Key", e.apiKey)
+		}
+		return httpReq, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	if e.apiKey != "" {
-		httpReq.Header.Set("X-API-Key", e.apiKey)
-	}
-
-	resp, err := e.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("get order failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -139,32 +184,29 @@ func (e *CCXTOrderExecutor) GetOrder(ctx context.Context, exchange, orderID stri
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
-
 	return result, nil
 }
 
 func (e *CCXTOrderExecutor) GetOpenOrders(ctx context.Context, exchange, symbol string) ([]map[string]interface{}, error) {
 	baseURL := fmt.Sprintf("%s/api/orders/%s", e.serviceURL, exchange)
-
-	var requestURL string
-	if symbol != "" {
-		requestURL = baseURL + "?symbol=" + url.QueryEscape(symbol)
-	} else {
-		requestURL = baseURL
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
+	resp, err := e.doWithRetry(ctx, func() (*http.Request, error) {
+		var requestURL string
+		if symbol != "" {
+			requestURL = baseURL + "?symbol=" + url.QueryEscape(symbol)
+		} else {
+			requestURL = baseURL
+		}
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		if e.apiKey != "" {
+			httpReq.Header.Set("X-API-Key", e.apiKey)
+		}
+		return httpReq, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	if e.apiKey != "" {
-		httpReq.Header.Set("X-API-Key", e.apiKey)
-	}
-
-	resp, err := e.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("get open orders failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -175,44 +217,39 @@ func (e *CCXTOrderExecutor) GetOpenOrders(ctx context.Context, exchange, symbol 
 	var result struct {
 		Orders []map[string]interface{} `json:"orders"`
 	}
-
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
-
 	return result.Orders, nil
 }
 
 func (e *CCXTOrderExecutor) GetClosedOrders(ctx context.Context, exchange, symbol string, limit int) ([]map[string]interface{}, error) {
 	baseURL := fmt.Sprintf("%s/api/orders/%s/closed", e.serviceURL, exchange)
-
-	params := url.Values{}
-	if symbol != "" {
-		params.Add("symbol", symbol)
-	}
-	if limit > 0 {
-		params.Add("limit", fmt.Sprintf("%d", limit))
-	}
-
-	var requestURL string
-	if params.Encode() != "" {
-		requestURL = baseURL + "?" + params.Encode()
-	} else {
-		requestURL = baseURL
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
+	resp, err := e.doWithRetry(ctx, func() (*http.Request, error) {
+		params := url.Values{}
+		if symbol != "" {
+			params.Add("symbol", symbol)
+		}
+		if limit > 0 {
+			params.Add("limit", fmt.Sprintf("%d", limit))
+		}
+		var requestURL string
+		if params.Encode() != "" {
+			requestURL = baseURL + "?" + params.Encode()
+		} else {
+			requestURL = baseURL
+		}
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		if e.apiKey != "" {
+			httpReq.Header.Set("X-API-Key", e.apiKey)
+		}
+		return httpReq, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	if e.apiKey != "" {
-		httpReq.Header.Set("X-API-Key", e.apiKey)
-	}
-
-	resp, err := e.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("get closed orders failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -223,27 +260,25 @@ func (e *CCXTOrderExecutor) GetClosedOrders(ctx context.Context, exchange, symbo
 	var result struct {
 		Orders []map[string]interface{} `json:"orders"`
 	}
-
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
-
 	return result.Orders, nil
 }
 
 func (e *CCXTOrderExecutor) GetOrderTrades(ctx context.Context, exchange, orderID string) ([]map[string]interface{}, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/api/order/%s/%s/trades", e.serviceURL, exchange, orderID), nil)
+	resp, err := e.doWithRetry(ctx, func() (*http.Request, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/api/order/%s/%s/trades", e.serviceURL, exchange, orderID), nil)
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		if e.apiKey != "" {
+			httpReq.Header.Set("X-API-Key", e.apiKey)
+		}
+		return httpReq, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	if e.apiKey != "" {
-		httpReq.Header.Set("X-API-Key", e.apiKey)
-	}
-
-	resp, err := e.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("get order trades failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -254,10 +289,8 @@ func (e *CCXTOrderExecutor) GetOrderTrades(ctx context.Context, exchange, orderI
 	var result struct {
 		Trades []map[string]interface{} `json:"trades"`
 	}
-
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
-
 	return result.Trades, nil
 }

--- a/services/backend-api/internal/services/ccxt_order_executor_test.go
+++ b/services/backend-api/internal/services/ccxt_order_executor_test.go
@@ -214,52 +214,72 @@ func TestCCXTOrderExecutor_GetOrderTrades(t *testing.T) {
 	assert.Len(t, trades, 2)
 }
 
-func TestCCXTOrderExecutor_PlaceOrder_RetriesOn5xx(t *testing.T) {
-	attempts := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attempts++
-		if attempts < 3 {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"order": map[string]string{"id": "order-12345"},
+func TestCCXTOrderExecutor_PlaceOrder_RetryBehavior(t *testing.T) {
+	cases := []struct {
+		name             string
+		handler          func(attempts *int) http.HandlerFunc
+		maxRetries       int
+		expectError      bool
+		expectAttempts   int
+		expectOrderID    string
+	}{
+		{
+			name: "retries_on_5xx_then_succeeds",
+			handler: func(attempts *int) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					*attempts++
+					if *attempts < 3 {
+						w.WriteHeader(http.StatusServiceUnavailable)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(map[string]interface{}{
+						"order": map[string]string{"id": "order-12345"},
+					})
+				}
+			},
+			maxRetries:     3,
+			expectError:    false,
+			expectAttempts: 3,
+			expectOrderID:  "order-12345",
+		},
+		{
+			name: "no_retry_on_4xx",
+			handler: func(attempts *int) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					*attempts++
+					w.WriteHeader(http.StatusBadRequest)
+					json.NewEncoder(w).Encode(map[string]interface{}{"error": "invalid symbol"})
+				}
+			},
+			maxRetries:     3,
+			expectError:    true,
+			expectAttempts: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			attempts := 0
+			server := httptest.NewServer(tc.handler(&attempts))
+			defer server.Close()
+
+			executor := NewCCXTOrderExecutor(CCXTOrderExecutorConfig{
+				ServiceURL: server.URL,
+				Timeout:    30 * time.Second,
+				MaxRetries: tc.maxRetries,
+			})
+
+			orderID, err := executor.PlaceOrder(context.Background(), "binance", "BTC/USDT", "buy", "market", decimal.NewFromFloat(0.5), nil)
+
+			assert.Equal(t, tc.expectAttempts, attempts)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectOrderID, orderID)
 		})
-	}))
-	defer server.Close()
-
-	executor := NewCCXTOrderExecutor(CCXTOrderExecutorConfig{
-		ServiceURL: server.URL,
-		Timeout:    30 * time.Second,
-		MaxRetries: 3,
-	})
-
-	orderID, err := executor.PlaceOrder(context.Background(), "binance", "BTC/USDT", "buy", "market", decimal.NewFromFloat(0.5), nil)
-
-	require.NoError(t, err)
-	assert.Equal(t, "order-12345", orderID)
-	assert.Equal(t, 3, attempts)
-}
-
-func TestCCXTOrderExecutor_PlaceOrder_NoRetryOn4xx(t *testing.T) {
-	attempts := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attempts++
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]interface{}{"error": "invalid symbol"})
-	}))
-	defer server.Close()
-
-	executor := NewCCXTOrderExecutor(CCXTOrderExecutorConfig{
-		ServiceURL: server.URL,
-		Timeout:    30 * time.Second,
-		MaxRetries: 3,
-	})
-
-	_, err := executor.PlaceOrder(context.Background(), "binance", "BTC/USDT", "buy", "market", decimal.NewFromFloat(0.5), nil)
-
-	require.Error(t, err)
-	assert.Equal(t, 1, attempts)
+	}
 }

--- a/services/backend-api/internal/services/ccxt_order_executor_test.go
+++ b/services/backend-api/internal/services/ccxt_order_executor_test.go
@@ -216,12 +216,12 @@ func TestCCXTOrderExecutor_GetOrderTrades(t *testing.T) {
 
 func TestCCXTOrderExecutor_PlaceOrder_RetryBehavior(t *testing.T) {
 	cases := []struct {
-		name             string
-		handler          func(attempts *int) http.HandlerFunc
-		maxRetries       int
-		expectError      bool
-		expectAttempts   int
-		expectOrderID    string
+		name           string
+		handler        func(attempts *int) http.HandlerFunc
+		maxRetries     int
+		expectError    bool
+		expectAttempts int
+		expectOrderID  string
 	}{
 		{
 			name: "retries_on_5xx_then_succeeds",

--- a/services/backend-api/internal/services/ccxt_order_executor_test.go
+++ b/services/backend-api/internal/services/ccxt_order_executor_test.go
@@ -213,3 +213,53 @@ func TestCCXTOrderExecutor_GetOrderTrades(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, trades, 2)
 }
+
+func TestCCXTOrderExecutor_PlaceOrder_RetriesOn5xx(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"order": map[string]string{"id": "order-12345"},
+		})
+	}))
+	defer server.Close()
+
+	executor := NewCCXTOrderExecutor(CCXTOrderExecutorConfig{
+		ServiceURL: server.URL,
+		Timeout:    30 * time.Second,
+		MaxRetries: 3,
+	})
+
+	orderID, err := executor.PlaceOrder(context.Background(), "binance", "BTC/USDT", "buy", "market", decimal.NewFromFloat(0.5), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "order-12345", orderID)
+	assert.Equal(t, 3, attempts)
+}
+
+func TestCCXTOrderExecutor_PlaceOrder_NoRetryOn4xx(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{"error": "invalid symbol"})
+	}))
+	defer server.Close()
+
+	executor := NewCCXTOrderExecutor(CCXTOrderExecutorConfig{
+		ServiceURL: server.URL,
+		Timeout:    30 * time.Second,
+		MaxRetries: 3,
+	})
+
+	_, err := executor.PlaceOrder(context.Background(), "binance", "BTC/USDT", "buy", "market", decimal.NewFromFloat(0.5), nil)
+
+	require.Error(t, err)
+	assert.Equal(t, 1, attempts)
+}

--- a/services/backend-api/internal/services/max_drawdown_halt.go
+++ b/services/backend-api/internal/services/max_drawdown_halt.go
@@ -235,10 +235,18 @@ func (h *MaxDrawdownHalt) LoadStates(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to scan drawdown state: %w", err)
 		}
-		s.PeakValue, _ = decimal.NewFromString(peakStr)
-		s.CurrentValue, _ = decimal.NewFromString(currentStr)
-		s.CurrentDrawdown, _ = decimal.NewFromString(drawdownStr)
-		s.MaxDrawdownSeen, _ = decimal.NewFromString(maxSeenStr)
+		peakVal, peakErr := decimal.NewFromString(peakStr)
+		currentVal, currentErr := decimal.NewFromString(currentStr)
+		drawdownVal, drawdownErr := decimal.NewFromString(drawdownStr)
+		maxSeenVal, maxSeenErr := decimal.NewFromString(maxSeenStr)
+		if peakErr != nil || currentErr != nil || drawdownErr != nil || maxSeenErr != nil {
+			zaplogrus.Warnf("[DRAWDOWN] Skipping corrupt state for chat %s: parse error", s.ChatID)
+			continue
+		}
+		s.PeakValue = peakVal
+		s.CurrentValue = currentVal
+		s.CurrentDrawdown = drawdownVal
+		s.MaxDrawdownSeen = maxSeenVal
 		if haltedAt.Valid {
 			s.HaltedAt = &haltedAt.Time
 		}
@@ -456,6 +464,14 @@ func (h *MaxDrawdownHalt) GetState(chatID string) (*DrawdownState, bool) {
 func (h *MaxDrawdownHalt) ForceHalt(ctx context.Context, chatID string, _ string) error {
 	h.mu.Lock()
 
+	var stateToSave *DrawdownState
+	defer func() {
+		h.mu.Unlock()
+		if stateToSave != nil {
+			h.saveState(ctx, stateToSave)
+		}
+	}()
+
 	state, exists := h.states[chatID]
 	if !exists {
 		state = &DrawdownState{
@@ -473,23 +489,27 @@ func (h *MaxDrawdownHalt) ForceHalt(ctx context.Context, chatID string, _ string
 	state.HaltCount++
 	h.metrics.IncrementHalt()
 
-	h.mu.Unlock()
-	h.saveState(ctx, state)
-
+	stateToSave = state
 	return nil
 }
 
 func (h *MaxDrawdownHalt) ResumeTrading(ctx context.Context, chatID string) error {
 	h.mu.Lock()
 
+	var stateToSave *DrawdownState
+	defer func() {
+		h.mu.Unlock()
+		if stateToSave != nil {
+			h.saveState(ctx, stateToSave)
+		}
+	}()
+
 	state, exists := h.states[chatID]
 	if !exists {
-		h.mu.Unlock()
 		return fmt.Errorf("no state found for chat %s", chatID)
 	}
 
 	if !state.TradingHalted {
-		h.mu.Unlock()
 		return fmt.Errorf("trading is not halted for chat %s", chatID)
 	}
 
@@ -500,9 +520,7 @@ func (h *MaxDrawdownHalt) ResumeTrading(ctx context.Context, chatID string) erro
 	state.RecoveredAt = &now
 	h.metrics.IncrementRecovery()
 
-	h.mu.Unlock()
-	h.saveState(ctx, state)
-
+	stateToSave = state
 	return nil
 }
 
@@ -580,6 +598,14 @@ func (h *MaxDrawdownHalt) CalculateDrawdown(peak, current decimal.Decimal) decim
 func (h *MaxDrawdownHalt) ResetPeak(ctx context.Context, chatID string, newValue decimal.Decimal) error {
 	h.mu.Lock()
 
+	var stateToSave *DrawdownState
+	defer func() {
+		h.mu.Unlock()
+		if stateToSave != nil {
+			h.saveState(ctx, stateToSave)
+		}
+	}()
+
 	state, exists := h.states[chatID]
 	if !exists {
 		state = &DrawdownState{
@@ -593,9 +619,7 @@ func (h *MaxDrawdownHalt) ResetPeak(ctx context.Context, chatID string, newValue
 	state.CurrentValue = newValue
 	state.CurrentDrawdown = decimal.Zero
 
-	h.mu.Unlock()
-	h.saveState(ctx, state)
-
+	stateToSave = state
 	return nil
 }
 
@@ -605,8 +629,15 @@ func (h *MaxDrawdownHalt) ForceResumeAll(ctx context.Context) []string {
 	h.mu.Lock()
 
 	resumed := make([]string, 0)
-	resumedStates := make([]*DrawdownState, 0)
+	var statesToSave []*DrawdownState
 	now := time.Now().UTC()
+
+	defer func() {
+		h.mu.Unlock()
+		for _, s := range statesToSave {
+			h.saveState(ctx, s)
+		}
+	}()
 
 	for chatID, state := range h.states {
 		if state.TradingHalted {
@@ -616,14 +647,8 @@ func (h *MaxDrawdownHalt) ForceResumeAll(ctx context.Context) []string {
 			state.RecoveredAt = &now
 			h.metrics.IncrementRecovery()
 			resumed = append(resumed, chatID)
-			resumedStates = append(resumedStates, state)
+			statesToSave = append(statesToSave, state)
 		}
-	}
-
-	h.mu.Unlock()
-
-	for _, state := range resumedStates {
-		h.saveState(ctx, state)
 	}
 
 	if len(resumed) > 0 {

--- a/services/backend-api/internal/services/max_drawdown_halt.go
+++ b/services/backend-api/internal/services/max_drawdown_halt.go
@@ -236,12 +236,20 @@ func (h *MaxDrawdownHalt) LoadStates(ctx context.Context) error {
 			return fmt.Errorf("failed to scan drawdown state: %w", err)
 		}
 		peakVal, peakErr := decimal.NewFromString(peakStr)
+		if peakErr != nil {
+			return fmt.Errorf("failed to parse peak_value for chat %s: %w", s.ChatID, peakErr)
+		}
 		currentVal, currentErr := decimal.NewFromString(currentStr)
+		if currentErr != nil {
+			return fmt.Errorf("failed to parse current_value for chat %s: %w", s.ChatID, currentErr)
+		}
 		drawdownVal, drawdownErr := decimal.NewFromString(drawdownStr)
+		if drawdownErr != nil {
+			return fmt.Errorf("failed to parse current_drawdown for chat %s: %w", s.ChatID, drawdownErr)
+		}
 		maxSeenVal, maxSeenErr := decimal.NewFromString(maxSeenStr)
-		if peakErr != nil || currentErr != nil || drawdownErr != nil || maxSeenErr != nil {
-			zaplogrus.Warnf("[DRAWDOWN] Skipping corrupt state for chat %s: parse error", s.ChatID)
-			continue
+		if maxSeenErr != nil {
+			return fmt.Errorf("failed to parse max_drawdown_seen for chat %s: %w", s.ChatID, maxSeenErr)
 		}
 		s.PeakValue = peakVal
 		s.CurrentValue = currentVal
@@ -261,9 +269,9 @@ func (h *MaxDrawdownHalt) LoadStates(ctx context.Context) error {
 	return nil
 }
 
-func (h *MaxDrawdownHalt) saveState(ctx context.Context, state *DrawdownState) {
+func (h *MaxDrawdownHalt) saveState(ctx context.Context, state *DrawdownState) error {
 	if h.db == nil || state == nil {
-		return
+		return nil
 	}
 	now := time.Now().UTC()
 	_, err := h.db.Exec(ctx, `INSERT INTO drawdown_states (chat_id, peak_value, current_value, current_drawdown, max_drawdown_seen, status, trading_halted, halted_at, recovered_at, last_checked, warning_count, halt_count, updated_at)
@@ -287,7 +295,9 @@ func (h *MaxDrawdownHalt) saveState(ctx context.Context, state *DrawdownState) {
 	)
 	if err != nil {
 		zaplogrus.Warnf("[DRAWDOWN] Failed to persist state for chat %s: %v", state.ChatID, err)
+		return fmt.Errorf("failed to persist drawdown state for chat %s: %w", state.ChatID, err)
 	}
+	return nil
 }
 
 func (h *MaxDrawdownHalt) CheckDrawdown(ctx context.Context, chatID string, currentValue decimal.Decimal) (*DrawdownState, error) {
@@ -328,10 +338,14 @@ func (h *MaxDrawdownHalt) CheckDrawdown(ctx context.Context, chatID string, curr
 	// Collect notification events while holding lock, then release before notifying
 	events := h.updateState(state)
 
+	// Deep copy state for persistence to avoid data races after unlocking
+	snapshot := *state
+
 	h.mu.Unlock()
 
-	// Persist state to DB after releasing lock to avoid blocking concurrent checks
-	h.saveState(ctx, state)
+	if err := h.saveState(ctx, &snapshot); err != nil {
+		return state, err
+	}
 
 	// Send notifications after releasing lock to prevent deadlock during network I/O
 	for _, evt := range events {
@@ -461,14 +475,16 @@ func (h *MaxDrawdownHalt) GetState(chatID string) (*DrawdownState, bool) {
 	return state, true
 }
 
-func (h *MaxDrawdownHalt) ForceHalt(ctx context.Context, chatID string, _ string) error {
+func (h *MaxDrawdownHalt) ForceHalt(ctx context.Context, chatID string, _ string) (err error) {
 	h.mu.Lock()
 
-	var stateToSave *DrawdownState
+	var stateToSave DrawdownState
 	defer func() {
 		h.mu.Unlock()
-		if stateToSave != nil {
-			h.saveState(ctx, stateToSave)
+		if stateToSave.ChatID != "" {
+			if saveErr := h.saveState(ctx, &stateToSave); saveErr != nil && err == nil {
+				err = saveErr
+			}
 		}
 	}()
 
@@ -489,18 +505,20 @@ func (h *MaxDrawdownHalt) ForceHalt(ctx context.Context, chatID string, _ string
 	state.HaltCount++
 	h.metrics.IncrementHalt()
 
-	stateToSave = state
+	stateToSave = *state
 	return nil
 }
 
-func (h *MaxDrawdownHalt) ResumeTrading(ctx context.Context, chatID string) error {
+func (h *MaxDrawdownHalt) ResumeTrading(ctx context.Context, chatID string) (err error) {
 	h.mu.Lock()
 
-	var stateToSave *DrawdownState
+	var stateToSave DrawdownState
 	defer func() {
 		h.mu.Unlock()
-		if stateToSave != nil {
-			h.saveState(ctx, stateToSave)
+		if stateToSave.ChatID != "" {
+			if saveErr := h.saveState(ctx, &stateToSave); saveErr != nil && err == nil {
+				err = saveErr
+			}
 		}
 	}()
 
@@ -520,7 +538,7 @@ func (h *MaxDrawdownHalt) ResumeTrading(ctx context.Context, chatID string) erro
 	state.RecoveredAt = &now
 	h.metrics.IncrementRecovery()
 
-	stateToSave = state
+	stateToSave = *state
 	return nil
 }
 
@@ -595,14 +613,16 @@ func (h *MaxDrawdownHalt) CalculateDrawdown(peak, current decimal.Decimal) decim
 	return peak.Sub(current).Div(peak)
 }
 
-func (h *MaxDrawdownHalt) ResetPeak(ctx context.Context, chatID string, newValue decimal.Decimal) error {
+func (h *MaxDrawdownHalt) ResetPeak(ctx context.Context, chatID string, newValue decimal.Decimal) (err error) {
 	h.mu.Lock()
 
-	var stateToSave *DrawdownState
+	var stateToSave DrawdownState
 	defer func() {
 		h.mu.Unlock()
-		if stateToSave != nil {
-			h.saveState(ctx, stateToSave)
+		if stateToSave.ChatID != "" {
+			if saveErr := h.saveState(ctx, &stateToSave); saveErr != nil && err == nil {
+				err = saveErr
+			}
 		}
 	}()
 
@@ -619,7 +639,7 @@ func (h *MaxDrawdownHalt) ResetPeak(ctx context.Context, chatID string, newValue
 	state.CurrentValue = newValue
 	state.CurrentDrawdown = decimal.Zero
 
-	stateToSave = state
+	stateToSave = *state
 	return nil
 }
 
@@ -635,7 +655,7 @@ func (h *MaxDrawdownHalt) ForceResumeAll(ctx context.Context) []string {
 	defer func() {
 		h.mu.Unlock()
 		for _, s := range statesToSave {
-			h.saveState(ctx, s)
+			_ = h.saveState(ctx, s)
 		}
 	}()
 
@@ -647,7 +667,8 @@ func (h *MaxDrawdownHalt) ForceResumeAll(ctx context.Context) []string {
 			state.RecoveredAt = &now
 			h.metrics.IncrementRecovery()
 			resumed = append(resumed, chatID)
-			statesToSave = append(statesToSave, state)
+			snapshot := *state
+			statesToSave = append(statesToSave, &snapshot)
 		}
 	}
 

--- a/services/backend-api/internal/services/max_drawdown_halt.go
+++ b/services/backend-api/internal/services/max_drawdown_halt.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"strconv"
@@ -180,6 +181,107 @@ func NewMaxDrawdownHaltWithNotification(db DBPool, config MaxDrawdownConfig, not
 	}
 }
 
+func (h *MaxDrawdownHalt) InitSchema(ctx context.Context) error {
+	if h.db == nil {
+		return fmt.Errorf("database connection is nil")
+	}
+	_, err := h.db.Exec(ctx, `CREATE TABLE IF NOT EXISTS drawdown_states (
+		chat_id TEXT PRIMARY KEY,
+		peak_value TEXT NOT NULL DEFAULT '0',
+		current_value TEXT NOT NULL DEFAULT '0',
+		current_drawdown TEXT NOT NULL DEFAULT '0',
+		max_drawdown_seen TEXT NOT NULL DEFAULT '0',
+		status TEXT NOT NULL DEFAULT 'normal',
+		trading_halted BOOLEAN NOT NULL DEFAULT FALSE,
+		halted_at TIMESTAMP,
+		recovered_at TIMESTAMP,
+		last_checked TIMESTAMP NOT NULL,
+		warning_count INTEGER NOT NULL DEFAULT 0,
+		halt_count INTEGER NOT NULL DEFAULT 0,
+		updated_at TIMESTAMP NOT NULL
+	)`)
+	if err != nil {
+		return fmt.Errorf("failed to create drawdown_states table: %w", err)
+	}
+	_, err = h.db.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_drawdown_states_trading_halted ON drawdown_states(trading_halted, updated_at DESC)`)
+	if err != nil {
+		return fmt.Errorf("failed to create trading_halted index: %w", err)
+	}
+	_, err = h.db.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_drawdown_states_status ON drawdown_states(status, updated_at DESC)`)
+	if err != nil {
+		return fmt.Errorf("failed to create status index: %w", err)
+	}
+	return nil
+}
+
+func (h *MaxDrawdownHalt) LoadStates(ctx context.Context) error {
+	if h.db == nil {
+		return nil
+	}
+	rows, err := h.db.Query(ctx, `SELECT chat_id, peak_value, current_value, current_drawdown, max_drawdown_seen, status, trading_halted, halted_at, recovered_at, last_checked, warning_count, halt_count FROM drawdown_states`)
+	if err != nil {
+		return fmt.Errorf("failed to load drawdown states: %w", err)
+	}
+	defer rows.Close()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for rows.Next() {
+		var s DrawdownState
+		var peakStr, currentStr, drawdownStr, maxSeenStr string
+		var haltedAt, recoveredAt sql.NullTime
+		err := rows.Scan(&s.ChatID, &peakStr, &currentStr, &drawdownStr, &maxSeenStr, &s.Status, &s.TradingHalted, &haltedAt, &recoveredAt, &s.LastChecked, &s.WarningCount, &s.HaltCount)
+		if err != nil {
+			return fmt.Errorf("failed to scan drawdown state: %w", err)
+		}
+		s.PeakValue, _ = decimal.NewFromString(peakStr)
+		s.CurrentValue, _ = decimal.NewFromString(currentStr)
+		s.CurrentDrawdown, _ = decimal.NewFromString(drawdownStr)
+		s.MaxDrawdownSeen, _ = decimal.NewFromString(maxSeenStr)
+		if haltedAt.Valid {
+			s.HaltedAt = &haltedAt.Time
+		}
+		if recoveredAt.Valid {
+			s.RecoveredAt = &recoveredAt.Time
+		}
+		h.states[s.ChatID] = &s
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate drawdown states: %w", err)
+	}
+	return nil
+}
+
+func (h *MaxDrawdownHalt) saveState(ctx context.Context, state *DrawdownState) {
+	if h.db == nil || state == nil {
+		return
+	}
+	now := time.Now().UTC()
+	_, err := h.db.Exec(ctx, `INSERT INTO drawdown_states (chat_id, peak_value, current_value, current_drawdown, max_drawdown_seen, status, trading_halted, halted_at, recovered_at, last_checked, warning_count, halt_count, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+		ON CONFLICT (chat_id) DO UPDATE SET
+			peak_value = EXCLUDED.peak_value,
+			current_value = EXCLUDED.current_value,
+			current_drawdown = EXCLUDED.current_drawdown,
+			max_drawdown_seen = EXCLUDED.max_drawdown_seen,
+			status = EXCLUDED.status,
+			trading_halted = EXCLUDED.trading_halted,
+			halted_at = EXCLUDED.halted_at,
+			recovered_at = EXCLUDED.recovered_at,
+			last_checked = EXCLUDED.last_checked,
+			warning_count = EXCLUDED.warning_count,
+			halt_count = EXCLUDED.halt_count,
+			updated_at = EXCLUDED.updated_at`,
+		state.ChatID, state.PeakValue.String(), state.CurrentValue.String(), state.CurrentDrawdown.String(), state.MaxDrawdownSeen.String(),
+		string(state.Status), state.TradingHalted, state.HaltedAt, state.RecoveredAt, state.LastChecked,
+		state.WarningCount, state.HaltCount, now,
+	)
+	if err != nil {
+		zaplogrus.Warnf("[DRAWDOWN] Failed to persist state for chat %s: %v", state.ChatID, err)
+	}
+}
+
 func (h *MaxDrawdownHalt) CheckDrawdown(ctx context.Context, chatID string, currentValue decimal.Decimal) (*DrawdownState, error) {
 	h.metrics.IncrementTotal()
 
@@ -219,6 +321,9 @@ func (h *MaxDrawdownHalt) CheckDrawdown(ctx context.Context, chatID string, curr
 	events := h.updateState(state)
 
 	h.mu.Unlock()
+
+	// Persist state to DB after releasing lock to avoid blocking concurrent checks
+	h.saveState(ctx, state)
 
 	// Send notifications after releasing lock to prevent deadlock during network I/O
 	for _, evt := range events {
@@ -350,7 +455,6 @@ func (h *MaxDrawdownHalt) GetState(chatID string) (*DrawdownState, bool) {
 
 func (h *MaxDrawdownHalt) ForceHalt(ctx context.Context, chatID string, _ string) error {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	state, exists := h.states[chatID]
 	if !exists {
@@ -369,19 +473,23 @@ func (h *MaxDrawdownHalt) ForceHalt(ctx context.Context, chatID string, _ string
 	state.HaltCount++
 	h.metrics.IncrementHalt()
 
+	h.mu.Unlock()
+	h.saveState(ctx, state)
+
 	return nil
 }
 
 func (h *MaxDrawdownHalt) ResumeTrading(ctx context.Context, chatID string) error {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	state, exists := h.states[chatID]
 	if !exists {
+		h.mu.Unlock()
 		return fmt.Errorf("no state found for chat %s", chatID)
 	}
 
 	if !state.TradingHalted {
+		h.mu.Unlock()
 		return fmt.Errorf("trading is not halted for chat %s", chatID)
 	}
 
@@ -391,6 +499,9 @@ func (h *MaxDrawdownHalt) ResumeTrading(ctx context.Context, chatID string) erro
 	now := time.Now().UTC()
 	state.RecoveredAt = &now
 	h.metrics.IncrementRecovery()
+
+	h.mu.Unlock()
+	h.saveState(ctx, state)
 
 	return nil
 }
@@ -468,7 +579,6 @@ func (h *MaxDrawdownHalt) CalculateDrawdown(peak, current decimal.Decimal) decim
 
 func (h *MaxDrawdownHalt) ResetPeak(ctx context.Context, chatID string, newValue decimal.Decimal) error {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	state, exists := h.states[chatID]
 	if !exists {
@@ -483,6 +593,9 @@ func (h *MaxDrawdownHalt) ResetPeak(ctx context.Context, chatID string, newValue
 	state.CurrentValue = newValue
 	state.CurrentDrawdown = decimal.Zero
 
+	h.mu.Unlock()
+	h.saveState(ctx, state)
+
 	return nil
 }
 
@@ -490,9 +603,9 @@ func (h *MaxDrawdownHalt) ResetPeak(ctx context.Context, chatID string, newValue
 // This is useful for manual intervention or when system state needs to be reset.
 func (h *MaxDrawdownHalt) ForceResumeAll(ctx context.Context) []string {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	resumed := make([]string, 0)
+	resumedStates := make([]*DrawdownState, 0)
 	now := time.Now().UTC()
 
 	for chatID, state := range h.states {
@@ -503,7 +616,14 @@ func (h *MaxDrawdownHalt) ForceResumeAll(ctx context.Context) []string {
 			state.RecoveredAt = &now
 			h.metrics.IncrementRecovery()
 			resumed = append(resumed, chatID)
+			resumedStates = append(resumedStates, state)
 		}
+	}
+
+	h.mu.Unlock()
+
+	for _, state := range resumedStates {
+		h.saveState(ctx, state)
 	}
 
 	if len(resumed) > 0 {

--- a/services/backend-api/internal/services/max_drawdown_halt_test.go
+++ b/services/backend-api/internal/services/max_drawdown_halt_test.go
@@ -2,9 +2,13 @@ package services
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
+	"github.com/irfndi/neuratrade/internal/database"
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMaxDrawdownConfig_Defaults(t *testing.T) {
@@ -317,4 +321,179 @@ func TestMaxDrawdownHalt_GetStatusSummary(t *testing.T) {
 	if !ok || total != 2 {
 		t.Errorf("expected 2 total accounts, got %v", summary["total_accounts"])
 	}
+}
+
+func TestMaxDrawdownHalt_DB_InitSchema(t *testing.T) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "drawdown-halt.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	halt := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	ctx := context.Background()
+
+	require.NoError(t, halt.InitSchema(ctx))
+}
+
+func TestMaxDrawdownHalt_DB_CheckDrawdownPersists(t *testing.T) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "drawdown-halt-persist.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	halt := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	ctx := context.Background()
+	require.NoError(t, halt.InitSchema(ctx))
+
+	state, err := halt.CheckDrawdown(ctx, "chat-1", decimal.NewFromInt(1000))
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	// Create a new instance and load states to verify persistence
+	halt2 := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	require.NoError(t, halt2.LoadStates(ctx))
+
+	loaded, exists := halt2.GetState("chat-1")
+	require.True(t, exists)
+	assert.True(t, loaded.PeakValue.Equal(decimal.NewFromInt(1000)))
+	assert.True(t, loaded.CurrentValue.Equal(decimal.NewFromInt(1000)))
+	assert.Equal(t, DrawdownStatusNormal, loaded.Status)
+}
+
+func TestMaxDrawdownHalt_DB_ForceHaltPersists(t *testing.T) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "drawdown-halt-force.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	halt := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	ctx := context.Background()
+	require.NoError(t, halt.InitSchema(ctx))
+
+	require.NoError(t, halt.ForceHalt(ctx, "chat-1", "manual"))
+
+	halt2 := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	require.NoError(t, halt2.LoadStates(ctx))
+
+	assert.True(t, halt2.IsTradingHalted("chat-1"))
+	loaded, exists := halt2.GetState("chat-1")
+	require.True(t, exists)
+	assert.Equal(t, DrawdownStatusHalted, loaded.Status)
+	assert.Equal(t, 1, loaded.HaltCount)
+}
+
+func TestMaxDrawdownHalt_DB_ResumeTradingPersists(t *testing.T) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "drawdown-halt-resume.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	halt := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	ctx := context.Background()
+	require.NoError(t, halt.InitSchema(ctx))
+
+	_, _ = halt.CheckDrawdown(ctx, "chat-1", decimal.NewFromInt(1000))
+	_, _ = halt.CheckDrawdown(ctx, "chat-1", decimal.NewFromInt(800))
+	require.True(t, halt.IsTradingHalted("chat-1"))
+
+	require.NoError(t, halt.ResumeTrading(ctx, "chat-1"))
+
+	halt2 := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	require.NoError(t, halt2.LoadStates(ctx))
+
+	assert.False(t, halt2.IsTradingHalted("chat-1"))
+	loaded, exists := halt2.GetState("chat-1")
+	require.True(t, exists)
+	assert.Equal(t, DrawdownStatusNormal, loaded.Status)
+	require.NotNil(t, loaded.RecoveredAt)
+}
+
+func TestMaxDrawdownHalt_DB_ResetPeakPersists(t *testing.T) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "drawdown-halt-reset.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	halt := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	ctx := context.Background()
+	require.NoError(t, halt.InitSchema(ctx))
+
+	_, _ = halt.CheckDrawdown(ctx, "chat-1", decimal.NewFromInt(1000))
+	require.NoError(t, halt.ResetPeak(ctx, "chat-1", decimal.NewFromInt(900)))
+
+	halt2 := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	require.NoError(t, halt2.LoadStates(ctx))
+
+	loaded, exists := halt2.GetState("chat-1")
+	require.True(t, exists)
+	assert.True(t, loaded.PeakValue.Equal(decimal.NewFromInt(900)))
+	assert.True(t, loaded.CurrentValue.Equal(decimal.NewFromInt(900)))
+	assert.True(t, loaded.CurrentDrawdown.IsZero())
+}
+
+func TestMaxDrawdownHalt_DB_ForceResumeAllPersists(t *testing.T) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "drawdown-halt-resume-all.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	halt := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	ctx := context.Background()
+	require.NoError(t, halt.InitSchema(ctx))
+
+	_, _ = halt.CheckDrawdown(ctx, "chat-1", decimal.NewFromInt(1000))
+	_, _ = halt.CheckDrawdown(ctx, "chat-1", decimal.NewFromInt(800))
+	_, _ = halt.CheckDrawdown(ctx, "chat-2", decimal.NewFromInt(1000))
+	_, _ = halt.CheckDrawdown(ctx, "chat-2", decimal.NewFromInt(700))
+
+	require.True(t, halt.IsTradingHalted("chat-1"))
+	require.True(t, halt.IsTradingHalted("chat-2"))
+
+	resumed := halt.ForceResumeAll(ctx)
+	require.Len(t, resumed, 2)
+
+	halt2 := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	require.NoError(t, halt2.LoadStates(ctx))
+
+	assert.False(t, halt2.IsTradingHalted("chat-1"))
+	assert.False(t, halt2.IsTradingHalted("chat-2"))
+}
+
+func TestMaxDrawdownHalt_DB_LoadStatesEmpty(t *testing.T) {
+	sqliteDB, err := database.NewSQLiteConnection(filepath.Join(t.TempDir(), "drawdown-halt-empty.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqliteDB.Close()
+	})
+
+	halt := NewMaxDrawdownHalt(sqliteDB, DefaultMaxDrawdownConfig())
+	ctx := context.Background()
+	require.NoError(t, halt.InitSchema(ctx))
+	require.NoError(t, halt.LoadStates(ctx))
+
+	assert.False(t, halt.IsTradingHalted("any-chat"))
+}
+
+func TestMaxDrawdownHalt_DB_NilDatabase(t *testing.T) {
+	halt := NewMaxDrawdownHalt(nil, DefaultMaxDrawdownConfig())
+	ctx := context.Background()
+
+	// InitSchema should return error when db is nil
+	err := halt.InitSchema(ctx)
+	require.Error(t, err)
+
+	// LoadStates should return nil (no-op) when db is nil
+	err = halt.LoadStates(ctx)
+	require.NoError(t, err)
+
+	// Operations should work without DB
+	state, err := halt.CheckDrawdown(ctx, "chat-1", decimal.NewFromInt(1000))
+	require.NoError(t, err)
+	require.NotNil(t, state)
 }

--- a/services/backend-api/test/e2e/telegram_e2e_test.go
+++ b/services/backend-api/test/e2e/telegram_e2e_test.go
@@ -100,7 +100,7 @@ func (s *TelegramE2ETestSuite) SetupSuite() {
 	cacheAnalyticsService := services.NewCacheAnalyticsService(nil)
 
 	// Setup routes
-	_, err = api.SetupRoutes(s.router, s.db, s.redisClient, mockCCXT, nil, nil, cacheAnalyticsService, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil)
+	_, err = api.SetupRoutes(s.router, s.db, s.redisClient, mockCCXT, nil, nil, cacheAnalyticsService, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil, nil)
 	require.NoError(s.T(), err)
 
 	// Create test user

--- a/services/backend-api/test/integration/autonomous_integration_test.go
+++ b/services/backend-api/test/integration/autonomous_integration_test.go
@@ -84,7 +84,7 @@ func TestAutonomousIntegration(t *testing.T) {
 		Used:      map[string]float64{"USDT": 5000.0, "BTC": 0.0},
 	}, nil)
 
-	_, err = api.SetupRoutes(router, db, redisClient, mockCCXT, nil, nil, nil, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil)
+	_, err = api.SetupRoutes(router, db, redisClient, mockCCXT, nil, nil, nil, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	testTelegramChatID := fmt.Sprintf("tg_auto_%s", uuid.New().String())

--- a/services/backend-api/test/integration/telegram_integration_test.go
+++ b/services/backend-api/test/integration/telegram_integration_test.go
@@ -80,7 +80,7 @@ func TestTelegramIntegration(t *testing.T) {
 
 	// Call SetupRoutes
 	// We pass nil for services not involved in this test flow
-	_, err = api.SetupRoutes(router, db, redisClient, mockCCXT, nil, nil, nil, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil)
+	_, err = api.SetupRoutes(router, db, redisClient, mockCCXT, nil, nil, nil, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Test Data


### PR DESCRIPTION
## Summary
This PR addresses critical real-money readiness gaps identified in the production audit:

1. **Drawdown Halt DB Persistence** (most critical gap)
   - Drawdown halt state was purely in-memory. A process restart would lose halt status and peak values, allowing trades immediately after restart.
   - Added `drawdown_states` table (migration 082) with individual columns for queryability.
   - `MaxDrawdownHalt` now loads persisted states on startup and saves after every mutation (`CheckDrawdown`, `ForceHalt`, `ResumeTrading`, `ResetPeak`, `ForceResumeAll`).
   - Added 8 new tests for DB persistence round-trips.

2. **CCXT Order Executor Retry Logic**
   - Added `doWithRetry` with exponential backoff + jitter.
   - Retries on 5xx/network errors, NOT on 4xx client errors.
   - `MaxRetries` config (default 3).
   - Added retry tests for 5xx recovery and 4xx no-retry.

## Test Plan
- [x] All 23 drawdown halt tests pass
- [x] All 2335 services package tests pass
- [x] All 41 API package tests pass
- [x] Full suite: 4900+ tests pass, 0 failures
- [x] Coverage remains at 77.8% (above 77% threshold)

## Migration
- Run migration `082_create_drawdown_states.sql` to create the new table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent drawdown halt state stored in the database for recovery after restarts.
  * Automatic retry with jittered backoff for order operations, improving resilience.

* **Tests**
  * Added tests covering retry behavior and drawdown-state persistence and recovery.

* **Chores**
  * Configuration validation added for encryption keys in production/staging; encryption setup now rejects empty/whitespace keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->