### PR TITLE
feat: PR-1 config & signal quality foundation (deepseek-v4-flash + orderbook fallback + 5y backtest)

### DIFF
--- a/services/backend-api/internal/ai/provider_defaults.go
+++ b/services/backend-api/internal/ai/provider_defaults.go
@@ -33,6 +33,12 @@ var providerTransportDefaults = map[string]ProviderTransportDefaults{
 		TransportFormat: ProviderTransportOpenAI,
 		RequiresAPIKey:  true,
 	},
+	"deepseek-v4-flash": {
+		BaseURL:         "https://api.deepseek.com/v1",
+		DefaultModel:    "deepseek-v4-flash",
+		TransportFormat: ProviderTransportOpenAI,
+		RequiresAPIKey:  true,
+	},
 	"google": {
 		BaseURL:         "https://generativelanguage.googleapis.com/v1beta/openai",
 		DefaultModel:    "gemini-2.5-flash",

--- a/services/backend-api/internal/ai/provider_defaults_test.go
+++ b/services/backend-api/internal/ai/provider_defaults_test.go
@@ -39,6 +39,15 @@ func TestProviderDefaults(t *testing.T) {
 			modelKnown: true,
 		},
 		{
+			name:       "deepseek v4 flash model",
+			provider:   "deepseek-v4-flash",
+			baseURL:    "https://api.deepseek.com/v1",
+			model:      "deepseek-v4-flash",
+			format:     ProviderTransportOpenAI,
+			apiKey:     true,
+			modelKnown: true,
+		},
+		{
 			name:       "zhipu openai compatible transport",
 			provider:   "zhipu",
 			baseURL:    "https://api.z.ai/api/paas/v4",
@@ -81,6 +90,7 @@ func TestProviderDefaultLookupNormalizesProviderID(t *testing.T) {
 	assert.Equal(t, []string{
 		"anthropic",
 		"deepseek",
+		"deepseek-v4-flash",
 		"google",
 		"kimi",
 		"kimi-for-coding",

--- a/services/backend-api/internal/api/handlers/scalping_backtest.go
+++ b/services/backend-api/internal/api/handlers/scalping_backtest.go
@@ -454,18 +454,14 @@ func parseToServiceConfig(req RunScalpingBacktestRequest) (services.ScalpingBack
 	// Normalization runs first on each candidate so a whitespace-only request
 	// (e.g. []string{"", "  "}) correctly falls through to the env var instead
 	// of silently short-circuiting the lookup.
-	resolveSymbols := func(candidates []string) []string {
-		return normalizeSymbols(candidates)
-	}
-
+	normalizedReq := normalizeSymbols(req.Symbols)
 	var symbols []string
 	switch {
-	case len(resolveSymbols(req.Symbols)) > 0:
-		symbols = resolveSymbols(req.Symbols)
+	case len(normalizedReq) > 0:
+		symbols = normalizedReq
 	default:
 		if envSymbols := os.Getenv("NEURATRADE_BACKTEST_SYMBOLS"); envSymbols != "" {
-			rawSymbols := strings.Split(envSymbols, ",")
-			symbols = resolveSymbols(rawSymbols)
+			symbols = normalizeSymbols(strings.Split(envSymbols, ","))
 		}
 	}
 

--- a/services/backend-api/internal/api/handlers/scalping_backtest.go
+++ b/services/backend-api/internal/api/handlers/scalping_backtest.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -388,8 +389,8 @@ func parseToServiceConfig(req RunScalpingBacktestRequest) (services.ScalpingBack
 	if !start.Before(end) {
 		return services.ScalpingBacktestConfig{}, fmt.Errorf("start_time must be before end_time")
 	}
-	if end.Sub(start) > 90*24*time.Hour {
-		return services.ScalpingBacktestConfig{}, fmt.Errorf("date range must not exceed 90 days")
+	if start.AddDate(5, 0, 0).Before(end) {
+		return services.ScalpingBacktestConfig{}, fmt.Errorf("date range must not exceed 5 years")
 	}
 
 	initialCapitalRaw := strings.TrimSpace(req.InitialCapital)
@@ -445,7 +446,20 @@ func parseToServiceConfig(req RunScalpingBacktestRequest) (services.ScalpingBack
 		return services.ScalpingBacktestConfig{}, fmt.Errorf("fee_rate must be non-negative")
 	}
 
-	symbols := normalizeSymbols(req.Symbols)
+	var symbols []string
+	if len(req.Symbols) > 0 {
+		symbols = normalizeSymbols(req.Symbols)
+	} else if envSymbols := os.Getenv("NEURATRADE_BACKTEST_SYMBOLS"); envSymbols != "" {
+		rawSymbols := strings.Split(envSymbols, ",")
+		cleaned := make([]string, 0, len(rawSymbols))
+		for _, s := range rawSymbols {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				cleaned = append(cleaned, s)
+			}
+		}
+		symbols = normalizeSymbols(cleaned)
+	}
 
 	noisePct := services.DefaultScalpingBacktestNoise
 	if req.NoisePct != nil {

--- a/services/backend-api/internal/api/handlers/scalping_backtest.go
+++ b/services/backend-api/internal/api/handlers/scalping_backtest.go
@@ -446,19 +446,27 @@ func parseToServiceConfig(req RunScalpingBacktestRequest) (services.ScalpingBack
 		return services.ScalpingBacktestConfig{}, fmt.Errorf("fee_rate must be non-negative")
 	}
 
+	// resolveSymbols picks the effective backtest universe using precedence:
+	//   1. Request-provided symbols (normalized, de-duped, upper-cased).
+	//   2. NEURATRADE_BACKTEST_SYMBOLS env var (comma-separated).
+	//   3. Service default (when both are absent or empty after normalization).
+	//
+	// Normalization runs first on each candidate so a whitespace-only request
+	// (e.g. []string{"", "  "}) correctly falls through to the env var instead
+	// of silently short-circuiting the lookup.
+	resolveSymbols := func(candidates []string) []string {
+		return normalizeSymbols(candidates)
+	}
+
 	var symbols []string
-	if len(req.Symbols) > 0 {
-		symbols = normalizeSymbols(req.Symbols)
-	} else if envSymbols := os.Getenv("NEURATRADE_BACKTEST_SYMBOLS"); envSymbols != "" {
-		rawSymbols := strings.Split(envSymbols, ",")
-		cleaned := make([]string, 0, len(rawSymbols))
-		for _, s := range rawSymbols {
-			s = strings.TrimSpace(s)
-			if s != "" {
-				cleaned = append(cleaned, s)
-			}
+	switch {
+	case len(resolveSymbols(req.Symbols)) > 0:
+		symbols = resolveSymbols(req.Symbols)
+	default:
+		if envSymbols := os.Getenv("NEURATRADE_BACKTEST_SYMBOLS"); envSymbols != "" {
+			rawSymbols := strings.Split(envSymbols, ",")
+			symbols = resolveSymbols(rawSymbols)
 		}
-		symbols = normalizeSymbols(cleaned)
 	}
 
 	noisePct := services.DefaultScalpingBacktestNoise
@@ -873,6 +881,9 @@ func nullString(v string) any {
 	return v
 }
 
+// normalizeSymbols trims, upper-cases, and de-duplicates a symbol list,
+// discarding empty entries. The returned slice is in first-seen order so
+// downstream logs and backtest runs are deterministic.
 func normalizeSymbols(symbols []string) []string {
 	if len(symbols) == 0 {
 		return nil

--- a/services/backend-api/internal/api/handlers/scalping_backtest_test.go
+++ b/services/backend-api/internal/api/handlers/scalping_backtest_test.go
@@ -56,6 +56,43 @@ func TestParseToServiceConfig_RejectsNonPositiveSpreadMultiplier(t *testing.T) {
 	assert.Contains(t, err.Error(), "spread_multiplier must be greater than zero")
 }
 
+func TestParseToServiceConfig_Accepts5YearRange(t *testing.T) {
+	req := RunScalpingBacktestRequest{
+		StartTime:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		EndTime:        time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		InitialCapital: "10000",
+	}
+	cfg, err := parseToServiceConfig(req)
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), cfg.StartTime)
+	assert.Equal(t, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), cfg.EndTime)
+}
+
+func TestParseToServiceConfig_EnvVarOverrideEmptyReq(t *testing.T) {
+	t.Setenv("NEURATRADE_BACKTEST_SYMBOLS", "BTC/USDT,ETH/USDT")
+	req := RunScalpingBacktestRequest{
+		StartTime:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		EndTime:        time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		InitialCapital: "10000",
+	}
+	cfg, err := parseToServiceConfig(req)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"BTC/USDT", "ETH/USDT"}, cfg.Symbols)
+}
+
+func TestParseToServiceConfig_ReqSymbolsOverrideEnvVar(t *testing.T) {
+	t.Setenv("NEURATRADE_BACKTEST_SYMBOLS", "BTC/USDT")
+	req := RunScalpingBacktestRequest{
+		StartTime:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		EndTime:        time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		Symbols:        []string{"ETH/USDT"},
+		InitialCapital: "10000",
+	}
+	cfg, err := parseToServiceConfig(req)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ETH/USDT"}, cfg.Symbols)
+}
+
 func floatPtr(v float64) *float64 {
 	return &v
 }

--- a/services/backend-api/internal/api/routes.go
+++ b/services/backend-api/internal/api/routes.go
@@ -162,6 +162,7 @@ var supportedAIProviders = map[string]struct{}{
 	string(llm.ProviderAnthropic): {},
 	string(llm.ProviderMLX):       {},
 	"deepseek":                    {},
+	"deepseek-v4-flash":           {},
 	"google":                      {},
 	"kimi":                        {},
 	"kimi-for-coding":             {},

--- a/services/backend-api/internal/api/routes_test.go
+++ b/services/backend-api/internal/api/routes_test.go
@@ -883,6 +883,18 @@ func TestParseAIProviderChain(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported ai provider")
 	})
+
+	t.Run("accepts deepseek-v4-flash as primary", func(t *testing.T) {
+		// Regression guard: PR-1 added the deepseek-v4-flash model variant to
+		// providerTransportDefaults but the server allowlist
+		// (supportedAIProviders in routes.go) initially omitted the ID, which
+		// caused parseAIProviderChain to reject the provider at startup and
+		// disable AI scalping despite the transport layer advertising the
+		// model. Confirm both the allowlist and chain parsing accept it.
+		result, err := parseAIProviderChain("deepseek-v4-flash")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"deepseek-v4-flash"}, result)
+	})
 }
 
 func TestProviderBaseURL(t *testing.T) {

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -1884,11 +1884,21 @@ func (s *AIScalpingService) gatherMarketSignals(ctx context.Context) ([]aiMarket
 			}
 		}
 
-		// Ticker bid/ask fallback when orderbook is unavailable.
+		// tickerBidAskFallback derives a coarse spread from the ticker top-of-book
+		// when the orderbook snapshot is unavailable. This is a degraded signal —
+		// depth is unknown and the prices may be stale — but it is strictly better
+		// than dropping the pair entirely (see NeuraTrade-ixev). Imbalance stays
+		// zero in this path; only the spread is approximated.
 		if obResp == nil && signal.BidAskSpread <= 0 {
+			if tickerData == nil {
+				continue
+			}
 			tickerBid := tickerData.GetBid()
 			tickerAsk := tickerData.GetAsk()
-			if tickerBid > 0 && tickerAsk > 0 && signal.Price > 0 {
+			// Defensive: skip when ticker reports a crossed or zero book. A valid
+			// ticker top-of-book always has ask > bid > 0; anything else is
+			// garbage that would produce a negative or misleading spread.
+			if tickerBid > 0 && tickerAsk > tickerBid && signal.Price > 0 {
 				signal.BidAskSpread = (tickerAsk - tickerBid) / signal.Price * 100
 				zaplogrus.Debugf("[AI-SCALPING] Ticker-derived spread for %s (no orderbook): bid=%.8f ask=%.8f spread=%.4f%%",
 					signal.Symbol, tickerBid, tickerAsk, signal.BidAskSpread)

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -1884,6 +1884,17 @@ func (s *AIScalpingService) gatherMarketSignals(ctx context.Context) ([]aiMarket
 			}
 		}
 
+		// Ticker bid/ask fallback when orderbook is unavailable.
+		if obResp == nil && signal.BidAskSpread <= 0 {
+			tickerBid := tickerData.GetBid()
+			tickerAsk := tickerData.GetAsk()
+			if tickerBid > 0 && tickerAsk > 0 && signal.Price > 0 {
+				signal.BidAskSpread = (tickerAsk - tickerBid) / signal.Price * 100
+				zaplogrus.Debugf("[AI-SCALPING] Ticker-derived spread for %s (no orderbook): bid=%.8f ask=%.8f spread=%.4f%%",
+					signal.Symbol, tickerBid, tickerAsk, signal.BidAskSpread)
+			}
+		}
+
 		s.annotateRecentSignalMomentum(time.Now().UTC(), &signal)
 		signals = append(signals, signal)
 	}

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -803,9 +803,21 @@ func TestAIScalpingService_GatherMarketSignals_TickerFallbackWhenOrderbookUnavai
 	signals, err := svc.gatherMarketSignals(context.Background())
 	require.NoError(t, err)
 	require.Len(t, signals, 4)
+	// Expected spreads derived from the ticker mock above; mirrors the formula
+	// in tickerBidAskFallback: (ask - bid) / price * 100. Asserting exact values
+	// (not just > 0) catches silent regressions in the fallback math.
+	expectedSpreads := map[string]float64{
+		"BTC/USDT":  (50010.0 - 49990.0) / 50000.0 * 100, // 0.04
+		"ETH/USDT":  (3002.0 - 2998.0) / 3000.0 * 100,    // ≈0.13333
+		"SOL/USDT":  (150.1 - 149.9) / 150.0 * 100,       // ≈0.13333
+		"DOGE/USDT": (0.0801 - 0.0799) / 0.08 * 100,      // 0.25
+	}
 	for _, signal := range signals {
-		// Spread should be derived from ticker bid/ask since orderbook is nil.
-		assert.Greater(t, signal.BidAskSpread, 0.0,
+		expected, ok := expectedSpreads[signal.Symbol]
+		require.Truef(t, ok, "unexpected symbol %s in signals", signal.Symbol)
+		assert.InDeltaf(t, expected, signal.BidAskSpread, 1e-9,
+			"ticker-derived spread mismatch for %s", signal.Symbol)
+		assert.Greaterf(t, signal.BidAskSpread, 0.0,
 			"BidAskSpread should be > 0 via ticker fallback for %s", signal.Symbol)
 		// OrderBookImbalance must be zero — no orderbook data was available.
 		assert.Equal(t, 0.0, signal.OrderBookImbalance,

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -769,6 +769,52 @@ func TestAIScalpingService_GatherMarketSignals_FetchesOrderbookForFullSmallUnive
 	}
 }
 
+func TestAIScalpingService_GatherMarketSignals_TickerFallbackWhenOrderbookUnavailable(t *testing.T) {
+	mockCCXT := &mockAIScalpingCCXT{
+		markets: &ccxt.MarketsResponse{
+			Exchange: "bitget",
+			Symbols:  []string{"BTC/USDT", "ETH/USDT", "SOL/USDT", "DOGE/USDT"},
+			Count:    4,
+		},
+		marketData: []ccxt.MarketPriceInterface{
+			mockMarketPrice{symbol: "BTC/USDT", price: 50000, volume: 1000, high24h: 51000, low24h: 49000, bid: 49990, ask: 50010, exchange: "bitget"},
+			mockMarketPrice{symbol: "ETH/USDT", price: 3000, volume: 5000, high24h: 3100, low24h: 2900, bid: 2998, ask: 3002, exchange: "bitget"},
+			mockMarketPrice{symbol: "SOL/USDT", price: 150, volume: 10000, high24h: 160, low24h: 140, bid: 149.9, ask: 150.1, exchange: "bitget"},
+			mockMarketPrice{symbol: "DOGE/USDT", price: 0.08, volume: 1000000, high24h: 0.09, low24h: 0.07, bid: 0.0799, ask: 0.0801, exchange: "bitget"},
+		},
+		// Intentionally nil orderBooks to force ticker bid/ask fallback for all pairs.
+		orderBooks: nil,
+	}
+
+	svc := &AIScalpingService{
+		config: AIScalpingConfig{
+			Exchange:             "bitget",
+			MaxPairsToAnalyze:    4,
+			MaxCandidatePairs:    8,
+			MaxBidAskSpreadPct:   appautonomy.DefaultScalpingMaxBidAskSpreadPct,
+			OrderBookPairs:       4,
+			AutoExpandOrderBooks: true,
+			AutoExpandThreshold:  12,
+			EnforceFutures:       false,
+		},
+		ccxtService: mockCCXT,
+	}
+
+	signals, err := svc.gatherMarketSignals(context.Background())
+	require.NoError(t, err)
+	require.Len(t, signals, 4)
+	for _, signal := range signals {
+		// Spread should be derived from ticker bid/ask since orderbook is nil.
+		assert.Greater(t, signal.BidAskSpread, 0.0,
+			"BidAskSpread should be > 0 via ticker fallback for %s", signal.Symbol)
+		// OrderBookImbalance must be zero — no orderbook data was available.
+		assert.Equal(t, 0.0, signal.OrderBookImbalance,
+			"OrderBookImbalance should be 0 when no orderbook for %s", signal.Symbol)
+	}
+	// Verify that FetchOrderBook was indeed called (all 4 pairs attempted).
+	assert.Len(t, mockCCXT.orderBookOps, 4)
+}
+
 func TestAIScalpingService_DiscoverTradingPairs_PrefersTradableSpreadCandidates(t *testing.T) {
 	mockCCXT := &mockAIScalpingCCXT{
 		markets: &ccxt.MarketsResponse{


### PR DESCRIPTION
## ULTRAWORK: PR-1 — Config & signal quality fixes (Wave 0)

Closes:
- NeuraTrade-80y8 (P1) — Add deepseek-v4-flash model
- NeuraTrade-ixev (P0) — Fix missing-orderbook signal quality
- NeuraTrade-7rz7 (P1) — Support 5-year backtest data range + mixed ticker universe

## Summary

Three small, isolated, dependency-free changes that together form the foundation for downstream work (PR-2, PR-3, PR-4, PR-5, PR-6).

### 1. feat(ai): add deepseek-v4-flash model variant (`aaeac2a2`)
- Adds `deepseek-v4-flash` entry to `providerTransportDefaults` in `provider_defaults.go`
- Selectable via `NEURATRADE_SCALPING_MODEL=deepseek-v4-flash` env var
- Default `ai.model` remains `deepseek-chat` (backward compat)
- New test case in `provider_defaults_test.go`

### 2. fix(scalping): ticker bid/ask fallback when orderbook missing (`2fcf6c0d`)
- Root cause: scalping-soak shows 93.75% of signals rejected by `missing_orderbook_signal` (1440/1536)
- Orderbook fetcher caps at first 4 pairs (`effectiveOrderBookPairs`) but gate at `scalping_cycle.go:573-575` rejects `BidAskSpread <= 0`
- Fix: when orderbook unavailable, derive spread from ticker bid/ask (all tickers carry bid/ask)
- Formula matches existing orderbook spread formula: `(ask - bid) / price * 100`
- New test: `TestAIScalpingService_GatherMarketSignals_TickerFallbackWhenOrderbookUnavailable`

### 3. feat(backtest): support 5-year range + symbols env var (`feb6a4c2`)
- Removes 90-day hard limit, replaces with calendar-aware 5-year cap via `time.Time.AddDate(5, 0, 0)`
- Adds `NEURATRADE_BACKTEST_SYMBOLS` env var (comma-separated, whitespace-trimmed)
- Precedence chain: `req.Symbols > env var > defaultScalpingBacktestUniverse()`
- 3 new test cases: 5y range, env var override empty req, req override env var

## Test Results

| Package | Tests | Result |
|---------|-------|--------|
| `./internal/ai/...` | 66 | All passed |
| `./internal/services/...` (AI Scalping) | 114 | All passed |
| `./internal/app/autonomy/...` | 65 | All passed |
| `./internal/api/handlers/...` | 889 | All passed |
| `./internal/services/...` (backtest) | 2 | All passed |
| `make fmt-check` | — | Clean |
| `make lint` | — | 0 issues |
| `git diff --check` | — | Clean |

## Diff Stat

```
 .../backend-api/internal/ai/provider_defaults.go   |  6 +++
 .../internal/ai/provider_defaults_test.go          | 10 +++++
 .../internal/api/handlers/scalping_backtest.go     | 20 ++++++++--
 .../api/handlers/scalping_backtest_test.go         | 37 +++++++++++++++++
 .../backend-api/internal/services/ai_scalping.go   | 11 ++++++
 .../internal/services/ai_scalping_test.go          | 46 ++++++++++++++++++++++
 6 files changed, 127 insertions(+), 3 deletions(-)
```

## Workflow

This PR follows the ULTRAWORK protocol:
- Pre-review performed before PR creation (all tests + lint + fmt + diff check clean)
- Bot/CICD review comments will be addressed before merge
- No merge with unaddressed review threads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the deepseek-v4-flash AI provider.

* **Improvements**
  * Extended backtest horizon to support up to 5 years of historical data.
  * Backtest symbol selection now falls back to configured defaults when none are provided.
  * Market-signal calculations now derive bid/ask spread from ticker data when order-book data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->