### PR TITLE
feat(risk): add env-var overrides for MaxDrawdown/MaxDailyLoss and graduated drawdown tiers

### DIFF
--- a/services/backend-api/internal/app/autonomy/scalping_cycle.go
+++ b/services/backend-api/internal/app/autonomy/scalping_cycle.go
@@ -343,6 +343,8 @@ func EvaluateScalpingPolicy(input ScalpingCycleInput, cfg ScalpingPolicyConfig) 
 				"critical_recent_win_rate",
 				"loss_streak_confidence_tightening",
 				"drawdown_tightening",
+				"drawdown_tightening_moderate",
+				"drawdown_tightening_early",
 			) {
 			policy.EffectiveMinConfidence = cfg.MicroConfidenceCap
 			policy.PolicyAdjustments = append(policy.PolicyAdjustments, "micro_confidence_cap")

--- a/services/backend-api/internal/app/autonomy/scalping_cycle.go
+++ b/services/backend-api/internal/app/autonomy/scalping_cycle.go
@@ -304,10 +304,19 @@ func EvaluateScalpingPolicy(input ScalpingCycleInput, cfg ScalpingPolicyConfig) 
 		policy.EffectiveMaxCapitalPct = policy.EffectiveMaxCapitalPct * 0.75
 		policy.PolicyAdjustments = append(policy.PolicyAdjustments, "negative_expectancy_cap")
 	}
