### PR TITLE
fix(market_data): add unique index to prevent duplicate OHLCV inserts (GH #311)

### DIFF
--- a/services/backend-api/database/migrations/087_unique_market_data_exchange_pair_timestamp.sql
+++ b/services/backend-api/database/migrations/087_unique_market_data_exchange_pair_timestamp.sql
@@ -1,0 +1,9 @@
+-- Migration 087 (postgres): Add unique index on market_data to prevent duplicate OHLCV inserts
+-- Created: 2026-06-01
+-- Addresses GitHub #311 / NeuraTrade-cpv4: OHLCV collection interval (30s)
+-- shorter than candle timeframe (1m) produces duplicate candles. Adding a
+-- unique constraint on (exchange_id, trading_pair_id, timestamp) makes
+-- re-runs of backfill safe and dedup-on-insert the new norm.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_market_data_exchange_pair_timestamp
+    ON market_data(exchange_id, trading_pair_id, timestamp);

--- a/services/backend-api/database/sqlite_migrations/087_unique_market_data_exchange_pair_timestamp.sql
+++ b/services/backend-api/database/sqlite_migrations/087_unique_market_data_exchange_pair_timestamp.sql
@@ -1,0 +1,11 @@
+-- Migration 087: Add unique index on market_data to prevent duplicate OHLCV inserts
+-- Created: 2026-06-01
+-- Addresses GitHub #311 / NeuraTrade-cpv4: OHLCV collection interval (30s)
+-- shorter than candle timeframe (1m) produces duplicate candles. Adding a
+-- unique constraint on (exchange_id, trading_pair_id, timestamp) makes
+-- re-runs of backfill safe and dedup-on-insert the new norm.
+
+PRAGMA foreign_keys = ON;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_market_data_exchange_pair_timestamp
+    ON market_data(exchange_id, trading_pair_id, timestamp);

--- a/services/backend-api/internal/services/collector_backfill.go
+++ b/services/backend-api/internal/services/collector_backfill.go
@@ -586,7 +586,8 @@ func (c *CollectorService) generateHistoricalDataPoints(ctx context.Context, exc
 		err := c.errorRecoveryManager.ExecuteWithRetry(ctx, "database_operation", func() error {
 			_, execErr := c.db.Exec(ctx,
 				`INSERT INTO market_data (exchange_id, trading_pair_id, last_price, volume_24h, timestamp, created_at)
-				 VALUES (?, ?, ?, ?, ?, ?)`,
+				 VALUES (?, ?, ?, ?, ?, ?)
+				 ON CONFLICT (exchange_id, trading_pair_id, timestamp) DO NOTHING`,
 				exchangeDBID, tradingPairID, candle.Close, candle.Volume, candleTime, candleTime)
 			return execErr
 		})


### PR DESCRIPTION
## Summary

Fixes GitHub #311 / NeuraTrade-cpv4: OHLCV collection interval (30s)
shorter than candle timeframe (1m) produces duplicate candles because
`market_data` has no unique constraint on
`(exchange_id, trading_pair_id, timestamp)`. Re-running backfill or
double-collection produces duplicate rows.

## Change

- New migration **087** adds `UNIQUE INDEX
  uq_market_data_exchange_pair_timestamp` on
  `(exchange_id, trading_pair_id, timestamp)` for both SQLite and
  Postgres.
- `collector_backfill.go` `generateHistoricalDataPoints` INSERT now
  uses `ON CONFLICT (exchange_id, trading_pair_id, timestamp) DO
  NOTHING`. Re-runs are safe and idempotent.

## Migration safety

Existing duplicates (if any) won't be retroactively removed. The
unique index will fail to create on production DBs that already
have duplicates. To handle that case, run before applying:

```sql
DELETE FROM market_data WHERE id NOT IN (
  SELECT MIN(id) FROM market_data
  GROUP BY exchange_id, trading_pair_id, timestamp
);
```

## Verification

- 4974 tests pass with `-race`
- `gofmt` clean, `go vet` clean