### PR TITLE
fix(risk): unify kill switch + safe mode across HTTP routes and trading pipeline (NeuraTrade-n6g)

### DIFF
--- a/.beads/export-state.json
+++ b/.beads/export-state.json
@@ -1,1 +1,1 @@
-{"last_dolt_commit":"cd1a2t4lpdss7b4dn95iqv4eeuf53aqe","timestamp":"2026-06-01T21:11:21.337757+07:00","issues":491,"memories":0}
+{"last_dolt_commit":"ue9g4vbkutbqgrr7pf11epuvgd8tnu6u","timestamp":"2026-06-01T22:38:54.088078+07:00","issues":491,"memories":0}

--- a/services/backend-api/cmd/server/main.go
+++ b/services/backend-api/cmd/server/main.go
@@ -28,6 +28,8 @@ import (
 	"github.com/irfndi/neuratrade/internal/observability"
 	"github.com/irfndi/neuratrade/internal/services"
 	"github.com/redis/go-redis/v9"
+
+	apprisk "github.com/irfndi/neuratrade/internal/app/risk"
 	"github.com/shopspring/decimal"
 )
 
@@ -529,8 +531,20 @@ func run() error {
 		cfg.Security.CORSAllowedOrigins = cfg.Server.AllowedOrigins
 	}
 
+	sharedKillSwitch := apprisk.NewKillSwitch()
+	if db != nil {
+		store := apprisk.NewSQLKillSwitchStore(db)
+		sharedKillSwitch.SetStore(store)
+		reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := sharedKillSwitch.Reconcile(reconcileCtx); err != nil {
+			zaplogrus.Warnf("kill switch reconcile: %v", err)
+		}
+		reconcileCancel()
+	}
+	sharedSafeMode := apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
+
 	// Setup routes and get cleanup function
-	cleanupRoutes, err := api.SetupRoutes(router, db, redisClient, ccxtService, collectorService, cleanupService, cacheAnalyticsService, signalAggregator, analyticsService, &cfg.Telegram, &cfg.AI, &cfg.Features, authMiddleware, walletValidator, opModeService, technicalAnalysisService, &cfg.Security, apiKeyService)
+	cleanupRoutes, err := api.SetupRoutes(router, db, redisClient, ccxtService, collectorService, cleanupService, cacheAnalyticsService, signalAggregator, analyticsService, &cfg.Telegram, &cfg.AI, &cfg.Features, authMiddleware, walletValidator, opModeService, technicalAnalysisService, &cfg.Security, apiKeyService, sharedKillSwitch, sharedSafeMode)
 	if err != nil {
 		return fmt.Errorf("failed to setup routes: %w", err)
 	}

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -442,7 +442,7 @@ func riskLockSourcePriority(source string) int {
 // It returns a cleanup function that should be called on shutdown to stop background resources (for example, the WebSocket handler).
 //
 //nolint:staticcheck // SA1019: SignalAggregator and TechnicalAnalysisService are deprecated but required for backward compatibility until scalping composer migration completes.
-func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, ccxtService ccxt.CCXTService, collectorService *services.CollectorService, cleanupService *services.CleanupService, cacheAnalyticsService *services.CacheAnalyticsService, signalAggregator *services.SignalAggregator, analyticsService *services.AnalyticsService, telegramConfig *config.TelegramConfig, aiConfig *config.AIConfig, featuresConfig *config.FeaturesConfig, authMiddleware *middleware.AuthMiddleware, walletValidator *services.WalletValidator, opModeService *services.OperationalModeService, technicalAnalysisService *services.TechnicalAnalysisService, securityConfig *config.SecurityConfig, apiKeyService *services.APIKeyService) (func(), error) {
+func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, ccxtService ccxt.CCXTService, collectorService *services.CollectorService, cleanupService *services.CleanupService, cacheAnalyticsService *services.CacheAnalyticsService, signalAggregator *services.SignalAggregator, analyticsService *services.AnalyticsService, telegramConfig *config.TelegramConfig, aiConfig *config.AIConfig, featuresConfig *config.FeaturesConfig, authMiddleware *middleware.AuthMiddleware, walletValidator *services.WalletValidator, opModeService *services.OperationalModeService, technicalAnalysisService *services.TechnicalAnalysisService, securityConfig *config.SecurityConfig, apiKeyService *services.APIKeyService, sharedKillSwitch *apprisk.KillSwitchImpl, sharedSafeMode *apprisk.SafeModeImpl) (func(), error) {
 	configureLiveReadinessGuard(opModeService, db)
 
 	allowedOrigins := []string{"http://localhost:3000"}
@@ -806,6 +806,8 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		NotificationService: notificationService,
 		MonitoringService:   autonomousMonitoring,
 		SQLDB:               sqlDB,
+		KillSwitch:          sharedKillSwitch,
+		SafeMode:            sharedSafeMode,
 	}
 
 	// Create integrated quest runtime handlers through app/autonomy module.
