### PR TITLE
feat(metrics): add Prometheus counters/gauges for actor pipeline (NeuraTrade-d75g)

### DIFF
--- a/services/backend-api/go.mod
+++ b/services/backend-api/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/services/backend-api/internal/app/execution/actor.go
+++ b/services/backend-api/internal/app/execution/actor.go
@@ -15,6 +15,7 @@ import (
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
 	"github.com/google/uuid"
+	"github.com/irfndi/neuratrade/internal/metrics"
 	"github.com/irfndi/neuratrade/internal/platform/actor"
 	"github.com/irfndi/neuratrade/internal/ports"
 	"github.com/shopspring/decimal"
@@ -228,6 +229,8 @@ func (a *ExecutionActor) Receive(ctx context.Context, env actor.Envelope) error 
 
 // handlePlaceOrder processes a new order placement with idempotency
 func (a *ExecutionActor) handlePlaceOrder(ctx context.Context, msg PlaceOrderMsg) error {
+	start := time.Now()
+
 	// Check for duplicate intent
 	existing, err := a.idempotencyStore.GetIntent(ctx, msg.IntentID)
 	if err != nil {
@@ -338,6 +341,10 @@ func (a *ExecutionActor) handlePlaceOrder(ctx context.Context, msg PlaceOrderMsg
 			"rejection_source": "execution_actor",
 		})
 		a.publishEvent(ctx, ports.EventTypeOrderRejected, intent)
+		metrics.ExecutionOrdersTotal.WithLabelValues(
+			intent.Request.Exchange, intent.Request.Symbol, string(intent.Request.Side), "rejected",
+		).Inc()
+		a.updatePendingGauge()
 		if updateErr != nil {
 			return errors.Join(
 				ErrRiskNotApproved,
@@ -361,6 +368,10 @@ func (a *ExecutionActor) handlePlaceOrder(ctx context.Context, msg PlaceOrderMsg
 
 		a.logAuditEvent(ctx, msg.IntentID, "rejected", req.Exchange, req.Symbol, reason, nil)
 		a.publishEvent(ctx, ports.EventTypeOrderRejected, intent)
+		metrics.ExecutionOrdersTotal.WithLabelValues(
+			req.Exchange, req.Symbol, string(req.Side), "rejected",
+		).Inc()
+		a.updatePendingGauge()
 		if updateErr != nil {
 			return errors.Join(
 				fmt.Errorf("%w: %s", ErrExecutionRejected, reason),
@@ -393,6 +404,10 @@ func (a *ExecutionActor) handlePlaceOrder(ctx context.Context, msg PlaceOrderMsg
 
 	// Publish event
 	a.publishEvent(ctx, ports.EventTypeOrderPlaced, intent)
+	metrics.ExecutionOrdersTotal.WithLabelValues(
+		req.Exchange, req.Symbol, string(req.Side), "placed",
+	).Inc()
+	a.updatePendingGauge()
 
 	// If already filled, emit fill event
 	if result.Status == ports.OrderStatusFilled {
@@ -401,7 +416,13 @@ func (a *ExecutionActor) handlePlaceOrder(ctx context.Context, msg PlaceOrderMsg
 			"fill_price":    result.AveragePrice,
 		})
 		a.publishEvent(ctx, ports.EventTypeOrderFilled, intent)
+		metrics.ExecutionOrdersTotal.WithLabelValues(
+			req.Exchange, req.Symbol, string(req.Side), "filled",
+		).Inc()
+		metrics.ExecutionPendingOrders.Set(0)
 	}
+
+	metrics.ExecutionOrderLatency.WithLabelValues(req.Exchange).Observe(time.Since(start).Seconds())
 
 	return nil
 }
@@ -711,6 +732,17 @@ func (a *ExecutionActor) publishEvent(ctx context.Context, eventType string, int
 	if err := a.eventBus.Publish(ctx, orderEvent); err != nil {
 		zaplogrus.Warnf("[EVENT] failed to publish intent=%s type=%s: %s", intent.IntentID, eventType, sanitizeExternalError(err))
 	}
+}
+
+// updatePendingGauge recalculates pending orders gauge from in-memory state.
+func (a *ExecutionActor) updatePendingGauge() {
+	count := 0
+	for _, intent := range a.intents {
+		if !intent.IsTerminal() {
+			count++
+		}
+	}
+	metrics.ExecutionPendingOrders.Set(float64(count))
 }
 
 // OrderEvent wraps domain events with order data

--- a/services/backend-api/internal/app/marketdata/collector_actor.go
+++ b/services/backend-api/internal/app/marketdata/collector_actor.go
@@ -11,6 +11,7 @@ import (
 	domainmarketdata "github.com/irfndi/neuratrade/internal/domain/marketdata"
 	"github.com/irfndi/neuratrade/internal/logging"
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
+	"github.com/irfndi/neuratrade/internal/metrics"
 	"github.com/irfndi/neuratrade/internal/platform/actor"
 	"github.com/irfndi/neuratrade/internal/platform/eventbus"
 	"github.com/irfndi/neuratrade/internal/ports"
@@ -469,6 +470,7 @@ func (a *CollectorActor) collectFromExchange(ctx context.Context, exchangeID str
 		}); err != nil {
 			a.logger.WithError(err).Warnf("failed to publish market tick for %s:%s", exchangeID, symbol)
 		}
+		metrics.MarketTicksTotal.WithLabelValues(exchangeID, symbol).Inc()
 
 		key := exchangeID + ":" + symbol
 		now := time.Now()

--- a/services/backend-api/internal/app/portfolio/actor.go
+++ b/services/backend-api/internal/app/portfolio/actor.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	domainportfolio "github.com/irfndi/neuratrade/internal/domain/portfolio"
+	"github.com/irfndi/neuratrade/internal/metrics"
 	"github.com/irfndi/neuratrade/internal/platform/actor"
 	"github.com/irfndi/neuratrade/internal/ports"
 )
@@ -115,6 +116,8 @@ func (a *PortfolioActor) handleOrderFilled(ctx context.Context, event OrderFille
 	if err != nil {
 		return err
 	}
+
+	metrics.PortfolioPositionsActive.Set(float64(len(a.portfolio.Snapshot().Positions)))
 
 	if a.eventBus == nil {
 		return nil

--- a/services/backend-api/internal/app/risk/risk_actor.go
+++ b/services/backend-api/internal/app/risk/risk_actor.go
@@ -9,6 +9,7 @@ import (
 
 	zaplogrus "github.com/irfndi/neuratrade/internal/logging/zaplogrus"
 
+	"github.com/irfndi/neuratrade/internal/metrics"
 	"github.com/irfndi/neuratrade/internal/platform/actor"
 	"github.com/irfndi/neuratrade/internal/platform/eventbus"
 	"github.com/irfndi/neuratrade/internal/ports"
@@ -285,6 +286,7 @@ func (a *RiskActor) Receive(ctx context.Context, env actor.Envelope) error {
 }
 
 func (a *RiskActor) handleEvaluateIntent(ctx context.Context, traceID string, msg EvaluateIntentMsg) {
+	start := time.Now()
 	decision, err := a.policy.Evaluate(ctx, msg.Intent)
 
 	// Publish decision event
@@ -300,6 +302,17 @@ func (a *RiskActor) handleEvaluateIntent(ctx context.Context, traceID string, ms
 			"rule":      decision.RuleName,
 		})
 	}
+
+	outcome := "approved"
+	if err != nil || !decision.Approved {
+		outcome = "rejected"
+	}
+	reason := decision.Reason
+	if err != nil {
+		reason = err.Error()
+	}
+	metrics.RiskDecisionsTotal.WithLabelValues(outcome, reason).Inc()
+	metrics.RiskDecisionDuration.Observe(time.Since(start).Seconds())
 
 	if msg.Reply != nil {
 		msg.Reply <- EvaluateIntentReply{

--- a/services/backend-api/internal/app/strategy/strategy_actor.go
+++ b/services/backend-api/internal/app/strategy/strategy_actor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/irfndi/neuratrade/internal/domain/marketdata"
 	"github.com/irfndi/neuratrade/internal/domain/signals"
+	"github.com/irfndi/neuratrade/internal/metrics"
 	"github.com/irfndi/neuratrade/internal/platform/actor"
 	"github.com/irfndi/neuratrade/internal/platform/eventbus"
 	"github.com/irfndi/neuratrade/internal/ports"
@@ -199,6 +200,8 @@ func (s *StrategyActor) handleTick(ctx context.Context, env actor.Envelope, tick
 		return fmt.Errorf("publish SignalProposed event: %w", err)
 	}
 
+	metrics.StrategySignalsTotal.WithLabelValues(s.strategyID, payload.Symbol, string(payload.Side)).Inc()
+
 	return nil
 }
 
@@ -287,6 +290,9 @@ func (s *StrategyActor) tryComposeScalpingSignal(ctx context.Context, traceID st
 		s.logger.Warn("failed to publish scalping signal", "error", err)
 		return
 	}
+
+	metrics.StrategySignalsTotal.WithLabelValues(s.strategyID, payload.Symbol, payload.Direction).Inc()
+
 	if fingerprint != "" {
 		s.lastScalpingKeys[key] = fingerprint
 	}

--- a/services/backend-api/internal/metrics/actor_metrics_test.go
+++ b/services/backend-api/internal/metrics/actor_metrics_test.go
@@ -1,0 +1,183 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarketTicksTotal(t *testing.T) {
+	counter, err := MarketTicksTotal.GetMetricWithLabelValues("binance", "BTC/USDT")
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), testutil.ToFloat64(counter))
+
+	counter.Inc()
+	assert.Equal(t, float64(1), testutil.ToFloat64(counter))
+
+	MarketTicksTotal.WithLabelValues("coinbase", "ETH/USDT").Add(3)
+	assert.Equal(t, float64(3), testutil.ToFloat64(
+		MarketTicksTotal.WithLabelValues("coinbase", "ETH/USDT"),
+	))
+}
+
+
+
+func TestStrategySignalsTotal(t *testing.T) {
+	StrategySignalsTotal.WithLabelValues("strat-1", "BTC/USDT", "buy").Inc()
+	StrategySignalsTotal.WithLabelValues("strat-1", "BTC/USDT", "buy").Inc()
+	StrategySignalsTotal.WithLabelValues("strat-1", "ETH/USDT", "sell").Inc()
+
+	assert.Equal(t, float64(2), testutil.ToFloat64(
+		StrategySignalsTotal.WithLabelValues("strat-1", "BTC/USDT", "buy"),
+	))
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		StrategySignalsTotal.WithLabelValues("strat-1", "ETH/USDT", "sell"),
+	))
+}
+
+func TestRiskDecisionsTotal(t *testing.T) {
+	RiskDecisionsTotal.WithLabelValues("approved", "").Inc()
+	RiskDecisionsTotal.WithLabelValues("rejected", "kill_switch_engaged").Inc()
+	RiskDecisionsTotal.WithLabelValues("rejected", "max_drawdown_exceeded").Inc()
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		RiskDecisionsTotal.WithLabelValues("approved", ""),
+	))
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		RiskDecisionsTotal.WithLabelValues("rejected", "kill_switch_engaged"),
+	))
+}
+
+func TestRiskDecisionDuration(t *testing.T) {
+	RiskDecisionDuration.Observe(0.005)
+	RiskDecisionDuration.Observe(0.010)
+	RiskDecisionDuration.Observe(0.100)
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() == "neuratrade_risk_decision_duration_seconds" {
+			assert.Equal(t, float64(3), float64(f.GetMetric()[0].Histogram.GetSampleCount()))
+			return
+		}
+	}
+	t.Error("metric neuratrade_risk_decision_duration_seconds not found")
+}
+
+func TestExecutionOrdersTotal(t *testing.T) {
+	ExecutionOrdersTotal.WithLabelValues("binance", "BTC/USDT", "buy", "placed").Inc()
+	ExecutionOrdersTotal.WithLabelValues("binance", "BTC/USDT", "buy", "filled").Inc()
+	ExecutionOrdersTotal.WithLabelValues("coinbase", "ETH/USDT", "sell", "rejected").Inc()
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		ExecutionOrdersTotal.WithLabelValues("binance", "BTC/USDT", "buy", "placed"),
+	))
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		ExecutionOrdersTotal.WithLabelValues("binance", "BTC/USDT", "buy", "filled"),
+	))
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		ExecutionOrdersTotal.WithLabelValues("coinbase", "ETH/USDT", "sell", "rejected"),
+	))
+}
+
+func TestExecutionOrderLatency(t *testing.T) {
+	ExecutionOrderLatency.WithLabelValues("binance").Observe(0.05)
+	ExecutionOrderLatency.WithLabelValues("coinbase").Observe(0.10)
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() == "neuratrade_execution_order_latency_seconds" {
+			for _, m := range f.GetMetric() {
+				if len(m.GetLabel()) == 1 && m.GetLabel()[0].GetValue() == "binance" {
+					assert.Equal(t, float64(1), float64(m.Histogram.GetSampleCount()))
+					return
+				}
+			}
+		}
+	}
+	t.Error("metric neuratrade_execution_order_latency_seconds{exchange=\"binance\"} not found")
+}
+
+func TestExecutionPendingOrders(t *testing.T) {
+	ExecutionPendingOrders.Set(3)
+	assert.Equal(t, float64(3), testutil.ToFloat64(ExecutionPendingOrders))
+
+	ExecutionPendingOrders.Set(0)
+	assert.Equal(t, float64(0), testutil.ToFloat64(ExecutionPendingOrders))
+
+	ExecutionPendingOrders.Set(5)
+	assert.Equal(t, float64(5), testutil.ToFloat64(ExecutionPendingOrders))
+}
+
+func TestPortfolioPositionsActive(t *testing.T) {
+	PortfolioPositionsActive.Set(0)
+	assert.Equal(t, float64(0), testutil.ToFloat64(PortfolioPositionsActive))
+
+	PortfolioPositionsActive.Set(4)
+	assert.Equal(t, float64(4), testutil.ToFloat64(PortfolioPositionsActive))
+
+	PortfolioPositionsActive.Set(2)
+	assert.Equal(t, float64(2), testutil.ToFloat64(PortfolioPositionsActive))
+}
+
+func TestActorLoopIterationsTotal(t *testing.T) {
+	ActorLoopIterationsTotal.WithLabelValues("marketdata-collector").Inc()
+	ActorLoopIterationsTotal.WithLabelValues("strategy-actor").Inc()
+	ActorLoopIterationsTotal.WithLabelValues("marketdata-collector").Inc()
+
+	assert.Equal(t, float64(2), testutil.ToFloat64(
+		ActorLoopIterationsTotal.WithLabelValues("marketdata-collector"),
+	))
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		ActorLoopIterationsTotal.WithLabelValues("strategy-actor"),
+	))
+}
+
+func TestMetricsHandlerServesActorMetrics(t *testing.T) {
+	handler := MetricsHandler()
+	require.NotNil(t, handler)
+}
+
+func TestAllActorMetricsAreRegistered(t *testing.T) {
+	names := []string{
+		"neuratrade_market_ticks_total",
+		"neuratrade_strategy_signals_total",
+		"neuratrade_risk_decisions_total",
+		"neuratrade_risk_decision_duration_seconds",
+		"neuratrade_execution_orders_total",
+		"neuratrade_execution_order_latency_seconds",
+		"neuratrade_execution_pending_orders",
+		"neuratrade_portfolio_positions_active",
+		"neuratrade_actor_loop_iterations_total",
+	}
+
+	for _, name := range names {
+		families, err := prometheus.DefaultGatherer.Gather()
+		require.NoError(t, err)
+		found := false
+		for _, f := range families {
+			if f.GetName() == name {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "metric %s should be registered in the default registry", name)
+	}
+}
+
+func TestMetricsLabelsAreConsistent(t *testing.T) {
+	// Verify no duplicate metric registration panics by re-registering via init()
+	// All metrics should be registered exactly once
+	require.NotPanics(t, func() {
+		_ = prometheus.Register(MarketTicksTotal)
+	})
+
+	// Clean up: unregister the duplicate
+	prometheus.Unregister(MarketTicksTotal)
+}
+
+

--- a/services/backend-api/internal/metrics/actor_metrics_test.go
+++ b/services/backend-api/internal/metrics/actor_metrics_test.go
@@ -23,8 +23,6 @@ func TestMarketTicksTotal(t *testing.T) {
 	))
 }
 