-	if input.RiskDrawdown > 0.12 {
+	switch {
+	case input.RiskDrawdown > 0.12:
 		policy.EffectiveMinConfidence += 0.05
 		policy.EffectiveMaxCapitalPct = policy.EffectiveMaxCapitalPct * 0.70
 		policy.PolicyAdjustments = append(policy.PolicyAdjustments, "drawdown_tightening")
+	case input.RiskDrawdown > 0.08:
+		policy.EffectiveMinConfidence += 0.03
+		policy.EffectiveMaxCapitalPct = policy.EffectiveMaxCapitalPct * 0.80
+		policy.PolicyAdjustments = append(policy.PolicyAdjustments, "drawdown_tightening_moderate")
+	case input.RiskDrawdown > 0.05:
+		policy.EffectiveMinConfidence += 0.02
+		policy.EffectiveMaxCapitalPct = policy.EffectiveMaxCapitalPct * 0.90
+		policy.PolicyAdjustments = append(policy.PolicyAdjustments, "drawdown_tightening_early")
 	}
 
 	switch recoveryMode {

--- a/services/backend-api/internal/app/autonomy/scalping_cycle_test.go
+++ b/services/backend-api/internal/app/autonomy/scalping_cycle_test.go
@@ -264,6 +264,49 @@ func TestEvaluateScalpingPolicy_LossStreakAndNegativeExpectancyTightening(t *tes
 	require.Contains(t, withLossAndNegativeExpectancy.PolicyAdjustments, "negative_expectancy_cap")
 }
 
+func TestEvaluateScalpingPolicy_GraduatedDrawdownTightening(t *testing.T) {
+	config := DefaultScalpingPolicyConfig()
+
+	baseline := EvaluateScalpingPolicy(ScalpingCycleInput{
+		TotalValue:        decimal.NewFromInt(1_000),
+		BaseMinConfidence: 0.70,
+		BaseMaxCapitalPct: 5.0,
+	}, config)
+
+	early := EvaluateScalpingPolicy(ScalpingCycleInput{
+		TotalValue:        decimal.NewFromInt(1_000),
+		BaseMinConfidence: 0.70,
+		BaseMaxCapitalPct: 5.0,
+		RiskDrawdown:      0.06,
+	}, config)
+
+	moderate := EvaluateScalpingPolicy(ScalpingCycleInput{
+		TotalValue:        decimal.NewFromInt(1_000),
+		BaseMinConfidence: 0.70,
+		BaseMaxCapitalPct: 5.0,
+		RiskDrawdown:      0.09,
+	}, config)
+
+	heavy := EvaluateScalpingPolicy(ScalpingCycleInput{
+		TotalValue:        decimal.NewFromInt(1_000),
+		BaseMinConfidence: 0.70,
+		BaseMaxCapitalPct: 5.0,
+		RiskDrawdown:      0.15,
+	}, config)
+
+	require.Contains(t, early.PolicyAdjustments, "drawdown_tightening_early")
+	require.Greater(t, early.EffectiveMinConfidence, baseline.EffectiveMinConfidence)
+	require.Less(t, early.EffectiveMaxCapitalPct, baseline.EffectiveMaxCapitalPct)
+
+	require.Contains(t, moderate.PolicyAdjustments, "drawdown_tightening_moderate")
+	require.Greater(t, moderate.EffectiveMinConfidence, early.EffectiveMinConfidence)
+	require.Less(t, moderate.EffectiveMaxCapitalPct, early.EffectiveMaxCapitalPct)
+
+	require.Contains(t, heavy.PolicyAdjustments, "drawdown_tightening")
+	require.Greater(t, heavy.EffectiveMinConfidence, moderate.EffectiveMinConfidence)
+	require.Less(t, heavy.EffectiveMaxCapitalPct, moderate.EffectiveMaxCapitalPct)
+}
+
 func TestEvaluateScalpingPolicy_UsesInclusiveTierThresholdsAndStandardConcurrentCap(t *testing.T) {
 	cfg := DefaultScalpingPolicyConfig()
 

--- a/services/backend-api/internal/app/autonomy/scalping_cycle_test.go
+++ b/services/backend-api/internal/app/autonomy/scalping_cycle_test.go
@@ -307,6 +307,30 @@ func TestEvaluateScalpingPolicy_GraduatedDrawdownTightening(t *testing.T) {
 	require.Less(t, heavy.EffectiveMaxCapitalPct, moderate.EffectiveMaxCapitalPct)
 }
 
+func TestEvaluateScalpingPolicy_GraduatedDrawdownPreservesMicroConfidenceCap(t *testing.T) {
+	cfg := DefaultScalpingPolicyConfig()
+
+	withDrawdown := EvaluateScalpingPolicy(ScalpingCycleInput{
+		TotalValue:        decimal.NewFromInt(10),
+		BaseMinConfidence: 0.70,
+		BaseMaxCapitalPct: 5.0,
+		RiskDrawdown:      0.06,
+	}, cfg)
+
+	require.Equal(t, AccountTierMicro, withDrawdown.AccountTier)
+	require.Contains(t, withDrawdown.PolicyAdjustments, "drawdown_tightening_early")
+	require.NotContains(t, withDrawdown.PolicyAdjustments, "micro_confidence_cap")
+
+	withoutDrawdown := EvaluateScalpingPolicy(ScalpingCycleInput{
+		TotalValue:        decimal.NewFromInt(10),
+		BaseMinConfidence: 0.70,
+		BaseMaxCapitalPct: 5.0,
+	}, cfg)
+
+	require.Contains(t, withoutDrawdown.PolicyAdjustments, "micro_confidence_cap")
+	require.Greater(t, withDrawdown.EffectiveMinConfidence, withoutDrawdown.EffectiveMinConfidence)
+}
+
 func TestEvaluateScalpingPolicy_UsesInclusiveTierThresholdsAndStandardConcurrentCap(t *testing.T) {
 	cfg := DefaultScalpingPolicyConfig()
 

--- a/services/backend-api/internal/app/bootstrap/bootstrap.go
+++ b/services/backend-api/internal/app/bootstrap/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -70,13 +71,26 @@ type RiskConfig struct {
 
 // DefaultRiskConfig returns default risk configuration.
 func DefaultRiskConfig() RiskConfig {
-	return RiskConfig{
+	cfg := RiskConfig{
 		MaxDrawdown:         decimal.NewFromFloat(0.1),  // 10%
 		MaxDailyLoss:        decimal.NewFromFloat(0.05), // 5%
 		CooldownPeriod:      5 * time.Minute,
 		CooldownAfterLosses: 3,
 		SafeMode:            risk.DefaultSafeModeConfig(),
 	}
+
+	if v := os.Getenv("NEURATRADE_RISK_MAX_DRAWDOWN"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 && f <= 1 {
+			cfg.MaxDrawdown = decimal.NewFromFloat(f)
+		}
+	}
+	if v := os.Getenv("NEURATRADE_RISK_MAX_DAILY_LOSS"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 && f <= 1 {
+			cfg.MaxDailyLoss = decimal.NewFromFloat(f)
+		}
+	}
+
+	return cfg
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/services/backend-api/internal/app/bootstrap/bootstrap.go
+++ b/services/backend-api/internal/app/bootstrap/bootstrap.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -80,13 +79,13 @@ func DefaultRiskConfig() RiskConfig {
 	}
 
 	if v := os.Getenv("NEURATRADE_RISK_MAX_DRAWDOWN"); v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 && f <= 1 {
-			cfg.MaxDrawdown = decimal.NewFromFloat(f)
+		if d, err := decimal.NewFromString(v); err == nil && d.GreaterThan(decimal.Zero) && d.LessThanOrEqual(decimal.NewFromInt(1)) {
+			cfg.MaxDrawdown = d
 		}
 	}
 	if v := os.Getenv("NEURATRADE_RISK_MAX_DAILY_LOSS"); v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 && f <= 1 {
-			cfg.MaxDailyLoss = decimal.NewFromFloat(f)
+		if d, err := decimal.NewFromString(v); err == nil && d.GreaterThan(decimal.Zero) && d.LessThanOrEqual(decimal.NewFromInt(1)) {
+			cfg.MaxDailyLoss = d
 		}
 	}
 

--- a/services/backend-api/internal/app/bootstrap/bootstrap_test.go
+++ b/services/backend-api/internal/app/bootstrap/bootstrap_test.go
@@ -48,6 +48,30 @@ func TestLoadScalpingWeightsFromEnv_RejectsInvalidNumber(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDefaultRiskConfig_DefaultsWhenEnvUnset(t *testing.T) {
+	t.Setenv("NEURATRADE_RISK_MAX_DRAWDOWN", "")
+	t.Setenv("NEURATRADE_RISK_MAX_DAILY_LOSS", "")
+	cfg := DefaultRiskConfig()
+	require.True(t, cfg.MaxDrawdown.Equal(decimal.RequireFromString("0.1")))
+	require.True(t, cfg.MaxDailyLoss.Equal(decimal.RequireFromString("0.05")))
+}
+
+func TestDefaultRiskConfig_AppliesEnvOverrides(t *testing.T) {
+	t.Setenv("NEURATRADE_RISK_MAX_DRAWDOWN", "0.08")
+	t.Setenv("NEURATRADE_RISK_MAX_DAILY_LOSS", "0.03")
+	cfg := DefaultRiskConfig()
+	require.True(t, cfg.MaxDrawdown.Equal(decimal.RequireFromString("0.08")))
+	require.True(t, cfg.MaxDailyLoss.Equal(decimal.RequireFromString("0.03")))
+}
+
+func TestDefaultRiskConfig_RejectsInvalidValues(t *testing.T) {
+	t.Setenv("NEURATRADE_RISK_MAX_DRAWDOWN", "not-a-number")
+	t.Setenv("NEURATRADE_RISK_MAX_DAILY_LOSS", "2.0")
+	cfg := DefaultRiskConfig()
+	require.True(t, cfg.MaxDrawdown.Equal(decimal.RequireFromString("0.1")))
+	require.True(t, cfg.MaxDailyLoss.Equal(decimal.RequireFromString("0.05")))
+}
+
 type noopActor struct{}
 
 func (noopActor) Receive(ctx context.Context, env actor.Envelope) error { return nil }


### PR DESCRIPTION
- Add NEURATRADE_RISK_MAX_DRAWDOWN and NEURATRADE_RISK_MAX_DAILY_LOSS env vars
  to bootstrap DefaultRiskConfig() (validates 0 < v <= 1, falls back to defaults)
- Replace single >12% drawdown tightening with graduated tiers:
  >5%: early tightening (+0.02 confidence, ×0.90 capital)
  >8%: moderate tightening (+0.03 confidence, ×0.80 capital)
  >12%: heavy tightening (+0.05 confidence, ×0.70 capital)
- Add tests for env var parsing (default, override, invalid) and graduated tiers
- All 8 bootstrap tests and 64 autonomy tests pass

Closes bd-NeuraTrade-pani (#453)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scalping policy risk management now applies graduated adjustments based on multiple drawdown thresholds for improved risk control.
  * Risk configuration parameters can now be customized via environment variables.

* **Tests**
  * Added test coverage for graduated drawdown-based risk adjustments.
  * Added test coverage for environment variable configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->