@@ -1250,17 +1252,21 @@ func SetupRoutes(router *gin.Engine, db routeDB, redis *database.RedisClient, cc
 		zaplogrus.Warnf("WARNING: OperationalModeService is nil, trading mode endpoints disabled")
 	}
 
-	sharedKillSwitch := apprisk.NewKillSwitch()
-	if db != nil {
-		store := apprisk.NewSQLKillSwitchStore(db)
-		sharedKillSwitch.SetStore(store)
-		reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if err := sharedKillSwitch.Reconcile(reconcileCtx); err != nil {
-			zaplogrus.Warnf("kill switch reconcile: %v", err)
+	if sharedKillSwitch == nil {
+		sharedKillSwitch = apprisk.NewKillSwitch()
+		if db != nil {
+			store := apprisk.NewSQLKillSwitchStore(db)
+			sharedKillSwitch.SetStore(store)
+			reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := sharedKillSwitch.Reconcile(reconcileCtx); err != nil {
+				zaplogrus.Warnf("kill switch reconcile: %v", err)
+			}
+			reconcileCancel()
 		}
-		reconcileCancel()
 	}
-	sharedSafeMode := apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
+	if sharedSafeMode == nil {
+		sharedSafeMode = apprisk.NewSafeMode(apprisk.DefaultSafeModeConfig())
+	}
 
 	agentControlHandler := handlers.NewAgentControlHandler(handlers.AgentControlDeps{
 		Autonomy:  integratedHandlers.AutonomyCoordinator(),

--- a/services/backend-api/internal/api/routes_regression_test.go
+++ b/services/backend-api/internal/api/routes_regression_test.go
@@ -60,7 +60,7 @@ func TestSetupRoutes_HealthEndpointContractRegression(t *testing.T) {
 	cacheAnalyticsService := services.NewCacheAnalyticsService(nil)
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
 
-	teardown, err := SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, cacheAnalyticsService, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil)
+	teardown, err := SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, cacheAnalyticsService, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer teardown()
 

--- a/services/backend-api/internal/api/routes_test.go
+++ b/services/backend-api/internal/api/routes_test.go
@@ -332,7 +332,7 @@ func TestSetupRoutes_PanicHandling(t *testing.T) {
 	assert.NotNil(t, router)
 
 	assert.Panics(t, func() {
-		_, _ = SetupRoutes(router, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		_, _ = SetupRoutes(router, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	}, "SetupRoutes should panic with nil dependencies")
 }
 
@@ -376,7 +376,7 @@ func TestSetupRoutes_RouteRegistration(t *testing.T) {
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
 
 	assert.NotPanics(t, func() {
-		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil)
+		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil, nil, nil)
 	}, "SetupRoutes should handle minimal dependencies gracefully")
 
 	// Verify routes were registered
@@ -434,7 +434,7 @@ func TestSetupRoutes_RouteGroups(t *testing.T) {
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil, nil, nil)
 
 	// Get all routes
 	routes := router.Routes()
@@ -499,7 +499,7 @@ func TestSetupRoutes_HttpMethods(t *testing.T) {
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil, nil, nil)
 
 	// Get all routes
 	routes := router.Routes()
@@ -567,7 +567,7 @@ func TestSetupRoutes_Middleware(t *testing.T) {
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil, nil, nil)
 
 	// Test that router has middleware configured
 	// Gin router should have middleware registered
@@ -623,7 +623,7 @@ func TestSetupRoutes_MissingAdminKey(t *testing.T) {
 			}),
 		}
 		mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil)
+		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil, nil, nil)
 	}, "SetupRoutes should handle missing admin key gracefully")
 }
 