-
-
 func TestStrategySignalsTotal(t *testing.T) {
 	StrategySignalsTotal.WithLabelValues("strat-1", "BTC/USDT", "buy").Inc()
 	StrategySignalsTotal.WithLabelValues("strat-1", "BTC/USDT", "buy").Inc()
@@ -179,5 +177,3 @@ func TestMetricsLabelsAreConsistent(t *testing.T) {
 	// Clean up: unregister the duplicate
 	prometheus.Unregister(MarketTicksTotal)
 }
-
-

--- a/services/backend-api/internal/metrics/prometheus.go
+++ b/services/backend-api/internal/metrics/prometheus.go
@@ -67,6 +67,78 @@ var (
 		},
 		[]string{"provider"},
 	)
+
+	// Actor pipeline metrics
+	MarketTicksTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "neuratrade_market_ticks_total",
+			Help: "Total number of market ticks collected, labeled by exchange and symbol.",
+		},
+		[]string{"exchange", "symbol"},
+	)
+
+	StrategySignalsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "neuratrade_strategy_signals_total",
+			Help: "Total number of signals proposed by strategies, labeled by strategy, symbol, and side.",
+		},
+		[]string{"strategy_id", "symbol", "side"},
+	)
+
+	RiskDecisionsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "neuratrade_risk_decisions_total",
+			Help: "Total number of risk decisions made, labeled by outcome and reason.",
+		},
+		[]string{"outcome", "reason"},
+	)
+
+	RiskDecisionDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "neuratrade_risk_decision_duration_seconds",
+			Help:    "Duration of risk evaluation decisions in seconds.",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1},
+		},
+	)
+
+	ExecutionOrdersTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "neuratrade_execution_orders_total",
+			Help: "Total number of orders processed, labeled by exchange, symbol, side, and status.",
+		},
+		[]string{"exchange", "symbol", "side", "status"},
+	)
+
+	ExecutionOrderLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "neuratrade_execution_order_latency_seconds",
+			Help:    "Order placement latency in seconds, labeled by exchange.",
+			Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{"exchange"},
+	)
+
+	ExecutionPendingOrders = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "neuratrade_execution_pending_orders",
+			Help: "Number of pending (in-flight) orders.",
+		},
+	)
+
+	PortfolioPositionsActive = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "neuratrade_portfolio_positions_active",
+			Help: "Number of currently active positions.",
+		},
+	)
+
+	ActorLoopIterationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "neuratrade_actor_loop_iterations_total",
+			Help: "Total number of actor loop iterations (liveness signal).",
+		},
+		[]string{"actor"},
+	)
 )
 
 func init() {
@@ -78,6 +150,15 @@ func init() {
 	_ = prometheus.Register(RedisPingDuration)
 	_ = prometheus.Register(DatabasePingDuration)
 	_ = prometheus.Register(LLMNonJSONPaperTotal)
+	_ = prometheus.Register(MarketTicksTotal)
+	_ = prometheus.Register(StrategySignalsTotal)
+	_ = prometheus.Register(RiskDecisionsTotal)
+	_ = prometheus.Register(RiskDecisionDuration)
+	_ = prometheus.Register(ExecutionOrdersTotal)
+	_ = prometheus.Register(ExecutionOrderLatency)
+	_ = prometheus.Register(ExecutionPendingOrders)
+	_ = prometheus.Register(PortfolioPositionsActive)
+	_ = prometheus.Register(ActorLoopIterationsTotal)
 	_ = prometheus.Register(collectors.NewGoCollector())
 	_ = prometheus.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 }


### PR DESCRIPTION
## Summary

Adds 9 Prometheus-native metrics to the trading actor pipeline (Collector → Strategy → Risk → Execution → Portfolio) for operator observability.

## Metrics Added

| Metric | Type | Labels | Actor |
|--------|------|--------|-------|
| `neuratrade_market_ticks_total` | Counter | exchange, symbol | CollectorActor |
| `neuratrade_strategy_signals_total` | Counter | strategy_id, symbol, side | StrategyActor |
| `neuratrade_risk_decisions_total` | Counter | outcome, reason | RiskActor |
| `neuratrade_risk_decision_duration_seconds` | Histogram | - | RiskActor |
| `neuratrade_execution_orders_total` | Counter | exchange, symbol, side, status | ExecutionActor |
| `neuratrade_execution_order_latency_seconds` | Histogram | exchange | ExecutionActor |
| `neuratrade_execution_pending_orders` | Gauge | - | ExecutionActor |
| `neuratrade_portfolio_positions_active` | Gauge | - | PortfolioActor |
| `neuratrade_actor_loop_iterations_total` | Counter | actor | (liveness) |

## Testing

- All 29 metrics tests pass (`go test ./internal/metrics/`)
- Build verified: all touched packages compile
- `prometheus/testutil` used for counter/gauge/histogram verification

Closes NeuraTrade-d75g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced system observability with comprehensive metrics tracking across market data collection, strategy signals, risk decisions, order execution, latency measurements, and portfolio positions.

* **Tests**
  * Added comprehensive unit test suite validating metrics initialization, increments, and registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->