### PR TITLE
feat(scalping): relax fallback gates for ticker-only data + add chop-regime env var

### DIFF
--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -407,8 +407,8 @@ func ResolveAIScalpingConfigFromEnv(base AIScalpingConfig) AIScalpingConfig {
 	if value, ok := getEnvFloat("NEURATRADE_SCALPING_REGIME_LOW_BAND"); ok {
 		cfg.RegimeLowBand = clampFloat(value, 1, 45)
 	}
-	if value, ok := getEnvFloat("NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE"); ok {
-		cfg.RegimeChopConfidence = clampFloat(value, 0, 1)
+	if value, ok := getEnvFloat("NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE"); ok && value > 0 && value <= 1 {
+		cfg.RegimeChopConfidence = value
 	}
 	if value := getEnvInt("NEURATRADE_SCALPING_SHADOW_TIMEOUT_SECONDS"); value > 0 {
 		cfg.ShadowMirrorTimeout = time.Duration(clampInt(value, 1, 60)) * time.Second
@@ -438,7 +438,7 @@ func ResolveAIScalpingConfigFromEnv(base AIScalpingConfig) AIScalpingConfig {
 	cfg.DeterministicFallback = applyDeterministicFallbackConfigFromEnv(cfg.DeterministicFallback).Normalized()
 
 	zaplogrus.Infof(
-		"[AI-SCALPING] Runtime config: exchange=%s model=%s leverage=%d max_tokens=%d max_capital_pct=%.2f min_confidence=%.2f timeout=%s auto_execute=%t allow_spot_fallback=%t max_pairs=%d max_candidates=%d max_bid_ask_spread=%.4f orderbook_pairs=%d auto_expand_orderbooks=%t auto_expand_threshold=%d enforce_futures=%t symbol_cooldown=%s failure_budget=%d failure_window=%s structured_retries=%d loss_streak_budget=%d loss_cooldown=%s loss_window=%s 		pretrade_gate=%t min_expectancy_edge=%.4f min_expectancy_samples=%d regime_low=%.1f regime_high=%.1f regime_chop_confidence=%.2f fallback_max_spread=%.4f fallback_min_imbalance=%.2f fallback_floor=%.2f fallback_size_fraction=%.2f",
+		"[AI-SCALPING] Runtime config: exchange=%s model=%s leverage=%d max_tokens=%d max_capital_pct=%.2f min_confidence=%.2f timeout=%s auto_execute=%t allow_spot_fallback=%t max_pairs=%d max_candidates=%d max_bid_ask_spread=%.4f orderbook_pairs=%d auto_expand_orderbooks=%t auto_expand_threshold=%d enforce_futures=%t symbol_cooldown=%s failure_budget=%d failure_window=%s structured_retries=%d loss_streak_budget=%d loss_cooldown=%s loss_window=%s pretrade_gate=%t min_expectancy_edge=%.4f min_expectancy_samples=%d regime_low=%.1f regime_high=%.1f regime_chop_confidence=%.2f fallback_max_spread=%.4f fallback_min_imbalance=%.2f fallback_floor=%.2f fallback_size_fraction=%.2f",
 		cfg.Exchange,
 		cfg.Model,
 		cfg.Leverage,
@@ -698,8 +698,8 @@ func applyAIScalpingConfigFromFile(base AIScalpingConfig) AIScalpingConfig {
 	if fileConfig.AI.Scalping.RegimeLowBand != nil {
 		cfg.RegimeLowBand = clampFloat(*fileConfig.AI.Scalping.RegimeLowBand, 1, 45)
 	}
-	if fileConfig.AI.Scalping.RegimeChopConfidence != nil {
-		cfg.RegimeChopConfidence = clampFloat(*fileConfig.AI.Scalping.RegimeChopConfidence, 0, 1)
+	if v := fileConfig.AI.Scalping.RegimeChopConfidence; v != nil && *v > 0 && *v <= 1 {
+		cfg.RegimeChopConfidence = *v
 	}
 
 	return cfg
@@ -2468,7 +2468,7 @@ func (s *AIScalpingService) evaluatePreTradeGate(ctx context.Context, decision *
 	}
 
 	// In choppy/non-directional conditions require either strong confidence or proven edge.
-	if regime == "chop" && decision.Confidence < 0.65 && (!hasExpectancy || expectancy <= s.config.MinExpectancyEdge) {
+	if regime == "chop" && decision.Confidence < s.effectiveRegimeChopConfidence() && (!hasExpectancy || expectancy <= s.config.MinExpectancyEdge) {
 		result.Allowed = false
 		result.Reason = fmt.Sprintf(
 			"pre-trade regime gate blocked %s: choppy market with low confidence (%.2f)",
@@ -2477,6 +2477,20 @@ func (s *AIScalpingService) evaluatePreTradeGate(ctx context.Context, decision *
 		)
 	}
 	return result
+}
+
+// effectiveRegimeChopConfidence returns the chop-regime confidence actually
+// used at runtime. Mis-set values (≤0, >1, or NaN) and unset values fall back
+// to DefaultAIScalpingConfig().RegimeChopConfidence so the default can never
+// drift from the fallback. The guard uses !(x > 0 && x <= 1) which is NaN-safe
+// (NaN comparisons return false), unlike the more obvious x <= 0 || x > 1
+// which would let NaN propagate as a regime confidence.
+func (s *AIScalpingService) effectiveRegimeChopConfidence() float64 {
+	chopConfidence := s.config.RegimeChopConfidence
+	if !(chopConfidence > 0 && chopConfidence <= 1) {
+		chopConfidence = DefaultAIScalpingConfig().RegimeChopConfidence
+	}
+	return chopConfidence
 }
 
 func (s *AIScalpingService) classifyScalpingRegime(signal aiMarketSignal, action string) (string, float64, string) {
@@ -2491,12 +2505,10 @@ func (s *AIScalpingService) classifyScalpingRegime(signal aiMarketSignal, action
 	// Chop regime confidence is configurable (NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE
 	// or config.json regime_chop_confidence) so operators can adjust how much
 	// confidence is allocated to the "chop" label in imbalance-thin markets.
-	// Default 0.65 preserves the prior hardcoded behavior. Clamp into (0, 1]
-	// to avoid zero-confidence floors when the field is mis-set.
-	chopConfidence := s.config.RegimeChopConfidence
-	if chopConfidence <= 0 || chopConfidence > 1 {
-		chopConfidence = 0.65
-	}
+	// Default 0.65 preserves the prior hardcoded behavior. The guard uses
+	// !(x > 0 && x <= 1) so NaN (which is neither > 0 nor <= 1) falls back to
+	// the canonical default rather than propagating as a regime confidence.
+	chopConfidence := s.effectiveRegimeChopConfidence()
 
 	spreadThreshold := s.maxBidAskSpreadPct()
 	if signal.BidAskSpread > spreadThreshold {

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -29,35 +29,42 @@ import (
 )
 
 type AIScalpingConfig struct {
-	Exchange              string
-	Model                 string
-	Leverage              int
-	MaxTokens             int
-	MaxCapitalPct         float64
-	MinConfidence         float64
-	MaxIterations         int
-	Timeout               time.Duration
-	AutoExecute           bool
-	AllowSpotFallback     bool
-	MaxPairsToAnalyze     int
-	MaxCandidatePairs     int
-	MaxBidAskSpreadPct    float64
-	OrderBookPairs        int
-	AutoExpandOrderBooks  bool
-	AutoExpandThreshold   int
-	EnforceFutures        bool
-	SymbolCooldown        time.Duration
-	FailureBudget         int
-	FailureWindow         time.Duration
-	StructuredRetries     int
-	LossStreakBudget      int
-	LossCooldown          time.Duration
-	LossWindow            time.Duration
-	PreTradeGate          bool
-	MinExpectancyEdge     float64
-	MinExpectancyN        int
-	RegimeHighBand        float64
-	RegimeLowBand         float64
+	Exchange             string
+	Model                string
+	Leverage             int
+	MaxTokens            int
+	MaxCapitalPct        float64
+	MinConfidence        float64
+	MaxIterations        int
+	Timeout              time.Duration
+	AutoExecute          bool
+	AllowSpotFallback    bool
+	MaxPairsToAnalyze    int
+	MaxCandidatePairs    int
+	MaxBidAskSpreadPct   float64
+	OrderBookPairs       int
+	AutoExpandOrderBooks bool
+	AutoExpandThreshold  int
+	EnforceFutures       bool
+	SymbolCooldown       time.Duration
+	FailureBudget        int
+	FailureWindow        time.Duration
+	StructuredRetries    int
+	LossStreakBudget     int
+	LossCooldown         time.Duration
+	LossWindow           time.Duration
+	PreTradeGate         bool
+	MinExpectancyEdge    float64
+	MinExpectancyN       int
+	RegimeHighBand       float64
+	RegimeLowBand        float64
+	// RegimeChopConfidence is the regime-confidence weight applied when
+	// |OrderBookImbalance| falls below the neutral floor. The default of 0.65
+	// matches the prior hardcoded value; tune via
+	// NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE or the config.json
+	// regime_chop_confidence field. Lowering this unblocks more candidates in
+	// chop-heavy markets; raising it makes the regime label more selective.
+	RegimeChopConfidence  float64
 	ShadowMirrorTimeout   time.Duration
 	DeterministicFallback DeterministicFallbackConfig
 }
@@ -143,8 +150,8 @@ type DeterministicFallbackConfig struct {
 
 func DefaultDeterministicFallbackConfig() DeterministicFallbackConfig {
 	return DeterministicFallbackConfig{
-		MaxBidAskSpread:       0.08,
-		MinImbalance:          0.35,
+		MaxBidAskSpread:       0.15,
+		MinImbalance:          0.10,
 		BuyRangeMax:           45.0,
 		SellRangeMin:          55.0,
 		BuyMinPriceChangePct:  0.0,
@@ -301,6 +308,7 @@ func DefaultAIScalpingConfig() AIScalpingConfig {
 		MinExpectancyN:        8,
 		RegimeHighBand:        85,
 		RegimeLowBand:         15,
+		RegimeChopConfidence:  0.65,
 		ShadowMirrorTimeout:   10 * time.Second,
 		DeterministicFallback: DefaultDeterministicFallbackConfig(),
 	}
@@ -399,6 +407,9 @@ func ResolveAIScalpingConfigFromEnv(base AIScalpingConfig) AIScalpingConfig {
 	if value, ok := getEnvFloat("NEURATRADE_SCALPING_REGIME_LOW_BAND"); ok {
 		cfg.RegimeLowBand = clampFloat(value, 1, 45)
 	}
+	if value, ok := getEnvFloat("NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE"); ok {
+		cfg.RegimeChopConfidence = clampFloat(value, 0, 1)
+	}
 	if value := getEnvInt("NEURATRADE_SCALPING_SHADOW_TIMEOUT_SECONDS"); value > 0 {
 		cfg.ShadowMirrorTimeout = time.Duration(clampInt(value, 1, 60)) * time.Second
 	}
@@ -427,7 +438,7 @@ func ResolveAIScalpingConfigFromEnv(base AIScalpingConfig) AIScalpingConfig {
 	cfg.DeterministicFallback = applyDeterministicFallbackConfigFromEnv(cfg.DeterministicFallback).Normalized()
 
 	zaplogrus.Infof(
-		"[AI-SCALPING] Runtime config: exchange=%s model=%s leverage=%d max_tokens=%d max_capital_pct=%.2f min_confidence=%.2f timeout=%s auto_execute=%t allow_spot_fallback=%t max_pairs=%d max_candidates=%d max_bid_ask_spread=%.4f orderbook_pairs=%d auto_expand_orderbooks=%t auto_expand_threshold=%d enforce_futures=%t symbol_cooldown=%s failure_budget=%d failure_window=%s structured_retries=%d loss_streak_budget=%d loss_cooldown=%s loss_window=%s pretrade_gate=%t min_expectancy_edge=%.4f min_expectancy_samples=%d regime_low=%.1f regime_high=%.1f fallback_max_spread=%.4f fallback_min_imbalance=%.2f fallback_floor=%.2f fallback_size_fraction=%.2f",
+		"[AI-SCALPING] Runtime config: exchange=%s model=%s leverage=%d max_tokens=%d max_capital_pct=%.2f min_confidence=%.2f timeout=%s auto_execute=%t allow_spot_fallback=%t max_pairs=%d max_candidates=%d max_bid_ask_spread=%.4f orderbook_pairs=%d auto_expand_orderbooks=%t auto_expand_threshold=%d enforce_futures=%t symbol_cooldown=%s failure_budget=%d failure_window=%s structured_retries=%d loss_streak_budget=%d loss_cooldown=%s loss_window=%s 		pretrade_gate=%t min_expectancy_edge=%.4f min_expectancy_samples=%d regime_low=%.1f regime_high=%.1f regime_chop_confidence=%.2f fallback_max_spread=%.4f fallback_min_imbalance=%.2f fallback_floor=%.2f fallback_size_fraction=%.2f",
 		cfg.Exchange,
 		cfg.Model,
 		cfg.Leverage,
@@ -456,6 +467,7 @@ func ResolveAIScalpingConfigFromEnv(base AIScalpingConfig) AIScalpingConfig {
 		cfg.MinExpectancyN,
 		cfg.RegimeLowBand,
 		cfg.RegimeHighBand,
+		cfg.RegimeChopConfidence,
 		cfg.DeterministicFallback.MaxBidAskSpread,
 		cfg.DeterministicFallback.MinImbalance,
 		cfg.DeterministicFallback.ConfidenceFloor,
@@ -566,6 +578,7 @@ type aiScalpingFileConfig struct {
 			MinExpectancyN       *int     `json:"min_expectancy_samples"`
 			RegimeHighBand       *float64 `json:"regime_high_band"`
 			RegimeLowBand        *float64 `json:"regime_low_band"`
+			RegimeChopConfidence *float64 `json:"regime_chop_confidence"`
 		} `json:"scalping"`
 	} `json:"ai"`
 }
@@ -684,6 +697,9 @@ func applyAIScalpingConfigFromFile(base AIScalpingConfig) AIScalpingConfig {
 	}
 	if fileConfig.AI.Scalping.RegimeLowBand != nil {
 		cfg.RegimeLowBand = clampFloat(*fileConfig.AI.Scalping.RegimeLowBand, 1, 45)
+	}
+	if fileConfig.AI.Scalping.RegimeChopConfidence != nil {
+		cfg.RegimeChopConfidence = clampFloat(*fileConfig.AI.Scalping.RegimeChopConfidence, 0, 1)
 	}
 
 	return cfg
@@ -2472,6 +2488,16 @@ func (s *AIScalpingService) classifyScalpingRegime(signal aiMarketSignal, action
 		lowBand = 15
 	}
 
+	// Chop regime confidence is configurable (NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE
+	// or config.json regime_chop_confidence) so operators can adjust how much
+	// confidence is allocated to the "chop" label in imbalance-thin markets.
+	// Default 0.65 preserves the prior hardcoded behavior. Clamp into (0, 1]
+	// to avoid zero-confidence floors when the field is mis-set.
+	chopConfidence := s.config.RegimeChopConfidence
+	if chopConfidence <= 0 || chopConfidence > 1 {
+		chopConfidence = 0.65
+	}
+
 	spreadThreshold := s.maxBidAskSpreadPct()
 	if signal.BidAskSpread > spreadThreshold {
 		return "illiquid", 0, fmt.Sprintf("pre-trade regime gate blocked %s: spread %.3f%% too wide", signal.Symbol, signal.BidAskSpread)
@@ -2498,7 +2524,7 @@ func (s *AIScalpingService) classifyScalpingRegime(signal aiMarketSignal, action
 		return "trend", 1, ""
 	}
 	if math.Abs(signal.OrderBookImbalance) < 0.10 {
-		return "chop", 0.65, ""
+		return "chop", chopConfidence, ""
 	}
 	return "neutral", 0.85, ""
 }

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -3432,7 +3432,12 @@ func (s *AIScalpingService) deterministicFallbackCandidate(
 
 	imbalance := math.Abs(signal.OrderBookImbalance)
 	blowoffReversal := scalpingBlowoffSellTrendConfirmed(signal)
-	if imbalance < effectiveMinImbalance && !blowoffReversal && !reversalBuy && !sellWindow {
+	// Ticker-only signals have OrderBookImbalance=0 (no orderbook fetched) but
+	// carry a ticker-derived BidAskSpread > 0. The imbalance gate is meant to
+	// filter empty orderbook data, not to reject valid ticker-only candidates;
+	// bypass it when we have a non-zero spread but no imbalance reading.
+	tickerOnlySignal := signal.OrderBookImbalance == 0 && signal.BidAskSpread > 0
+	if imbalance < effectiveMinImbalance && !blowoffReversal && !reversalBuy && !sellWindow && !tickerOnlySignal {
 		return nil, 0, false
 	}
 
@@ -3461,6 +3466,22 @@ func (s *AIScalpingService) deterministicFallbackCandidate(
 		momentumAligned = true
 		rangeAlignment = clampFloat(
 			(signal.RangePosition24h-scalpingSellWindowMinRangePct)/math.Max(100-scalpingSellWindowMinRangePct, 1),
+			0,
+			1,
+		)
+	case tickerOnlySignal && signal.RangePosition24h <= buyRangeMax:
+		action = "buy"
+		momentumAligned = momentumPct >= buyMomentumMin
+		rangeAlignment = clampFloat(
+			(buyRangeMax-signal.RangePosition24h)/math.Max(buyRangeMax, 1),
+			0,
+			1,
+		)
+	case tickerOnlySignal && signal.RangePosition24h >= sellRangeMin:
+		action = "sell"
+		momentumAligned = momentumPct <= sellMomentumMax
+		rangeAlignment = clampFloat(
+			(signal.RangePosition24h-sellRangeMin)/math.Max(100-sellRangeMin, 1),
 			0,
 			1,
 		)

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -3151,7 +3151,7 @@ func TestAIScalpingService_DeterministicFallbackCandidate_UsesConfigOverrides(t 
 func TestAIScalpingService_DeterministicFallbackCandidate_BypassesImbalanceGateForTickerOnly(t *testing.T) {
 	svc := &AIScalpingService{
 		config: AIScalpingConfig{
-			MaxBidAskSpreadPct:   0.22,
+			MaxBidAskSpreadPct:    0.22,
 			DeterministicFallback: DefaultDeterministicFallbackConfig(),
 		},
 	}

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -303,6 +303,35 @@ func TestResolveAIScalpingConfigFromEnv(t *testing.T) {
 	assert.Equal(t, 0.33, cfg.DeterministicFallback.SizeFraction)
 }
 
+// TestResolveAIScalpingConfigFromEnv_RejectsInvalidChopConfidence is a
+// regression guard for the env-resolver contract: invalid chop-confidence
+// values (≤0, >1, NaN) must NOT override the canonical default. The runtime
+// guard in classifyScalpingRegime is defense-in-depth; the resolver should
+// already filter these so the startup log and the runtime behavior agree.
+func TestResolveAIScalpingConfigFromEnv_RejectsInvalidChopConfidence(t *testing.T) {
+	t.Setenv("NEURATRADE_HOME", t.TempDir())
+	defaultConfidence := DefaultAIScalpingConfig().RegimeChopConfidence
+
+	tests := []struct {
+		name      string
+		envValue  string
+		wantValue float64
+	}{
+		{name: "zero rejected, default kept", envValue: "0", wantValue: defaultConfidence},
+		{name: "negative rejected, default kept", envValue: "-0.5", wantValue: defaultConfidence},
+		{name: "above one rejected, default kept", envValue: "1.5", wantValue: defaultConfidence},
+		{name: "NaN rejected, default kept", envValue: "NaN", wantValue: defaultConfidence},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE", tc.envValue)
+			cfg := ResolveAIScalpingConfigFromEnv(DefaultAIScalpingConfig())
+			assert.InDelta(t, tc.wantValue, cfg.RegimeChopConfidence, 1e-9)
+		})
+	}
+}
+
 func TestAIMarketSignal(t *testing.T) {
 	signal := aiMarketSignal{
 		Symbol:             "BTC/USDT",
@@ -931,6 +960,55 @@ func TestAIScalpingService_PreTradeGate_UsesVisibleSpreadThreshold(t *testing.T)
 			} else {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "spread")
+			}
+		})
+	}
+}
+
+func TestAIScalpingService_EvaluatePreTradeGate_RespectsRegimeChopConfidence(t *testing.T) {
+	// Coderabbit MAJOR on PR #462: RegimeChopConfidence must be applied
+	// end-to-end in evaluatePreTradeGate's chop-blocking branch, not just
+	// in classifyScalpingRegime. Lowering the knob should lower the
+	// confidence floor that blocks low-confidence trades in chop regimes.
+	// Without this, NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE would only
+	// affect the regime label, not the actual gating — making the env var
+	// a no-op for chop-heavy markets (the exact scenario it was introduced
+	// to address).
+	signal := aiMarketSignal{
+		Symbol:             "BTC/USDT",
+		Price:              100,
+		BidAskSpread:       0.05,
+		OrderBookImbalance: 0.05, // < 0.10 → chop regime
+		RangePosition24h:   50,
+	}
+	decision := &AITradingDecision{
+		Action:     "buy",
+		Symbol:     "BTC/USDT",
+		Confidence: 0.50, // below both 0.65 (default) and 0.40 (relaxed)
+	}
+
+	tests := []struct {
+		name     string
+		chopConf float64
+		allowed  bool
+	}{
+		{name: "default 0.65 blocks 0.50 confidence chop trade", chopConf: 0.65, allowed: false},
+		{name: "lowered 0.40 allows 0.50 confidence chop trade", chopConf: 0.40, allowed: true},
+		{name: "raised 0.80 still blocks 0.50 confidence chop trade", chopConf: 0.80, allowed: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &AIScalpingService{config: AIScalpingConfig{
+				RegimeChopConfidence: tt.chopConf,
+				MaxBidAskSpreadPct:   0.5,
+				PreTradeGate:         true,
+			}}
+			result := svc.evaluatePreTradeGate(context.Background(), decision, []aiMarketSignal{signal})
+			assert.Equal(t, "chop", result.Regime, "regime should be 'chop' for |imbalance|<0.10")
+			assert.Equal(t, tt.allowed, result.Allowed, "chop confidence %.2f should set allowed=%t for decision confidence 0.50", tt.chopConf, tt.allowed)
+			if !tt.allowed {
+				assert.Contains(t, result.Reason, "choppy")
 			}
 		})
 	}
@@ -2731,6 +2809,21 @@ func TestAIScalpingService_ClassifyScalpingRegime_ChopConfidenceFromConfig(t *te
 		{
 			name:     "out-of-range value clamped to default",
 			config:   AIScalpingConfig{RegimeChopConfidence: 1.5, MaxBidAskSpreadPct: 0.5},
+			wantConf: 0.65,
+		},
+		{
+			// NaN must not propagate as a regime confidence. The guard
+			// !(x > 0 && x <= 1) catches NaN because NaN comparisons return
+			// false; the more obvious x <= 0 || x > 1 would silently let
+			// NaN through. Regression guard for the env-resolver path where
+			// strconv.ParseFloat accepts the literal "NaN".
+			name:     "NaN value falls back to default",
+			config:   AIScalpingConfig{RegimeChopConfidence: math.NaN(), MaxBidAskSpreadPct: 0.5},
+			wantConf: 0.65,
+		},
+		{
+			name:     "negative value falls back to default",
+			config:   AIScalpingConfig{RegimeChopConfidence: -0.1, MaxBidAskSpreadPct: 0.5},
 			wantConf: 0.65,
 		},
 	}

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -181,8 +181,9 @@ func TestAIScalpingConfig_Default(t *testing.T) {
 	assert.Equal(t, 8, config.MinExpectancyN)
 	assert.Equal(t, 85.0, config.RegimeHighBand)
 	assert.Equal(t, 15.0, config.RegimeLowBand)
-	assert.Equal(t, 0.08, config.DeterministicFallback.MaxBidAskSpread)
-	assert.Equal(t, 0.35, config.DeterministicFallback.MinImbalance)
+	assert.Equal(t, 0.15, config.DeterministicFallback.MaxBidAskSpread)
+	assert.Equal(t, 0.10, config.DeterministicFallback.MinImbalance)
+	assert.Equal(t, 0.65, config.RegimeChopConfidence)
 	assert.Equal(t, 0.72, config.DeterministicFallback.ConfidenceFloor)
 	assert.Equal(t, 0.50, config.DeterministicFallback.SizeFraction)
 }
@@ -260,6 +261,7 @@ func TestResolveAIScalpingConfigFromEnv(t *testing.T) {
 	t.Setenv("NEURATRADE_SCALPING_MIN_EXPECTANCY_SAMPLES", "12")
 	t.Setenv("NEURATRADE_SCALPING_REGIME_HIGH_BAND", "88")
 	t.Setenv("NEURATRADE_SCALPING_REGIME_LOW_BAND", "12")
+	t.Setenv("NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE", "0.42")
 	t.Setenv("NEURATRADE_SCALPING_FALLBACK_MAX_BID_ASK_SPREAD", "0.04")
 	t.Setenv("NEURATRADE_SCALPING_FALLBACK_MIN_IMBALANCE", "0.42")
 	t.Setenv("NEURATRADE_SCALPING_FALLBACK_CONFIDENCE_FLOOR", "0.79")
@@ -293,6 +295,7 @@ func TestResolveAIScalpingConfigFromEnv(t *testing.T) {
 	assert.Equal(t, 12, cfg.MinExpectancyN)
 	assert.Equal(t, 88.0, cfg.RegimeHighBand)
 	assert.Equal(t, 12.0, cfg.RegimeLowBand)
+	assert.Equal(t, 0.42, cfg.RegimeChopConfidence)
 	assert.Equal(t, 0.04, cfg.DeterministicFallback.MaxBidAskSpread)
 	assert.Equal(t, 0.42, cfg.DeterministicFallback.MinImbalance)
 	assert.Equal(t, 0.79, cfg.DeterministicFallback.ConfidenceFloor)
@@ -2649,28 +2652,37 @@ func TestAIScalpingService_DeterministicFallbackCandidate_RejectsIneligibleSigna
 		},
 	}
 
+	// Each signal is engineered to hit one specific rejection path given the
+	// DefaultDeterministicFallbackConfig() knobs (MaxBidAskSpread=0.15,
+	// MinImbalance=0.10, BuyRangeMax=45, SellRangeMin=55). Loosening those
+	// defaults (PR-2) requires re-tuning these test vectors so the underlying
+	// rejection logic is still exercised rather than short-circuited.
 	tests := []aiMarketSignal{
 		{
+			// Path: spread gate — BidAskSpread=0.20 > effectiveMaxSpread=0.15.
 			Symbol:             "BTC/USDT",
 			Price:              100,
 			High24h:            104,
 			Low24h:             96,
 			Volume24h:          2500000,
-			BidAskSpread:       0.09,
+			BidAskSpread:       0.20,
 			OrderBookImbalance: 0.60,
 			RangePosition24h:   20,
 		},
 		{
+			// Path: imbalance gate — |OrderBookImbalance|=0.05 < effectiveMinImbalance=0.10.
 			Symbol:             "BTC/USDT",
 			Price:              100,
 			High24h:            104,
 			Low24h:             96,
 			Volume24h:          2500000,
 			BidAskSpread:       0.03,
-			OrderBookImbalance: 0.20,
+			OrderBookImbalance: 0.05,
 			RangePosition24h:   20,
 		},
 		{
+			// Path: range/direction mismatch — positive imbalance with
+			// RangePosition24h=90 (deep sell zone) matches no action branch.
 			Symbol:             "BTC/USDT",
 			Price:              100,
 			High24h:            104,
@@ -2685,6 +2697,52 @@ func TestAIScalpingService_DeterministicFallbackCandidate_RejectsIneligibleSigna
 	for _, signal := range tests {
 		_, _, ok := svc.deterministicFallbackCandidate(context.Background(), signal, TradingPortfolio{}, false)
 		assert.False(t, ok)
+	}
+}
+
+func TestAIScalpingService_ClassifyScalpingRegime_ChopConfidenceFromConfig(t *testing.T) {
+	// Imbalance < 0.10 should land in the chop branch, and the returned
+	// confidence must match s.config.RegimeChopConfidence. Verifies the new
+	// NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE wiring (PR-2) and the
+	// default fallback when the config is mis-set.
+	signal := aiMarketSignal{
+		Symbol:             "BTC/USDT",
+		Price:              100,
+		BidAskSpread:       0.05,
+		OrderBookImbalance: 0.05, // < 0.10 → chop branch
+		RangePosition24h:   50,
+	}
+
+	tests := []struct {
+		name     string
+		config   AIScalpingConfig
+		wantConf float64
+	}{
+		{
+			name:     "explicit 0.42 propagated through",
+			config:   AIScalpingConfig{RegimeChopConfidence: 0.42, MaxBidAskSpreadPct: 0.5},
+			wantConf: 0.42,
+		},
+		{
+			name:     "default 0.65 used when unset",
+			config:   AIScalpingConfig{RegimeChopConfidence: 0, MaxBidAskSpreadPct: 0.5},
+			wantConf: 0.65,
+		},
+		{
+			name:     "out-of-range value clamped to default",
+			config:   AIScalpingConfig{RegimeChopConfidence: 1.5, MaxBidAskSpreadPct: 0.5},
+			wantConf: 0.65,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &AIScalpingService{config: tt.config}
+			regime, conf, blockReason := svc.classifyScalpingRegime(signal, "buy")
+			assert.Equal(t, "chop", regime)
+			assert.InDelta(t, tt.wantConf, conf, 1e-9)
+			assert.Empty(t, blockReason)
+		})
 	}
 }
 

--- a/services/backend-api/internal/services/ai_scalping_test.go
+++ b/services/backend-api/internal/services/ai_scalping_test.go
@@ -3148,6 +3148,32 @@ func TestAIScalpingService_DeterministicFallbackCandidate_UsesConfigOverrides(t 
 	assert.Zero(t, confidence)
 }
 
+func TestAIScalpingService_DeterministicFallbackCandidate_BypassesImbalanceGateForTickerOnly(t *testing.T) {
+	svc := &AIScalpingService{
+		config: AIScalpingConfig{
+			MaxBidAskSpreadPct:   0.22,
+			DeterministicFallback: DefaultDeterministicFallbackConfig(),
+		},
+	}
+
+	signal := aiMarketSignal{
+		Symbol:             "BTC/USDT",
+		Price:              50000,
+		High24h:            51000,
+		Low24h:             49000,
+		Volume24h:          1000,
+		BidAskSpread:       0.04, // ticker-derived spread is small and within tolerance
+		OrderBookImbalance: 0,    // no orderbook data: ticker-only signal
+		RangePosition24h:   18,
+	}
+
+	decision, confidence, ok := svc.deterministicFallbackCandidate(context.Background(), signal, TradingPortfolio{}, true)
+	require.True(t, ok, "ticker-only signal with valid spread should bypass imbalance gate")
+	require.NotNil(t, decision)
+	assert.Equal(t, "buy", decision.Action)
+	assert.Greater(t, confidence, 0.0)
+}
+
 func TestAIScalpingService_DeterministicFallbackCandidate_AlignsWithPolicySpreadAndImbalanceFloor(t *testing.T) {
 	svc := &AIScalpingService{
 		config: AIScalpingConfig{

--- a/services/backend-api/internal/services/scalping_llm_decision_probe_test.go
+++ b/services/backend-api/internal/services/scalping_llm_decision_probe_test.go
@@ -580,11 +580,18 @@ func newScalpingLLMDecisionProbeTestService(client llm.Client) *AIScalpingServic
 				exchange:  "bitget",
 			},
 		},
+		// Orderbook with equal bid/ask amounts produces |OrderBookImbalance|=0,
+		// keeping the signal below the deterministic-fallback MinImbalance floor
+		// so signalsWithDecisionHints does not pre-populate a ConfidenceHint.
+		// This preserves the test scenario where the LLM's reasoning references
+		// an absent confidence_hint (PR-2 relaxed the default imbalance floor
+		// from 0.35 to 0.10; the prior 5-vs-4 split produced 0.111 which
+		// short-circuited the diagnostic chain under the new default).
 		orderBooks: map[string]*ccxt.OrderBookResponse{
 			"BTC/USDT": {
 				OrderBook: ccxt.OrderBook{
-					Bids: []ccxt.OrderBookEntry{{Price: decimal.NewFromFloat(99.99), Amount: decimal.NewFromInt(5)}},
-					Asks: []ccxt.OrderBookEntry{{Price: decimal.NewFromFloat(100.01), Amount: decimal.NewFromInt(4)}},
+					Bids: []ccxt.OrderBookEntry{{Price: decimal.NewFromFloat(99.99), Amount: decimal.NewFromInt(1)}},
+					Asks: []ccxt.OrderBookEntry{{Price: decimal.NewFromFloat(100.01), Amount: decimal.NewFromInt(1)}},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Relax 3 scalping gates that were blocking all candidates in the 2026-06-04 soak (0 closed trades, 1440/1536 missing_orderbook_signal, 94.66% chop regime), plus expose the hardcoded chop-regime confidence as a tunable env var.

## Problem

The latest soak observed 0 closed trades despite W0-B (PR-1) introducing a ticker bid/ask fallback. Root cause analysis traced the gap to three gates that were designed for full orderbook data:

1. **`DeterministicFallback.MinImbalance = 0.35`** (ai_scalping.go:147). With ticker-only data, `OrderBookImbalance` is always 0 (no orderbook = no volume asymmetry). 0 < 0.35 → reject.
2. **`DeterministicFallback.MaxBidAskSpread = 0.08`** (ai_scalping.go:146). Ticker-derived spreads typically run 0.10-0.30% (wider than orderbook snapshots). 0.10 > 0.08 → reject.
3. **Hardcoded 0.65 chop-regime confidence** (ai_scalping.go:2501). When 94.66% of the market was classified as chop, all candidates got 0.65 confidence. After weak-performance feedback tightened `EffectiveMinConfidence` to 0.70, all chop-regime candidates failed.

## Changes

- **DefaultDeterministicFallbackConfig** (ai_scalping.go:144-167):
  - `MaxBidAskSpread`: 0.08 → 0.15 (covers ticker-derived spread range)
  - `MinImbalance`: 0.35 → 0.10 (aligns with `scalpingNeutralImbalanceFloor`)
- **AIScalpingConfig**: new `RegimeChopConfidence` field
  - Default: 0.65 (preserves prior hardcoded behavior)
  - Env var: `NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE`
  - config.json: `ai.scalping.regime_chop_confidence`
  - Clamp to (0, 1] in `classifyScalpingRegime` to avoid zero floors when mis-set
  - Logged in startup config line for visibility
- **classifyScalpingRegime** (ai_scalping.go:2482-2529): replace hardcoded 0.65 with `s.config.RegimeChopConfidence`; add inline guard for mis-set values

## Test updates

- `TestAIScalpingConfig_Default`: assert new defaults (0.15, 0.10, 0.65)
- `TestResolveAIScalpingConfigFromEnv`: assert env var wiring (`NEURATRADE_SCALPING_REGIME_CHOP_CONFIDENCE`)
- `TestAIScalpingService_DeterministicFallbackCandidate_RejectsIneligibleSignals`: re-tune 3 test vectors so spread (0.20 > 0.15) and imbalance (0.05 < 0.10) still hit the new (relaxed) gates
- `TestAIScalpingService_ClassifyScalpingRegime_ChopConfidenceFromConfig`: NEW 3-case test (explicit 0.42 propagation, default 0.65 fallback when unset, out-of-range value clamping)
- `newScalpingLLMDecisionProbeTestService`: change orderbook amounts from 5/4 to 1/1 to produce |OrderBookImbalance|=0; the prior 5/4 split produced 0.111 which now passes the relaxed MinImbalance=0.10 default and short-circuits the diagnostic-chain test scenario in `TestRunScalpingLLMDecisionProbeWithServiceNormalizesContradictoryHoldSpreadReasoning`

## Pre-review

- services + autonomy + handlers + ai packages: all green (`go test`)
- gofmt clean, go vet clean, golangci-lint 0 issues
- All changes follow existing env-var-resolution pattern (parallel to `NEURATRADE_SCALPING_REGIME_HIGH_BAND` / `NEURATRADE_SCALPING_REGIME_LOW_BAND`)

## Dependencies

- **Blocked by PR-1 (#461)**: PR-2 inherits the W0-B ticker fallback from PR-1. Without the ticker fallback, the relaxed gates have no signal to act on (the spread would still be 0). Once PR-1 merges, PR-2 can merge.

## bd issues

- Closes NeuraTrade-ixev (P0 missing-orderbook signal quality fix) — but only partially; the runtime signal generation is now possible. Full resolution requires a soak rerun to confirm 0 → N closed trades.
- Touches NeuraTrade-vrsr (P1 scalping max_pairs) tangentially: the relaxed gates may surface new edge cases if max_pairs is raised above current 64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "regime chop confidence" knob that controls chop detection used in pre-trade evaluation; configurable via environment or config file with validation and sensible default.

* **Configuration Updates**
  * Adjusted default bid/ask spread and order-book imbalance thresholds for the deterministic fallback.

* **Behavior Changes**
  * Ticker-only signals (no order-book imbalance) now bypass the imbalance gate and are handled with explicit buy/sell branches.

* **Tests**
  * Expanded tests to cover the new chop-confidence behavior, validation, and ticker-only handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->