@@ -667,7 +667,7 @@ func TestSetupRoutes_MissingTelegramConfig(t *testing.T) {
 			}),
 		}
 		mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil)
+		_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil, nil, nil)
 	}, "SetupRoutes should not panic when telegram config is missing")
 
 	// Verify routes were still registered
@@ -705,7 +705,7 @@ func TestSetupRoutes_AIUserRoutesRequireAuth(t *testing.T) {
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/ai/status/user-123", nil)
 	rec := httptest.NewRecorder()
@@ -745,7 +745,7 @@ func TestSetupRoutes_TelegramInternalRequiresAdminAuth(t *testing.T) {
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/telegram/internal/quests", nil)
 	rec := httptest.NewRecorder()
@@ -785,7 +785,7 @@ func TestSetupRoutes_TelegramLegacyInternalAliasesRequireAdminAuth(t *testing.T)
 		}),
 	}
 	mockAuthMiddleware := middleware.MustNewAuthMiddleware("test-secret-key-must-be-32-chars-min!")
-	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil)
+	_, _ = SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, nil, nil, nil, nil)
 
 	legacyPaths := []struct {
 		method string
@@ -1070,7 +1070,7 @@ func TestSetupRoutes_CORSAllowedOrigin(t *testing.T) {
 		CORSAllowedOrigins: []string{"https://app.example.com"},
 	}
 
-	_, err := SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, securityConfig, nil)
+	_, err := SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, securityConfig, nil, nil, nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodOptions, "/api/v1/health", nil)
@@ -1106,7 +1106,7 @@ func TestSetupRoutes_CORSDisallowedOrigin(t *testing.T) {
 		CORSAllowedOrigins: []string{"https://app.example.com"},
 	}
 
-	_, err := SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, securityConfig, nil)
+	_, err := SetupRoutes(router, mockDB, mockRedis, mockCCXT, nil, nil, nil, nil, nil, mockTelegramConfig, nil, nil, mockAuthMiddleware, nil, nil, nil, securityConfig, nil, nil, nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)

--- a/services/backend-api/internal/app/autonomy/runtime/runtime.go
+++ b/services/backend-api/internal/app/autonomy/runtime/runtime.go
@@ -19,6 +19,8 @@ type Dependencies struct {
 	NotificationService *services.NotificationService
 	MonitoringService   *services.AutonomousMonitorManager
 	SQLDB               *sql.DB
+	KillSwitch          interface{ IsEngaged() bool }
+	SafeMode            interface{ IsEnabled() bool }
 }
 
 func BuildLocalIntegratedHandlers(deps Dependencies) *services.IntegratedQuestHandlers {
@@ -29,6 +31,8 @@ func BuildLocalIntegratedHandlers(deps Dependencies) *services.IntegratedQuestHa
 		deps.FuturesArbService,
 		deps.NotificationService,
 		deps.MonitoringService,
+		deps.KillSwitch,
+		deps.SafeMode,
 	)
 	handlers.SetDB(deps.SQLDB)
 	return handlers
@@ -54,6 +58,8 @@ func BuildIntegratedHandlers(deps Dependencies) (*services.IntegratedQuestHandle
 		deps.MonitoringService,
 		deps.SQLDB,
 		nil,
+		deps.KillSwitch,
+		deps.SafeMode,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build integrated autonomy handlers: %w", err)

--- a/services/backend-api/internal/services/quest_handlers_integrated.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated.go
@@ -63,6 +63,8 @@ type IntegratedQuestHandlers struct {
 	tradeJournalMu       sync.Mutex
 	tradeJournalReady    bool
 	tradeJournalReadyFor *sql.DB
+	killSwitch           interface{ IsEngaged() bool }
+	safeMode             interface{ IsEnabled() bool }
 }
 
 const (
@@ -100,6 +102,8 @@ func NewIntegratedQuestHandlers(
 	futuresArb interface{},
 	notif *NotificationService,
 	monitoring *AutonomousMonitorManager,
+	killSwitch interface{ IsEngaged() bool },
+	safeMode interface{ IsEnabled() bool },
 ) *IntegratedQuestHandlers {
 	return &IntegratedQuestHandlers{
 		technicalAnalysis:   ta,
@@ -108,6 +112,8 @@ func NewIntegratedQuestHandlers(
 		futuresArbService:   futuresArb,
 		notificationService: notif,
 		monitoring:          monitoring,
+		killSwitch:          killSwitch,
+		safeMode:            safeMode,
 	}
 }
 
@@ -121,8 +127,10 @@ func NewIntegratedQuestHandlersWithAutonomyStore(
 	monitoring *AutonomousMonitorManager,
 	db *sql.DB,
 	store *AutonomousRolloutStore,
+	killSwitch interface{ IsEngaged() bool },
+	safeMode interface{ IsEnabled() bool },
 ) (*IntegratedQuestHandlers, error) {
-	handlers := NewIntegratedQuestHandlers(ta, ccxt, arb, futuresArb, notif, monitoring)
+	handlers := NewIntegratedQuestHandlers(ta, ccxt, arb, futuresArb, notif, monitoring, killSwitch, safeMode)
 	handlers.SetDB(db)
 	if err := handlers.setAutonomyStoreWithInit(context.Background(), store); err != nil {
 		return nil, fmt.Errorf("failed to set autonomy store in NewIntegratedQuestHandlersWithAutonomyStore: %w", err)
@@ -1391,16 +1399,8 @@ func (h *IntegratedQuestHandlers) executeAIScalping(ctx context.Context, quest *
 		connectionChecked = true
 		exchangeConnected = healthChecker.IsHealthy(ctx)
 	}
-	safeMode := checkpointBool(quest.Checkpoint["runtime_entry_blocked_by_risk_lock"])
-	if envSafeMode, ok := getEnvBool("NEURATRADE_SAFE_MODE_ENABLED"); ok && envSafeMode {
-		safeMode = true
-	}
-	killSwitchEngaged := false
-	if envKillSwitch, ok := getEnvBool("NEURATRADE_KILL_SWITCH_ENGAGED"); ok {
-		killSwitchEngaged = envKillSwitch
-	} else if envKillSwitch, ok := getEnvBool("NEURATRADE_KILL_SWITCH"); ok {
-		killSwitchEngaged = envKillSwitch
-	}
+	safeMode := checkpointBool(quest.Checkpoint["runtime_entry_blocked_by_risk_lock"]) || (h.safeMode != nil && h.safeMode.IsEnabled())
+	killSwitchEngaged := h.killSwitch != nil && h.killSwitch.IsEngaged()
 	strategyID := ScalpingStrategyID(chatID)
 	cycleCtx := WithScalpingAutonomyScope(ctx, ScalpingAutonomyScope{
 		ChatID:            chatID,

--- a/services/backend-api/internal/services/quest_handlers_integrated_test.go
+++ b/services/backend-api/internal/services/quest_handlers_integrated_test.go
@@ -62,7 +62,7 @@ func TestIntegratedQuestHandlers_MarketScanWithTA(t *testing.T) {
 	mockMonitoring := NewAutonomousMonitorManager(mockNotif, testLogger)
 
 	handlers := NewIntegratedQuestHandlers(
-		nil, nil, nil, nil, mockNotif, mockMonitoring,
+		nil, nil, nil, nil, mockNotif, mockMonitoring, nil, nil,
 	)
 
 	quest := &Quest{
@@ -91,7 +91,7 @@ func TestIntegratedQuestHandlers_FundingRateScan(t *testing.T) {
 	mockMonitoring := NewAutonomousMonitorManager(mockNotif, testLogger)
 
 	handlers := NewIntegratedQuestHandlers(
-		nil, nil, nil, nil, mockNotif, mockMonitoring,
+		nil, nil, nil, nil, mockNotif, mockMonitoring, nil, nil,
 	)
 
 	quest := &Quest{
@@ -119,7 +119,7 @@ func TestIntegratedQuestHandlers_PortfolioHealthWithRisk(t *testing.T) {
 	mockMonitoring := NewAutonomousMonitorManager(mockNotif, testLogger)
 
 	handlers := NewIntegratedQuestHandlers(
-		nil, nil, nil, nil, mockNotif, mockMonitoring,
+		nil, nil, nil, nil, mockNotif, mockMonitoring, nil, nil,
 	)
 
 	quest := &Quest{
@@ -148,7 +148,7 @@ func TestIntegratedQuestHandlers_GetMonitoringSnapshot(t *testing.T) {
 	mockMonitoring := NewAutonomousMonitorManager(mockNotif, testLogger)
 
 	handlers := NewIntegratedQuestHandlers(
-		nil, nil, nil, nil, mockNotif, mockMonitoring,
+		nil, nil, nil, nil, mockNotif, mockMonitoring, nil, nil,
 	)
 
 	snapshot := handlers.GetMonitoringSnapshot("test123")
@@ -162,7 +162,7 @@ func TestIntegratedQuestHandlers_GetMonitoringSnapshot(t *testing.T) {
 func TestIntegratedQuestHandlers_ExecuteRoutineUnknownDefinition(t *testing.T) {
 	mockNotif := &NotificationService{}
 	mockMonitoring := NewAutonomousMonitorManager(mockNotif, testLogger)
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, mockNotif, mockMonitoring)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, mockNotif, mockMonitoring, nil, nil)
 
 	quest := &Quest{
 		ID:         "unknown-routine",
@@ -184,7 +184,7 @@ func TestIntegratedQuestHandlers_ExecuteRoutineUnknownDefinition(t *testing.T) {
 func TestIntegratedQuestHandlers_ExecuteRoutine_VolatilityWatchUsesPortfolioHealthFlow(t *testing.T) {
 	mockNotif := &NotificationService{}
 	mockMonitoring := NewAutonomousMonitorManager(mockNotif, testLogger)
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, mockNotif, mockMonitoring)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, mockNotif, mockMonitoring, nil, nil)
 
 	quest := &Quest{
 		ID:           "volatility-watch",
@@ -209,7 +209,7 @@ func TestIntegratedQuestHandlers_ExecuteRoutine_VolatilityWatchUsesPortfolioHeal
 func TestIntegratedQuestHandlers_ExecuteRoutine_FundGrowthGoalUpdatesCheckpoint(t *testing.T) {
 	mockNotif := &NotificationService{}
 	mockMonitoring := NewAutonomousMonitorManager(mockNotif, testLogger)
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, mockNotif, mockMonitoring)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, mockNotif, mockMonitoring, nil, nil)
 
 	quest := &Quest{
 		ID:           "fund-growth",
@@ -235,7 +235,7 @@ func TestIntegratedQuestHandlers_ExecuteRoutine_FundGrowthGoalUpdatesCheckpoint(
 
 func TestIntegratedQuestHandlers_SetQuestEngine(t *testing.T) {
 	engine := NewQuestEngineWithNotification(NewInMemoryQuestStore(), nil, nil)
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetQuestEngine(engine)
 	assert.Equal(t, engine, handlers.questEngine)
 }
@@ -407,7 +407,7 @@ func TestIntegratedQuestHandlers_GetUserExchange_SQLiteLookup(t *testing.T) {
 	`, "w1", "chat-1", "bitget", "connected", time.Now().UTC())
 	require.NoError(t, err)
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDB(sqliteDB.DB)
 
 	assert.Equal(t, "bitget", handlers.getUserExchange("chat-1"))
@@ -794,7 +794,7 @@ func TestIntegratedQuestHandlers_EvaluateRecoveryGateState_HybridModes(t *testin
 	t.Setenv("NEURATRADE_RECOVERY_DERISK_ONLY_DRAWDOWN", "0.40")
 	t.Setenv("NEURATRADE_RECOVERY_MICRO_ENTRY_CAP_PCT", "0.50")
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	quest := &Quest{
 		Checkpoint: map[string]interface{}{
 			"recovery_clean_cycles": 2,
@@ -826,7 +826,7 @@ func TestIntegratedQuestHandlers_EvaluateRecoveryGateState_IgnoresRuntimeFailure
 	t.Setenv("NEURATRADE_RECOVERY_MICRO_ENTRY_MIN_DRAWDOWN", "0.30")
 	t.Setenv("NEURATRADE_RECOVERY_DERISK_ONLY_DRAWDOWN", "0.40")
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	quest := &Quest{
 		Checkpoint: map[string]interface{}{
 			"recovery_clean_cycles_current": 1,
@@ -844,7 +844,7 @@ func TestIntegratedQuestHandlers_EvaluateRecoveryGateState_IgnoresRuntimeFailure
 }
 
 func TestIntegratedQuestHandlers_EnrichPortfolioControlPlane_UsesCurrentDrawdownFromPeakEquity(t *testing.T) {
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDrawdownHalt(NewMaxDrawdownHalt(nil, DefaultMaxDrawdownConfig()))
 
 	quest := &Quest{
@@ -900,7 +900,7 @@ func TestIntegratedQuestHandlers_EnrichPortfolioControlPlane_UsesRawEquityForFul
 	}, "bootstrap_reconciliation")
 	require.NoError(t, err)
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetLifecycleStore(store)
 	handlers.SetDrawdownHalt(NewMaxDrawdownHalt(nil, DefaultMaxDrawdownConfig()))
 
@@ -988,7 +988,7 @@ func TestIntegratedQuestHandlers_RecentLossWindowRecoveryGate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("NEURATRADE_SCALPING_SYMBOL_LOSS_WINDOW_SECONDS", tt.windowSeconds)
-			handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+			handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 			store := newLifecycleStoreForTest(t)
 			handlers.SetLifecycleStore(store)
 
@@ -1034,7 +1034,7 @@ func TestIntegratedQuestHandlers_RecentLossWindowRecoveryGate(t *testing.T) {
 }
 
 func TestIntegratedQuestHandlers_UpdateRecoveryCleanCycles_ResetOnFailure(t *testing.T) {
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	quest := &Quest{Checkpoint: map[string]interface{}{}}
 
 	handlers.updateRecoveryCleanCycles(quest, true, "")
@@ -1052,7 +1052,7 @@ func TestIntegratedQuestHandlers_EvaluateEntryAttemptGateState_BudgetLimit(t *te
 	t.Setenv("NEURATRADE_LIVENESS_IDLE_MINUTES", "45")
 	t.Setenv("NEURATRADE_LIVENESS_MAX_ATTEMPTS_PER_HOUR", "3")
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	now := time.Now().UTC()
 	quest := &Quest{
 		Checkpoint: map[string]interface{}{
@@ -1082,7 +1082,7 @@ func TestIntegratedQuestHandlers_EvaluateEntryAttemptGateState_BudgetLimit(t *te
 func TestIntegratedQuestHandlers_RecordEntryAttempt_RotatesWindow(t *testing.T) {
 	t.Setenv("NEURATRADE_LIVENESS_MAX_ATTEMPTS_PER_HOUR", "3")
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	now := time.Now().UTC()
 	quest := &Quest{
 		Checkpoint: map[string]interface{}{
@@ -1103,7 +1103,7 @@ func TestIntegratedQuestHandlers_RecordEntryAttempt_RotatesWindow(t *testing.T) 
 func TestIntegratedQuestHandlers_RecordEntryAttempt_SetsBlockReasonAtBudgetEdge(t *testing.T) {
 	t.Setenv("NEURATRADE_LIVENESS_MAX_ATTEMPTS_PER_HOUR", "3")
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	now := time.Now().UTC()
 	windowStart := now.Add(-20 * time.Minute)
 	quest := &Quest{Checkpoint: map[string]interface{}{}}
@@ -1190,7 +1190,7 @@ func TestIsAutonomousManagedPosition(t *testing.T) {
 }
 
 func TestIntegratedQuestHandlers_ResetScalpingFailureState_ClearsCheckpointError(t *testing.T) {
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	quest := &Quest{Checkpoint: map[string]interface{}{
 		"runtime_failure_streak":  3,
 		"runtime_last_failure":    "portfolio safety blocked: maximum allowed 0.00",
@@ -1337,7 +1337,7 @@ func TestIntegratedQuestHandlers_IngestClosedOrderFeedback_SkipsProbableEntryFil
 		OpenedAt:   time.Now().UTC().Add(-30 * time.Second),
 	}))
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDB(sqliteDB.DB)
 	handlers.SetLifecycleStore(store)
 
@@ -1410,7 +1410,7 @@ func TestIntegratedQuestHandlers_IngestClosedOrderFeedback_SkipsProbableEntryFil
 		OpenedAt:   time.Now().UTC().Add(-30 * time.Second),
 	}))
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDB(sqliteDB.DB)
 	handlers.SetLifecycleStore(store)
 
@@ -1483,7 +1483,7 @@ func TestIntegratedQuestHandlers_IngestClosedOrderFeedback_DoesNotReprocessSkipp
 		OpenedAt:   time.Now().UTC().Add(-time.Minute),
 	}))
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDB(sqliteDB.DB)
 	handlers.SetLifecycleStore(store)
 
@@ -1871,7 +1871,7 @@ func TestIntegratedQuestHandlers_IngestClosedOrderFeedback_PersistsLegacyTradeCl
 		_ = sqliteDB.Close()
 	})
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDB(sqliteDB.DB)
 
 	orderExecutor := new(MockScalpingOrderExecutor)
@@ -1940,7 +1940,7 @@ func TestIntegratedQuestHandlers_IngestClosedOrderFeedback_SkipsLegacyJournalWhe
 	sqliteDB, err := database.NewSQLiteConnection(dbPath)
 	require.NoError(t, err)
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.db = sqliteDB.DB
 
 	orderExecutor := new(MockScalpingOrderExecutor)
@@ -1998,7 +1998,7 @@ func TestIntegratedQuestHandlers_IngestClosedOrderFeedback_LegacyCloseWithoutOpt
 		_ = sqliteDB.Close()
 	})
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDB(sqliteDB.DB)
 
 	orderExecutor := new(MockScalpingOrderExecutor)
@@ -2060,7 +2060,7 @@ func TestIntegratedQuestHandlers_IngestClosedOrderFeedback_TracksMissingPnL(t *t
 		_ = sqliteDB.Close()
 	})
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDB(sqliteDB.DB)
 
 	orderExecutor := new(MockScalpingOrderExecutor)
@@ -2107,7 +2107,7 @@ func TestIntegratedQuestHandlers_PersistLegacyTradeEntry_StoresBaseSizeAndCostBa
 		_ = sqliteDB.Close()
 	})
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDB(sqliteDB.DB)
 
 	quest := &Quest{
@@ -2149,7 +2149,7 @@ func TestIntegratedQuestHandlers_PersistLegacyTradeEntry_StoresZeroSizeWithoutEn
 		_ = sqliteDB.Close()
 	})
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDB(sqliteDB.DB)
 
 	quest := &Quest{
@@ -2187,7 +2187,7 @@ func TestIntegratedQuestHandlers_SetDB_RetriesTradeJournalInitAfterDBReplacement
 	sqliteDB1, err := database.NewSQLiteConnection(dbPath1)
 	require.NoError(t, err)
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 
 	require.NoError(t, sqliteDB1.Close())
 	handlers.SetDB(sqliteDB1.DB)
@@ -2227,7 +2227,7 @@ func TestIntegratedQuestHandlers_SetDB_RetriesTradeJournalInitAfterDBReplacement
 }
 
 func TestIntegratedQuestHandlers_ApplyScalpingCycleDecisionDiagnostics_ClearsStaleDecisionMetadata(t *testing.T) {
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	quest := &Quest{Checkpoint: map[string]interface{}{
 		"account_tier":                          "micro",
 		"effective_min_confidence":              0.72,
@@ -2269,7 +2269,7 @@ func TestIntegratedQuestHandlers_ApplyScalpingCycleDecisionDiagnostics_ClearsSta
 }
 
 func TestIntegratedQuestHandlers_ApplyScalpingCycleDecisionDiagnostics_ClearsNilDecisionMetadata(t *testing.T) {
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	quest := &Quest{Checkpoint: map[string]interface{}{
 		"account_tier":                          "small",
 		"effective_min_confidence":              0.70,
@@ -2297,7 +2297,7 @@ func TestIntegratedQuestHandlers_ApplyScalpingCycleDecisionDiagnostics_ClearsNil
 }
 
 func TestIntegratedQuestHandlers_ApplyScalpingCycleDecisionDiagnostics_PopulatesCountMetadata(t *testing.T) {
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	quest := &Quest{Checkpoint: map[string]interface{}{}}
 	decision := &AITradingDecision{
 		PolicyAdjustments: []string{
@@ -2353,7 +2353,7 @@ func TestIntegratedQuestHandlers_RecordTradeDecision_DoesNotSynthesizeTradeMemor
 		_ = sqliteDB.Close()
 	})
 
-	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil)
+	handlers := NewIntegratedQuestHandlers(nil, nil, nil, nil, nil, nil, nil, nil)
 	handlers.SetDB(sqliteDB.DB)
 
 	quest := &Quest{

--- a/services/backend-api/test/e2e/telegram_e2e_test.go
+++ b/services/backend-api/test/e2e/telegram_e2e_test.go
@@ -100,7 +100,7 @@ func (s *TelegramE2ETestSuite) SetupSuite() {
 	cacheAnalyticsService := services.NewCacheAnalyticsService(nil)
 
 	// Setup routes
-	_, err = api.SetupRoutes(s.router, s.db, s.redisClient, mockCCXT, nil, nil, cacheAnalyticsService, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil, nil, nil)
+	_, err = api.SetupRoutes(s.router, s.db, s.redisClient, mockCCXT, nil, nil, cacheAnalyticsService, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(s.T(), err)
 
 	// Create test user

--- a/services/backend-api/test/integration/autonomous_integration_test.go
+++ b/services/backend-api/test/integration/autonomous_integration_test.go
@@ -84,7 +84,7 @@ func TestAutonomousIntegration(t *testing.T) {
 		Used:      map[string]float64{"USDT": 5000.0, "BTC": 0.0},
 	}, nil)
 
-	_, err = api.SetupRoutes(router, db, redisClient, mockCCXT, nil, nil, nil, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil, nil, nil)
+	_, err = api.SetupRoutes(router, db, redisClient, mockCCXT, nil, nil, nil, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	testTelegramChatID := fmt.Sprintf("tg_auto_%s", uuid.New().String())

--- a/services/backend-api/test/integration/telegram_integration_test.go
+++ b/services/backend-api/test/integration/telegram_integration_test.go
@@ -80,7 +80,7 @@ func TestTelegramIntegration(t *testing.T) {
 
 	// Call SetupRoutes
 	// We pass nil for services not involved in this test flow
-	_, err = api.SetupRoutes(router, db, redisClient, mockCCXT, nil, nil, nil, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil, nil, nil)
+	_, err = api.SetupRoutes(router, db, redisClient, mockCCXT, nil, nil, nil, nil, nil, cfg, nil, nil, authMiddleware, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Test Data


### PR DESCRIPTION
## Summary

Fixes NeuraTrade-n6g: the scalping autonomy pipeline read kill-switch
and safe-mode state from `NEURATRADE_KILL_SWITCH_ENGAGED` and
`NEURATRADE_SAFE_MODE_ENABLED` env vars (read once at startup), while
routes.go created its own `sharedKillSwitch` and `sharedSafeMode`
instances. Engaging the kill switch via POST /api/v1/agent/kill-switch
only affected routes.go's local instance — the trading pipeline kept
running.

## Change

1. **main.go** creates `sharedKillSwitch` and `sharedSafeMode` and
   passes them to `SetupRoutes` and the autonomy runtime.
2. **SetupRoutes** signature now accepts `*apprisk.KillSwitchImpl` and
   `*apprisk.SafeModeImpl` as the last two parameters. When nil, it
   creates them locally (backward-compat for tests).
3. **autonomyruntime.Dependencies** has `KillSwitch` and `SafeMode`
   fields propagated through to `IntegratedQuestHandlers`.
4. **IntegratedQuestHandlers** has `killSwitch` and `safeMode` fields
   populated via constructor injection. The scalping cycle reads
   `IsEngaged()` / `IsEnabled()` from these instead of env vars.

The env var fallback is removed — kill switch state is now a runtime
concern, not a deployment-time one.

## Verification

- 4974 tests pass with `-race`
- `gofmt` clean, `go vet` clean
- `golangci-lint run` clean
- 11 files changed (main.go, routes.go, runtime.go, quest_handlers
  integrated.go + test, routes_test.go, routes_regression_test.go,
  telegram_integration_test.go, autonomous_integration_test.go,
  telegram_e2e_test.go)