### PR TITLE
feat(backtest): AI vs deterministic mode + paper diversify + CLI subcommand

### DIFF
--- a/cmd/neuratrade-cli/backtest.go
+++ b/cmd/neuratrade-cli/backtest.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// backtestRequest mirrors the API request shape for /api/v1/scalping/backtest.
+// backtestRequest mirrors the API request shape for /api/v1/backtest/scalping/run.
 // Only the fields the CLI exposes are included here; the API treats omitted
 // fields as "use default".
 type backtestRequest struct {
@@ -33,10 +33,10 @@ type backtestResponse struct {
 }
 
 // RunScalpingBacktest posts the backtest request and returns the parsed
-// response. The endpoint is /api/v1/scalping/backtest; on success the API
+// response. The endpoint is /api/v1/backtest/scalping/run; on success the API
 // returns 200 with a JSON body matching backtestResponse.
 func (c *APIClient) RunScalpingBacktest(req backtestRequest) (*backtestResponse, error) {
-	respBody, err := c.makeRequest("POST", "/api/v1/scalping/backtest", req)
+	respBody, err := c.makeRequest("POST", "/api/v1/backtest/scalping/run", req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/neuratrade-cli/backtest.go
+++ b/cmd/neuratrade-cli/backtest.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+// backtestRequest mirrors the API request shape for /api/v1/scalping/backtest.
+// Only the fields the CLI exposes are included here; the API treats omitted
+// fields as "use default".
+type backtestRequest struct {
+	StartTime      string   `json:"start_time"`
+	EndTime        string   `json:"end_time"`
+	Symbols        []string `json:"symbols,omitempty"`
+	Exchange       string   `json:"exchange,omitempty"`
+	InitialCapital string   `json:"initial_capital,omitempty"`
+	Mode           string   `json:"mode,omitempty"`
+}
+
+// backtestResponse mirrors the API response. The CLI only reads the summary
+// fields it prints; the full signal/trade streams are ignored to keep the
+// command's stdout operator-friendly.
+type backtestResponse struct {
+	RunID       string                 `json:"run_id"`
+	Status      string                 `json:"status"`
+	Mode        string                 `json:"mode"`
+	Summary     map[string]interface{} `json:"summary"`
+	GateSummary []interface{}          `json:"gate_summary"`
+}
+
+// RunScalpingBacktest posts the backtest request and returns the parsed
+// response. The endpoint is /api/v1/scalping/backtest; on success the API
+// returns 200 with a JSON body matching backtestResponse.
+func (c *APIClient) RunScalpingBacktest(req backtestRequest) (*backtestResponse, error) {
+	respBody, err := c.makeRequest("POST", "/api/v1/scalping/backtest", req)
+	if err != nil {
+		return nil, err
+	}
+	var response backtestResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal backtest response: %w", err)
+	}
+	return &response, nil
+}
+
+// backtestRunAction is the urfave/cli/v2 Action for `neuratrade backtest run`.
+// It parses the date/symbol/mode flags, POSTs to the backtest endpoint via
+// the shared APIClient, and prints a compact summary. Exits non-zero on
+// validation or backend errors so the command composes in shell pipelines.
+func backtestRunAction(cCtx *cli.Context) error {
+	start := strings.TrimSpace(cCtx.String("start"))
+	end := strings.TrimSpace(cCtx.String("end"))
+	if start == "" || end == "" {
+		return fmt.Errorf("--start and --end are required (RFC3339, e.g. 2025-01-01T00:00:00Z)")
+	}
+	if _, err := time.Parse(time.RFC3339, start); err != nil {
+		return fmt.Errorf("invalid --start: %w", err)
+	}
+	if _, err := time.Parse(time.RFC3339, end); err != nil {
+		return fmt.Errorf("invalid --end: %w", err)
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(cCtx.String("mode")))
+	switch mode {
+	case "", "deterministic", "ai":
+		// ok
+	default:
+		return fmt.Errorf("invalid --mode %q (expected 'deterministic' or 'ai')", mode)
+	}
+
+	var symbols []string
+	if raw := strings.TrimSpace(cCtx.String("symbols")); raw != "" {
+		for _, s := range strings.Split(raw, ",") {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				symbols = append(symbols, s)
+			}
+		}
+	}
+
+	exchange := strings.TrimSpace(cCtx.String("exchange"))
+	initialCapital := strings.TrimSpace(cCtx.String("initial-capital"))
+	timeout := cCtx.Duration("timeout")
+
+	req := backtestRequest{
+		StartTime:      start,
+		EndTime:        end,
+		Symbols:        symbols,
+		Exchange:       exchange,
+		InitialCapital: initialCapital,
+		Mode:           mode,
+	}
+
+	client := NewAPIClient(getBaseURL(), getAPIKey())
+	if timeout > 0 {
+		client.HTTPClient.Timeout = timeout
+	}
+
+	resp, err := client.RunScalpingBacktest(req)
+	if err != nil {
+		return fmt.Errorf("backtest request failed: %w", err)
+	}
+
+	fmt.Printf("RunID: %s\n", resp.RunID)
+	fmt.Printf("Status: %s\n", resp.Status)
+	fmt.Printf("Mode: %s\n", resp.Mode)
+	if len(resp.Summary) == 0 {
+		fmt.Println("Summary: (none returned)")
+		return nil
+	}
+	fmt.Println("Summary:")
+	printSummaryField(resp.Summary, "total_signals")
+	printSummaryField(resp.Summary, "accepted_signals")
+	printSummaryField(resp.Summary, "rejected_signals")
+	printSummaryField(resp.Summary, "total_trades")
+	printSummaryField(resp.Summary, "winning_trades")
+	printSummaryField(resp.Summary, "losing_trades")
+	printSummaryField(resp.Summary, "win_rate")
+	printSummaryField(resp.Summary, "total_pnl")
+	printSummaryField(resp.Summary, "total_pnl_pct")
+	printSummaryField(resp.Summary, "max_drawdown_pct")
+	return nil
+}
+
+// printSummaryField prints a single key from the summary map. Nil values are
+// skipped so operators don't see noisy "key: <nil>" lines for fields the
+// backend didn't populate.
+func printSummaryField(summary map[string]interface{}, key string) {
+	if v, ok := summary[key]; ok && v != nil {
+		fmt.Printf("  %s: %v\n", key, v)
+	}
+}
+
+// backtestCommand builds the urfave/cli/v2 Command tree for the
+// `neuratrade backtest` subcommand. The subcommand is registered in main.go's
+// Commands slice alongside `gateway`, `prompt`, etc.
+func backtestCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "backtest",
+		Usage: "Run a scalping backtest against the backend",
+		Subcommands: []*cli.Command{
+			{
+				Name:   "run",
+				Usage:  "Run a scalping backtest with the given date range and mode",
+				Action: backtestRunAction,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "start",
+						Usage:    "backtest start time (RFC3339, e.g. 2025-01-01T00:00:00Z)",
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:     "end",
+						Usage:    "backtest end time (RFC3339, e.g. 2025-12-31T00:00:00Z)",
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:  "mode",
+						Usage: "decision pipeline: 'deterministic' (default) or 'ai'",
+						Value: "deterministic",
+					},
+					&cli.StringFlag{
+						Name:  "symbols",
+						Usage: "comma-separated symbol list (default: backend scalping universe)",
+					},
+					&cli.StringFlag{
+						Name:  "exchange",
+						Usage: "exchange name (default: backend default)",
+					},
+					&cli.StringFlag{
+						Name:  "initial-capital",
+						Usage: "initial capital as a decimal string (default: backend default)",
+					},
+					&cli.DurationFlag{
+						Name:  "timeout",
+						Usage: "HTTP request timeout (default: 30s)",
+						Value: defaultTimeout,
+					},
+				},
+			},
+		},
+	}
+}

--- a/cmd/neuratrade-cli/main.go
+++ b/cmd/neuratrade-cli/main.go
@@ -516,6 +516,26 @@ func main() {
 
 	// Add autonomous command separately to avoid struct literal error
 	app.Commands = append(app.Commands, &cli.Command{
+		Name:  "backtest",
+		Usage: "Run a scalping backtest against the backend",
+		Subcommands: []*cli.Command{
+			{
+				Name:   "run",
+				Usage:  "Run a scalping backtest with the given date range and mode",
+				Action: backtestRunAction,
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "start", Usage: "backtest start time (RFC3339)", Required: true},
+					&cli.StringFlag{Name: "end", Usage: "backtest end time (RFC3339)", Required: true},
+					&cli.StringFlag{Name: "mode", Usage: "decision pipeline: 'deterministic' (default) or 'ai'", Value: "deterministic"},
+					&cli.StringFlag{Name: "symbols", Usage: "comma-separated symbol list"},
+					&cli.StringFlag{Name: "exchange", Usage: "exchange name"},
+					&cli.StringFlag{Name: "initial-capital", Usage: "initial capital as a decimal string"},
+					&cli.DurationFlag{Name: "timeout", Usage: "HTTP request timeout (default: 30s)", Value: defaultTimeout},
+				},
+			},
+		},
+	})
+	app.Commands = append(app.Commands, &cli.Command{
 		Name:  "autonomous",
 		Usage: "Manage autonomous trading mode",
 		Subcommands: []*cli.Command{

--- a/services/backend-api/internal/api/handlers/scalping_backtest.go
+++ b/services/backend-api/internal/api/handlers/scalping_backtest.go
@@ -489,6 +489,8 @@ func parseToServiceConfig(req RunScalpingBacktestRequest) (services.ScalpingBack
 		candidate := strings.ToLower(strings.TrimSpace(*req.Mode))
 		if candidate == "" {
 			mode = "deterministic"
+		} else if candidate != "deterministic" && candidate != "ai" {
+			return services.ScalpingBacktestConfig{}, fmt.Errorf("invalid mode %q (expected 'deterministic' or 'ai')", *req.Mode)
 		} else {
 			mode = candidate
 		}

--- a/services/backend-api/internal/api/handlers/scalping_backtest.go
+++ b/services/backend-api/internal/api/handlers/scalping_backtest.go
@@ -101,6 +101,7 @@ type ScalpingBacktestSignal struct {
 	RejectionReason  string                 `json:"rejection_reason,omitempty"`
 	Signal           map[string]interface{} `json:"signal,omitempty"`
 	GateResults      map[string]interface{} `json:"gate_results,omitempty"`
+	Hints            *services.SignalHints  `json:"hints,omitempty"`
 }
 
 type ScalpingBacktestTrade struct {
@@ -560,6 +561,7 @@ func serviceResultToAPI(result *services.ScalpingBacktestResult) apiBacktestResu
 			FunnelStage:      s.FunnelStage,
 			RejectionReason:  s.RejectionReason,
 			GateResults:      boolMapToInterfaceMap(s.GateResults),
+			Hints:            s.Hints,
 			Signal: map[string]interface{}{
 				"symbol":    s.Symbol,
 				"timestamp": s.Timestamp.Format(time.RFC3339),

--- a/services/backend-api/internal/api/handlers/scalping_backtest.go
+++ b/services/backend-api/internal/api/handlers/scalping_backtest.go
@@ -40,11 +40,15 @@ type RunScalpingBacktestRequest struct {
 	SpreadMultiplier   *float64 `json:"spread_multiplier"`
 	FeeRate            *string  `json:"fee_rate"`
 	NoisePct           *float64 `json:"noise_pct"`
+	// Mode selects the decision pipeline: "deterministic" (default) or
+	// "ai". See services.ScalpingBacktestConfig.Mode for semantics.
+	Mode *string `json:"mode"`
 }
 
 type RunScalpingBacktestResponse struct {
 	RunID       string                   `json:"run_id"`
 	Status      string                   `json:"status"`
+	Mode        string                   `json:"mode"`
 	Summary     ScalpingBacktestSummary  `json:"summary"`
 	Signals     []ScalpingBacktestSignal `json:"signals,omitempty"`
 	Trades      []ScalpingBacktestTrade  `json:"trades,omitempty"`
@@ -70,6 +74,7 @@ type ScalpingBacktestConfig struct {
 	MinConfidence      float64   `json:"min_confidence"`
 	SpreadMultiplier   float64   `json:"spread_multiplier"`
 	FeeRate            string    `json:"fee_rate"`
+	Mode               string    `json:"mode"`
 }
 
 type ScalpingBacktestSummary struct {
@@ -187,6 +192,7 @@ func (h *ScalpingBacktestHandler) RunScalpingBacktest(c *gin.Context) {
 	c.JSON(http.StatusOK, RunScalpingBacktestResponse{
 		RunID:       runID,
 		Status:      "completed",
+		Mode:        apiResult.Mode,
 		Summary:     apiResult.Summary,
 		Signals:     apiResult.Signals,
 		Trades:      apiResult.Trades,
@@ -477,6 +483,16 @@ func parseToServiceConfig(req RunScalpingBacktestRequest) (services.ScalpingBack
 		return services.ScalpingBacktestConfig{}, fmt.Errorf("noise_pct must be between 0 and 1.0")
 	}
 
+	mode := "deterministic"
+	if req.Mode != nil {
+		candidate := strings.ToLower(strings.TrimSpace(*req.Mode))
+		if candidate == "" {
+			mode = "deterministic"
+		} else {
+			mode = candidate
+		}
+	}
+
 	return services.ScalpingBacktestConfig{
 		StartTime:          start.UTC(),
 		EndTime:            end.UTC(),
@@ -491,6 +507,7 @@ func parseToServiceConfig(req RunScalpingBacktestRequest) (services.ScalpingBack
 		NoisePct:           noisePct,
 		MaxCapitalPct:      services.DefaultScalpingBacktestMaxCapitalPct,
 		DefaultHoldPeriod:  services.DefaultScalpingBacktestHoldPeriod,
+		Mode:               mode,
 	}, nil
 }
 
@@ -505,10 +522,12 @@ func serviceConfigToAPI(cfg services.ScalpingBacktestConfig) ScalpingBacktestCon
 		MinConfidence:      cfg.MinConfidence,
 		SpreadMultiplier:   cfg.SpreadMultiplier,
 		FeeRate:            cfg.FeeRate.String(),
+		Mode:               cfg.Mode,
 	}
 }
 
 type apiBacktestResult struct {
+	Mode        string
 	Summary     ScalpingBacktestSummary
 	Signals     []ScalpingBacktestSignal
 	Trades      []ScalpingBacktestTrade
@@ -591,6 +610,7 @@ func serviceResultToAPI(result *services.ScalpingBacktestResult) apiBacktestResu
 	}
 
 	return apiBacktestResult{
+		Mode:        result.Mode,
 		Summary:     summary,
 		Signals:     signals,
 		Trades:      trades,

--- a/services/backend-api/internal/api/handlers/scalping_backtest_test.go
+++ b/services/backend-api/internal/api/handlers/scalping_backtest_test.go
@@ -96,3 +96,61 @@ func TestParseToServiceConfig_ReqSymbolsOverrideEnvVar(t *testing.T) {
 func floatPtr(v float64) *float64 {
 	return &v
 }
+
+func stringPtr(v string) *string {
+	return &v
+}
+
+func TestParseToServiceConfig_ModeDefaultIsDeterministic(t *testing.T) {
+	// PR-3: when the Mode field is omitted, the engine should run in
+	// "deterministic" mode (the prior behavior). This guards against the
+	// default accidentally flipping to "ai" on a refactor, which would
+	// change the trade count post-hoc.
+	req := RunScalpingBacktestRequest{
+		StartTime:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		EndTime:        time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		InitialCapital: "10000",
+	}
+	cfg, err := parseToServiceConfig(req)
+	require.NoError(t, err)
+	assert.Equal(t, "deterministic", cfg.Mode)
+}
+
+func TestParseToServiceConfig_ModeExplicitAIPassesThrough(t *testing.T) {
+	req := RunScalpingBacktestRequest{
+		StartTime:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		EndTime:        time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		InitialCapital: "10000",
+		Mode:           stringPtr("ai"),
+	}
+	cfg, err := parseToServiceConfig(req)
+	require.NoError(t, err)
+	assert.Equal(t, "ai", cfg.Mode)
+}
+
+func TestParseToServiceConfig_ModeExplicitDeterministicPassesThrough(t *testing.T) {
+	req := RunScalpingBacktestRequest{
+		StartTime:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		EndTime:        time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		InitialCapital: "10000",
+		Mode:           stringPtr("deterministic"),
+	}
+	cfg, err := parseToServiceConfig(req)
+	require.NoError(t, err)
+	assert.Equal(t, "deterministic", cfg.Mode)
+}
+
+func TestParseToServiceConfig_ModeEmptyStringDefaultsToDeterministic(t *testing.T) {
+	// PR-3: an explicit empty-string mode is treated as "unset" and falls
+	// back to the default. Avoids the silent zero-value ambiguity where
+	// "mode: ''" would otherwise mean either "unset" or "invalid empty".
+	req := RunScalpingBacktestRequest{
+		StartTime:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		EndTime:        time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		InitialCapital: "10000",
+		Mode:           stringPtr(""),
+	}
+	cfg, err := parseToServiceConfig(req)
+	require.NoError(t, err)
+	assert.Equal(t, "deterministic", cfg.Mode)
+}

--- a/services/backend-api/internal/api/handlers/scalping_backtest_test.go
+++ b/services/backend-api/internal/api/handlers/scalping_backtest_test.go
@@ -154,3 +154,15 @@ func TestParseToServiceConfig_ModeEmptyStringDefaultsToDeterministic(t *testing.
 	require.NoError(t, err)
 	assert.Equal(t, "deterministic", cfg.Mode)
 }
+
+func TestParseToServiceConfig_ModeInvalidRejected(t *testing.T) {
+	req := RunScalpingBacktestRequest{
+		StartTime:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		EndTime:        time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		InitialCapital: "10000",
+		Mode:           stringPtr("invalid-mode"),
+	}
+	_, err := parseToServiceConfig(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid mode")
+}

--- a/services/backend-api/internal/services/ai_scalping.go
+++ b/services/backend-api/internal/services/ai_scalping.go
@@ -712,6 +712,7 @@ type AITradingDecision struct {
 	ExecutionGate                   *appautonomy.ExecutionGateSnapshot  `json:"-"`
 	PreTradeRegime                  string                              `json:"-"`
 	PreTradeExpectancy              float64                             `json:"-"`
+	RangeAlignment                  float64                             `json:"-"`
 	PreTradeExpectancySampleSize    int                                 `json:"-"`
 	SignalQualityKnown              bool                                `json:"-"`
 	SignalPrice                     float64                             `json:"-"`

--- a/services/backend-api/internal/services/paper_trading_backfill_validation.go
+++ b/services/backend-api/internal/services/paper_trading_backfill_validation.go
@@ -70,8 +70,10 @@ var DefaultPaperTradingUniverse = []string{"BTC/USDT", "ETH/USDT", "SOL/USDT", "
 const envPaperSymbols = "NEURATRADE_PAPER_SYMBOLS"
 
 // paperSymbolsFromEnv returns the parsed symbol list from
-// NEURATRADE_PAPER_SYMBOLS, or nil if unset / empty. Each symbol is
-// trimmed and de-duplicated while preserving order.
+// NEURATRADE_PAPER_SYMBOLS, or nil if unset / empty. Each token is
+// trimmed, upper-cased, and de-duplicated while preserving order, so the
+// downstream universe is normalized regardless of operator input casing
+// (e.g. "btc/usdt, eth/usdt" → ["BTC/USDT", "ETH/USDT"]).
 func paperSymbolsFromEnv() []string {
 	raw := strings.TrimSpace(os.Getenv(envPaperSymbols))
 	if raw == "" {
@@ -81,7 +83,7 @@ func paperSymbolsFromEnv() []string {
 	seen := make(map[string]struct{}, len(parts))
 	symbols := make([]string, 0, len(parts))
 	for _, p := range parts {
-		s := strings.TrimSpace(p)
+		s := strings.ToUpper(strings.TrimSpace(p))
 		if s == "" {
 			continue
 		}

--- a/services/backend-api/internal/services/paper_trading_backfill_validation.go
+++ b/services/backend-api/internal/services/paper_trading_backfill_validation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -59,10 +60,50 @@ type PaperTradingStrategy struct {
 	HoldCandles    int             `json:"hold_candles"` // candles to hold position
 }
 
+// DefaultPaperTradingUniverse defines the canonical set of symbols for paper
+// trading strategies. These are the symbols used when NEURATRADE_PAPER_SYMBOLS
+// is not set.
+var DefaultPaperTradingUniverse = []string{"BTC/USDT", "ETH/USDT", "SOL/USDT", "BNB/USDT", "XRP/USDT"}
+
+// NEURATRADE_PAPER_SYMBOLS env var name for overriding the paper trading
+// universe at runtime.
+const envPaperSymbols = "NEURATRADE_PAPER_SYMBOLS"
+
+// paperSymbolsFromEnv returns the parsed symbol list from
+// NEURATRADE_PAPER_SYMBOLS, or nil if unset / empty. Each symbol is
+// trimmed and de-duplicated while preserving order.
+func paperSymbolsFromEnv() []string {
+	raw := strings.TrimSpace(os.Getenv(envPaperSymbols))
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	seen := make(map[string]struct{}, len(parts))
+	symbols := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		symbols = append(symbols, s)
+	}
+	if len(symbols) == 0 {
+		return nil
+	}
+	return symbols
+}
+
 // DefaultPaperTradingStrategies returns the default set of strategies used for
-// backfill validation.
+// backfill validation. When the NEURATRADE_PAPER_SYMBOLS env var is set, all
+// strategy symbol lists are replaced with the user-supplied symbols.
 func DefaultPaperTradingStrategies() []PaperTradingStrategy {
-	return []PaperTradingStrategy{
+	envSymbols := paperSymbolsFromEnv()
+
+	strategies := []PaperTradingStrategy{
 		{
 			ID:             "scalping",
 			Name:           "Scalping",
@@ -84,7 +125,7 @@ func DefaultPaperTradingStrategies() []PaperTradingStrategy {
 		{
 			ID:             "swing_trading",
 			Name:           "Swing Trading",
-			Symbols:        []string{"BTC/USDT", "ETH/USDT", "BNB/USDT"},
+			Symbols:        []string{"BTC/USDT", "ETH/USDT", "SOL/USDT", "BNB/USDT", "XRP/USDT"},
 			Timeframe:      "4h",
 			MaxPositionPct: decimal.NewFromFloat(0.15), // 15%
 			MinConfidence:  0.55,
@@ -100,6 +141,17 @@ func DefaultPaperTradingStrategies() []PaperTradingStrategy {
 			HoldCandles:    1, // 1h on 1h
 		},
 	}
+
+	// When the env var is set, apply its symbols to every strategy so the
+	// full universe participates regardless of strategy-level defaults.
+	if len(envSymbols) > 0 {
+		for i := range strategies {
+			strategies[i].Symbols = make([]string, len(envSymbols))
+			copy(strategies[i].Symbols, envSymbols)
+		}
+	}
+
+	return strategies
 }
 
 // ---------------------------------------------------------------------------

--- a/services/backend-api/internal/services/paper_trading_backfill_validation_test.go
+++ b/services/backend-api/internal/services/paper_trading_backfill_validation_test.go
@@ -606,6 +606,11 @@ func TestPaperSymbolsFromEnv(t *testing.T) {
 		assert.Equal(t, "BTC/USDT", result[1])
 		assert.Equal(t, "ETH/USDT", result[2])
 	})
+
+	t.Run("mixed_case_normalized", func(t *testing.T) {
+		t.Setenv(envPaperSymbols, "btc/usdt, Eth/USDT, sol/usdt")
+		assert.Equal(t, []string{"BTC/USDT", "ETH/USDT", "SOL/USDT"}, paperSymbolsFromEnv())
+	})
 }
 
 func TestDefaultPaperTradingBackfillConfig(t *testing.T) {

--- a/services/backend-api/internal/services/paper_trading_backfill_validation_test.go
+++ b/services/backend-api/internal/services/paper_trading_backfill_validation_test.go
@@ -534,8 +534,10 @@ func TestDefaultPaperTradingStrategies(t *testing.T) {
 	assert.Len(t, strategies, 4)
 
 	strategyIDs := make(map[string]bool)
+	symbolSets := make(map[string][]string)
 	for _, s := range strategies {
 		strategyIDs[s.ID] = true
+		symbolSets[s.ID] = s.Symbols
 		assert.NotEmpty(t, s.Name)
 		assert.NotEmpty(t, s.Symbols)
 		assert.NotEmpty(t, s.Timeframe)
@@ -547,6 +549,63 @@ func TestDefaultPaperTradingStrategies(t *testing.T) {
 	assert.True(t, strategyIDs["daily_trading"])
 	assert.True(t, strategyIDs["swing_trading"])
 	assert.True(t, strategyIDs["arbitrage"])
+
+	// swing_trading must cover all 5 paper trading symbols (BTC, ETH, SOL, BNB, XRP).
+	swingSymbols := symbolSets["swing_trading"]
+	assert.Contains(t, swingSymbols, "BTC/USDT")
+	assert.Contains(t, swingSymbols, "ETH/USDT")
+	assert.Contains(t, swingSymbols, "SOL/USDT")
+	assert.Contains(t, swingSymbols, "BNB/USDT")
+	assert.Contains(t, swingSymbols, "XRP/USDT")
+	assert.Len(t, swingSymbols, 5)
+}
+
+func TestDefaultPaperTradingStrategies_EnvOverride(t *testing.T) {
+	t.Setenv(envPaperSymbols, "BTC/USDT,SOL/USDT")
+	t.Cleanup(func() { t.Setenv(envPaperSymbols, "") })
+
+	strategies := DefaultPaperTradingStrategies()
+	assert.Len(t, strategies, 4)
+
+	for _, s := range strategies {
+		assert.Equal(t, []string{"BTC/USDT", "SOL/USDT"}, s.Symbols,
+			"strategy %q should use env var symbols", s.ID)
+	}
+}
+
+func TestPaperSymbolsFromEnv(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv(envPaperSymbols, "")
+		assert.Nil(t, paperSymbolsFromEnv())
+	})
+
+	t.Run("single", func(t *testing.T) {
+		t.Setenv(envPaperSymbols, "BTC/USDT")
+		assert.Equal(t, []string{"BTC/USDT"}, paperSymbolsFromEnv())
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		t.Setenv(envPaperSymbols, "BTC/USDT,ETH/USDT,SOL/USDT")
+		assert.Equal(t, []string{"BTC/USDT", "ETH/USDT", "SOL/USDT"}, paperSymbolsFromEnv())
+	})
+
+	t.Run("dedup", func(t *testing.T) {
+		t.Setenv(envPaperSymbols, "BTC/USDT,BTC/USDT,ETH/USDT")
+		assert.Equal(t, []string{"BTC/USDT", "ETH/USDT"}, paperSymbolsFromEnv())
+	})
+
+	t.Run("whitespace", func(t *testing.T) {
+		t.Setenv(envPaperSymbols, " BTC/USDT , ETH/USDT ")
+		assert.Equal(t, []string{"BTC/USDT", "ETH/USDT"}, paperSymbolsFromEnv())
+	})
+
+	t.Run("order_preserved", func(t *testing.T) {
+		t.Setenv(envPaperSymbols, "XRP/USDT,BTC/USDT,ETH/USDT")
+		result := paperSymbolsFromEnv()
+		assert.Equal(t, "XRP/USDT", result[0])
+		assert.Equal(t, "BTC/USDT", result[1])
+		assert.Equal(t, "ETH/USDT", result[2])
+	})
 }
 
 func TestDefaultPaperTradingBackfillConfig(t *testing.T) {

--- a/services/backend-api/internal/services/scalping_backtest.go
+++ b/services/backend-api/internal/services/scalping_backtest.go
@@ -69,6 +69,14 @@ type ScalpingBacktestConfig struct {
 	DeterministicFallback DeterministicFallbackConfig
 	RegimeHighBand        float64
 	RegimeLowBand         float64
+	// Mode selects the decision pipeline used during the backtest. The
+	// default "deterministic" runs buildDecisionFromSignal alone. The "ai"
+	// mode additionally computes SuggestedAction/ConfidenceHint/CandidateScore
+	// hints (mirroring AIScalpingService.signalsWithDecisionHints) and
+	// records them in ScalpingBacktestSignal.Hints. No live LLM is called —
+	// backtests are offline replays, so the AI mode is a "shadow" that
+	// records what hints the AI path would have consumed.
+	Mode string
 }
 
 type ScalpingBacktestResult struct {
@@ -76,6 +84,7 @@ type ScalpingBacktestResult struct {
 	Config      ScalpingBacktestConfig
 	StartTime   time.Time
 	EndTime     time.Time
+	Mode        string
 	Summary     ScalpingBacktestSummary
 	Signals     []ScalpingBacktestSignal
 	Trades      []ScalpingBacktestTrade
@@ -117,6 +126,23 @@ type ScalpingBacktestSignal struct {
 	FunnelStage      string
 	RejectionReason  string
 	GateResults      map[string]bool
+	// Hints is populated only when the backtest ran in Mode="ai". It captures
+	// the SuggestedAction/ConfidenceHint/CandidateScore the AI scalping path
+	// would have consumed for this signal, so operators can post-hoc
+	// compare deterministic decisions against the hints the LLM would have
+	// used. Nil in Mode="deterministic" runs.
+	Hints *SignalHints
+}
+
+// SignalHints is the sidecar metadata the AI scalping path consumes per
+// signal. Mirrors the fields set by AIScalpingService.signalsWithDecisionHints
+// (SuggestedAction/ConfidenceHint/CandidateScore). Recorded in backtest
+// results so operators can compare the deterministic decision against the
+// hints without re-running the offline replay against a live LLM.
+type SignalHints struct {
+	SuggestedAction string  `json:"suggested_action"`
+	ConfidenceHint  float64 `json:"confidence_hint"`
+	CandidateScore  float64 `json:"candidate_score"`
 }
 
 type ScalpingBacktestTrade struct {
@@ -191,6 +217,9 @@ type SignalEvaluation struct {
 	RejectionReason string
 	GateResults     map[string]GateResult
 	Allowed         bool
+	// Hints is the AI-path sidecar (SuggestedAction/ConfidenceHint/CandidateScore)
+	// populated only when the backtest ran in Mode="ai". Nil in Mode="deterministic".
+	Hints *SignalHints
 }
 
 type SimulatedPosition struct {
@@ -345,6 +374,7 @@ func (e *ScalpingBacktestEngine) RunSignals(ctx context.Context, historicalSigna
 			FunnelStage:      evaluation.FunnelStage,
 			RejectionReason:  evaluation.RejectionReason,
 			GateResults:      toGateBoolMap(evaluation.GateResults),
+			Hints:            evaluation.Hints,
 		}
 		e.signalHistory = append(e.signalHistory, recorded)
 
@@ -374,6 +404,7 @@ func (e *ScalpingBacktestEngine) RunSignals(ctx context.Context, historicalSigna
 	result := &ScalpingBacktestResult{
 		RunID:       runID,
 		Config:      e.config,
+		Mode:        e.config.Mode,
 		StartTime:   e.config.StartTime,
 		EndTime:     e.config.EndTime,
 		Summary:     e.calculateSummary(),
@@ -492,6 +523,14 @@ func (e *ScalpingBacktestEngine) evaluateSignal(ctx context.Context, signal Hist
 		eval.FunnelStage = "deterministic_hold"
 		eval.RejectionReason = "no_directional_edge"
 		return eval, nil
+	}
+
+	// Mode="ai" records the hints the AI scalping path would have consumed
+	// for this signal. No live LLM is invoked (backtests are offline
+	// replays); hints are computed deterministically from the same
+	// DeterministicFallback config the AI service uses.
+	if e.config.Mode == "ai" {
+		eval.Hints = e.computeSignalHints(signal.Signal, decision)
 	}
 
 	eval.Decision = decision
@@ -907,6 +946,9 @@ func (e *ScalpingBacktestEngine) calculateSummary() ScalpingBacktestSummary {
 }
 
 func (e *ScalpingBacktestEngine) validateConfig() error {
+	if e.config.Mode != "" && e.config.Mode != "deterministic" && e.config.Mode != "ai" {
+		return fmt.Errorf("invalid mode %q (expected 'deterministic' or 'ai')", e.config.Mode)
+	}
 	if e.config.StartTime.IsZero() || e.config.EndTime.IsZero() {
 		return fmt.Errorf("start_time and end_time are required")
 	}
@@ -948,11 +990,57 @@ func normalizeScalpingBacktestConfig(config ScalpingBacktestConfig) ScalpingBack
 	if config.SpreadMultiplier <= 0 {
 		config.SpreadMultiplier = backtestSpreadMultiplier
 	}
+	if config.Mode == "" {
+		config.Mode = "deterministic"
+	}
 	config.DeterministicFallback = config.DeterministicFallback.Normalized()
 	if len(config.Symbols) == 0 {
 		config.Symbols = defaultScalpingBacktestUniverse()
 	}
 	return config
+}
+
+// computeSignalHints derives the AI-path sidecar metadata (SuggestedAction,
+// ConfidenceHint, CandidateScore) from a deterministic decision. Mirrors the
+// field set produced by AIScalpingService.signalsWithDecisionHints so a
+// backtest result recorded with Mode="ai" can be diffed against what the
+// live AI scalping path would have consumed. Returns nil for non-actionable
+// decisions (hold / nil). Note: AIScalpingService also runs
+// scalpingBuySignalRejectionReason for buy decisions, but that check lives
+// on the AI service and is not replicated here — by the time buildDecisionFromSignal
+// returns a "buy" the spread/momentum/range gates are already applied.
+func (e *ScalpingBacktestEngine) computeSignalHints(signal MarketSignal, decision *AITradingDecision) *SignalHints {
+	if decision == nil {
+		return nil
+	}
+	action := strings.ToLower(strings.TrimSpace(decision.Action))
+	if action != "buy" && action != "sell" {
+		return nil
+	}
+	fallback := e.config.DeterministicFallback.Normalized()
+
+	effectiveMaxSpread := fallback.MaxBidAskSpread
+	if e.config.MaxBidAskSpreadPct > 0 {
+		effectiveMaxSpread = math.Max(effectiveMaxSpread, e.config.MaxBidAskSpreadPct)
+	}
+	liquidityScore := clampFloat(1-(signal.BidAskSpread/effectiveMaxSpread), 0, 1)
+	volumeBasis := math.Max(signal.Volume24h, 0)
+	volumeScore := clampFloat(math.Log10(volumeBasis+1)/fallback.VolumeLogScale, 0, 1)
+	// Range alignment is a coarse approximation here; buildDecisionFromSignal
+	// computes an exact per-branch value but it lives in the deterministic
+	// helper. 0.0 is the safe lower bound that keeps the score non-negative
+	// and doesn't bias operators toward misleading high-confidence reads.
+	rangeAlignment := 0.0
+	score := math.Abs(signal.OrderBookImbalance)*fallback.ImbalanceWeight +
+		liquidityScore*fallback.LiquidityWeight +
+		rangeAlignment*fallback.RangeWeight +
+		volumeScore*fallback.VolumeWeight
+
+	return &SignalHints{
+		SuggestedAction: action,
+		ConfidenceHint:  decision.Confidence,
+		CandidateScore:  score,
+	}
 }
 
 func (e *ScalpingBacktestEngine) buildDecisionFromSignal(ctx context.Context, signal MarketSignal) *AITradingDecision {

--- a/services/backend-api/internal/services/scalping_backtest.go
+++ b/services/backend-api/internal/services/scalping_backtest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	randv2 "math/rand/v2"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -35,10 +36,31 @@ const (
 	backtestSpreadMultiplier = DefaultScalpingBacktestSpreadMultiplier
 )
 
+// envBacktestSymbols is the operator override for the scalping backtest
+// default universe. Set this (comma-separated) to run a backtest over a
+// custom symbol set without touching NEURATRADE_PAPER_SYMBOLS, which is
+// for paper-trading strategies and intentionally separate.
+const envBacktestSymbols = "NEURATRADE_BACKTEST_SYMBOLS"
+
 func defaultScalpingBacktestUniverse() []string {
-	// Allow env var to override the default universe.
-	if symbols := paperSymbolsFromEnv(); len(symbols) > 0 {
-		return symbols
+	if raw := os.Getenv(envBacktestSymbols); raw != "" {
+		parts := strings.Split(raw, ",")
+		seen := make(map[string]struct{}, len(parts))
+		symbols := make([]string, 0, len(parts))
+		for _, p := range parts {
+			s := strings.ToUpper(strings.TrimSpace(p))
+			if s == "" {
+				continue
+			}
+			if _, ok := seen[s]; ok {
+				continue
+			}
+			seen[s] = struct{}{}
+			symbols = append(symbols, s)
+		}
+		if len(symbols) > 0 {
+			return symbols
+		}
 	}
 	return []string{"BTC/USDT", "ETH/USDT", "SOL/USDT", "BNB/USDT", "XRP/USDT"}
 }
@@ -528,11 +550,10 @@ func (e *ScalpingBacktestEngine) evaluateSignal(ctx context.Context, signal Hist
 	// Mode="ai" records the hints the AI scalping path would have consumed
 	// for this signal. No live LLM is invoked (backtests are offline
 	// replays); hints are computed deterministically from the same
-	// DeterministicFallback config the AI service uses.
-	if e.config.Mode == "ai" {
-		eval.Hints = e.computeSignalHints(signal.Signal, decision)
-	}
-
+	// DeterministicFallback config the AI service uses. Hints are only
+	// persisted when the candidate survives the live gate cascade — the
+	// AI hint path's signalsWithDecisionHints also skips rejected
+	// candidates, so a rejected backtest candidate must not carry a hint.
 	eval.Decision = decision
 	eval.GateResults = e.evaluateGates(signal.Signal, decision)
 	sortedGates := make([]string, 0, len(eval.GateResults))
@@ -550,6 +571,9 @@ func (e *ScalpingBacktestEngine) evaluateSignal(ctx context.Context, signal Hist
 	}
 
 	eval.Allowed = eval.RejectionReason == ""
+	if eval.Allowed && e.config.Mode == "ai" {
+		eval.Hints = e.computeSignalHints(signal.Signal, decision)
+	}
 	if eval.Allowed {
 		eval.FunnelStage = "eligible"
 	}
@@ -1005,10 +1029,9 @@ func normalizeScalpingBacktestConfig(config ScalpingBacktestConfig) ScalpingBack
 // field set produced by AIScalpingService.signalsWithDecisionHints so a
 // backtest result recorded with Mode="ai" can be diffed against what the
 // live AI scalping path would have consumed. Returns nil for non-actionable
-// decisions (hold / nil). Note: AIScalpingService also runs
-// scalpingBuySignalRejectionReason for buy decisions, but that check lives
-// on the AI service and is not replicated here — by the time buildDecisionFromSignal
-// returns a "buy" the spread/momentum/range gates are already applied.
+// decisions (hold / nil) and for buy decisions that the live AI path would
+// reject via scalpingBuySignalRejectionReason (momentum below buy floor,
+// fee-fragile spread, or range position above the buy ceiling).
 func (e *ScalpingBacktestEngine) computeSignalHints(signal MarketSignal, decision *AITradingDecision) *SignalHints {
 	if decision == nil {
 		return nil
@@ -1017,12 +1040,16 @@ func (e *ScalpingBacktestEngine) computeSignalHints(signal MarketSignal, decisio
 	if action != "buy" && action != "sell" {
 		return nil
 	}
+	if action == "buy" && scalpingBacktestBuyRejectionReason(signal) != "" {
+		return nil
+	}
 	fallback := e.config.DeterministicFallback.Normalized()
 
 	effectiveMaxSpread := fallback.MaxBidAskSpread
 	if e.config.MaxBidAskSpreadPct > 0 {
 		effectiveMaxSpread = math.Max(effectiveMaxSpread, e.config.MaxBidAskSpreadPct)
 	}
+	effectiveMaxSpread = math.Max(effectiveMaxSpread, 0.0001)
 	liquidityScore := clampFloat(1-(signal.BidAskSpread/effectiveMaxSpread), 0, 1)
 	volumeBasis := math.Max(signal.Volume24h, 0)
 	volumeScore := clampFloat(math.Log10(volumeBasis+1)/fallback.VolumeLogScale, 0, 1)
@@ -1040,6 +1067,37 @@ func (e *ScalpingBacktestEngine) computeSignalHints(signal MarketSignal, decisio
 		SuggestedAction: action,
 		ConfidenceHint:  decision.Confidence,
 		CandidateScore:  score,
+	}
+}
+
+// scalpingBacktestBuyRejectionReason mirrors AIScalpingService.scalpingBuySignalRejectionReason
+// for the backtest engine: returns a non-empty reason when a buy decision
+// would be suppressed by the live AI hint path's momentum/spread/range gates
+// that buildDecisionFromSignal does not enforce when RequireRecentMomentum=false.
+// When RequireRecentMomentum=true, buildDecisionFromSignal already applies
+// these gates itself and returns nil before reaching computeSignalHints.
+func scalpingBacktestBuyRejectionReason(signal MarketSignal) string {
+	if scalpingReversalBuyCandidate(signal) {
+		return ""
+	}
+	buyMomentumMin := scalpingRecentBuyMinTrendPct
+	if !signal.RecentChangeKnown {
+		if signal.RangePosition24h > scalpingNoRecentBuyMaxRangePct {
+			return fmt.Sprintf("buy hint rejected without recent momentum confirmation above deep-low range ceiling on %s (range_pos_24h=%.1f%%, required<=%.1f%%)", signal.Symbol, signal.RangePosition24h, scalpingNoRecentBuyMaxRangePct)
+		}
+		return ""
+	}
+	switch {
+	case signal.RecentPriceChange < buyMomentumMin:
+		return fmt.Sprintf("buy hint rejected without recent momentum confirmation on %s (recent_price_change=%.4f%%, required>=%.4f%%)", signal.Symbol, signal.RecentPriceChange, buyMomentumMin)
+	case signal.BidAskSpread > scalpingRecentBuyMaxSpreadPct:
+		return fmt.Sprintf("buy hint rejected with fee-fragile spread on %s (spread=%.4f%%, required<=%.4f%%)", signal.Symbol, signal.BidAskSpread, scalpingRecentBuyMaxSpreadPct)
+	case signal.PriceChange24h < scalpingRecentBuyMinTrendPct:
+		return fmt.Sprintf("buy hint rejected without positive 24h trend on %s (price_change_24h=%.4f%%, required>=%.4f%%)", signal.Symbol, signal.PriceChange24h, scalpingRecentBuyMinTrendPct)
+	case signal.RangePosition24h > scalpingRecentBuyMaxRangePct:
+		return fmt.Sprintf("buy hint rejected above recent-buy range ceiling on %s (range_pos_24h=%.1f%%, required<=%.1f%%)", signal.Symbol, signal.RangePosition24h, scalpingRecentBuyMaxRangePct)
+	default:
+		return ""
 	}
 }
 

--- a/services/backend-api/internal/services/scalping_backtest.go
+++ b/services/backend-api/internal/services/scalping_backtest.go
@@ -1026,19 +1026,14 @@ func (e *ScalpingBacktestEngine) computeSignalHints(signal MarketSignal, decisio
 	liquidityScore := clampFloat(1-(signal.BidAskSpread/effectiveMaxSpread), 0, 1)
 	volumeBasis := math.Max(signal.Volume24h, 0)
 	volumeScore := clampFloat(math.Log10(volumeBasis+1)/fallback.VolumeLogScale, 0, 1)
-	// Mirrors the buy/sell branches of buildDecisionFromSignal so the AI-mode
-	// score in the backtest reflects the same range-alignment logic the live
-	// deterministic path would have applied for this action.
-	var rangeAlignment float64
-	switch action {
-	case "buy":
-		rangeAlignment = clampFloat((fallback.BuyRangeMax-signal.RangePosition24h)/math.Max(fallback.BuyRangeMax, 1), 0, 1)
-	case "sell":
-		rangeAlignment = clampFloat((signal.RangePosition24h-fallback.SellRangeMin)/math.Max(100-fallback.SellRangeMin, 1), 0, 1)
-	}
+	// Reuse the range-alignment value computed by buildDecisionFromSignal so
+	// the AI-mode score reflects the exact same per-branch logic the
+	// deterministic path applied for this action (reversal, sell-window,
+	// proximity-adjusted, blowoff, and dual-proximity variants are all
+	// captured by reading decision.RangeAlignment instead of re-deriving).
 	score := math.Abs(signal.OrderBookImbalance)*fallback.ImbalanceWeight +
 		liquidityScore*fallback.LiquidityWeight +
-		rangeAlignment*fallback.RangeWeight +
+		decision.RangeAlignment*fallback.RangeWeight +
 		volumeScore*fallback.VolumeWeight
 
 	return &SignalHints{
@@ -1194,6 +1189,7 @@ func (e *ScalpingBacktestEngine) buildDecisionFromSignal(ctx context.Context, si
 		ConfidenceKnown: true,
 		StopLoss:        &stopLoss,
 		TakeProfit:      &takeProfit,
+		RangeAlignment:  rangeAlignment,
 	}
 }
 

--- a/services/backend-api/internal/services/scalping_backtest.go
+++ b/services/backend-api/internal/services/scalping_backtest.go
@@ -1026,11 +1026,16 @@ func (e *ScalpingBacktestEngine) computeSignalHints(signal MarketSignal, decisio
 	liquidityScore := clampFloat(1-(signal.BidAskSpread/effectiveMaxSpread), 0, 1)
 	volumeBasis := math.Max(signal.Volume24h, 0)
 	volumeScore := clampFloat(math.Log10(volumeBasis+1)/fallback.VolumeLogScale, 0, 1)
-	// Range alignment is a coarse approximation here; buildDecisionFromSignal
-	// computes an exact per-branch value but it lives in the deterministic
-	// helper. 0.0 is the safe lower bound that keeps the score non-negative
-	// and doesn't bias operators toward misleading high-confidence reads.
-	rangeAlignment := 0.0
+	// Mirrors the buy/sell branches of buildDecisionFromSignal so the AI-mode
+	// score in the backtest reflects the same range-alignment logic the live
+	// deterministic path would have applied for this action.
+	var rangeAlignment float64
+	switch action {
+	case "buy":
+		rangeAlignment = clampFloat((fallback.BuyRangeMax-signal.RangePosition24h)/math.Max(fallback.BuyRangeMax, 1), 0, 1)
+	case "sell":
+		rangeAlignment = clampFloat((signal.RangePosition24h-fallback.SellRangeMin)/math.Max(100-fallback.SellRangeMin, 1), 0, 1)
+	}
 	score := math.Abs(signal.OrderBookImbalance)*fallback.ImbalanceWeight +
 		liquidityScore*fallback.LiquidityWeight +
 		rangeAlignment*fallback.RangeWeight +

--- a/services/backend-api/internal/services/scalping_backtest.go
+++ b/services/backend-api/internal/services/scalping_backtest.go
@@ -36,6 +36,10 @@ const (
 )
 
 func defaultScalpingBacktestUniverse() []string {
+	// Allow env var to override the default universe.
+	if symbols := paperSymbolsFromEnv(); len(symbols) > 0 {
+		return symbols
+	}
 	return []string{"BTC/USDT", "ETH/USDT", "SOL/USDT", "BNB/USDT", "XRP/USDT"}
 }
 

--- a/services/backend-api/internal/services/scalping_backtest_test.go
+++ b/services/backend-api/internal/services/scalping_backtest_test.go
@@ -270,6 +270,10 @@ func TestScalpingBacktestEngine_ComputeSignalHints(t *testing.T) {
 		// decision.RangeAlignment verbatim, not re-derive via the primary
 		// formula (which was the prior bug that produced wrong scores for
 		// signals entering through these branches).
+		// RangePosition24h=96 lands inside the blowoff band [95,98], yielding
+		// a non-zero alignment (1/3). Any prior value (e.g. 80) clamped to 0
+		// and made the test unable to distinguish "uses decision.RangeAlignment"
+		// from "ignores it and hardcodes 0".
 		fallback := engine.config.DeterministicFallback.Normalized()
 		signal := MarketSignal{
 			Symbol:             "BTC/USDT",
@@ -277,7 +281,7 @@ func TestScalpingBacktestEngine_ComputeSignalHints(t *testing.T) {
 			Volume24h:          1_000_000,
 			BidAskSpread:       0.05,
 			OrderBookImbalance: -0.40,
-			RangePosition24h:   80,
+			RangePosition24h:   96,
 		}
 		customAlignment := clampFloat(
 			(signal.RangePosition24h-scalpingBlowoffSellRangeMin)/

--- a/services/backend-api/internal/services/scalping_backtest_test.go
+++ b/services/backend-api/internal/services/scalping_backtest_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDefaultScalpingBacktestUniverse_EnvVarOverride(t *testing.T) {
+	t.Run("unset_returns_canonical_defaults", func(t *testing.T) {
+		t.Setenv(envBacktestSymbols, "")
+		assert.Equal(t, []string{"BTC/USDT", "ETH/USDT", "SOL/USDT", "BNB/USDT", "XRP/USDT"}, defaultScalpingBacktestUniverse())
+	})
+
+	t.Run("env_var_overrides_with_normalization", func(t *testing.T) {
+		t.Setenv(envBacktestSymbols, "doge/usdt, PEPE/USDT , doge/usdt")
+		assert.Equal(t, []string{"DOGE/USDT", "PEPE/USDT"}, defaultScalpingBacktestUniverse())
+	})
+}
+
 func TestNewScalpingBacktestEngine(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -244,6 +256,28 @@ func TestScalpingBacktestEngine_ComputeSignalHints(t *testing.T) {
 		assert.Equal(t, "sell", hints.SuggestedAction)
 		assert.InDelta(t, 0.72, hints.ConfidenceHint, 1e-9)
 		assert.GreaterOrEqual(t, hints.CandidateScore, 0.0)
+	})
+
+	t.Run("buy with fee-fragile spread returns nil hints", func(t *testing.T) {
+		// Mirrors the live AI hint path's scalpingBuySignalRejectionReason gate:
+		// a buy the deterministic path picks but the AI pipeline would suppress
+		// (fee-fragile spread) must not produce a hint.
+		signal := MarketSignal{
+			Symbol:             "BTC/USDT",
+			Price:              50000,
+			High24h:            51000,
+			Low24h:             49000,
+			Volume24h:          1_000_000,
+			BidAskSpread:       0.10, // > scalpingRecentBuyMaxSpreadPct (0.04)
+			OrderBookImbalance: 0.40,
+			RangePosition24h:   20,
+			PriceChange24h:     0.05,
+			RecentChangeKnown:  true,
+			RecentPriceChange:  0.05,
+		}
+		buyDecision := &AITradingDecision{Action: "buy", Confidence: 0.75, RangeAlignment: 0.6}
+		hints := engine.computeSignalHints(signal, buyDecision)
+		assert.Nil(t, hints, "buy with fee-fragile spread should be rejected at hint layer")
 	})
 
 	t.Run("whitespace action trimmed", func(t *testing.T) {

--- a/services/backend-api/internal/services/scalping_backtest_test.go
+++ b/services/backend-api/internal/services/scalping_backtest_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -260,6 +261,73 @@ func TestScalpingBacktestEngine_ComputeSignalHints(t *testing.T) {
 		hints := engine.computeSignalHints(signal, decision)
 		require.NotNil(t, hints)
 		assert.Equal(t, "buy", hints.SuggestedAction, "action should be lowercased + trimmed")
+	})
+
+	t.Run("uses decision.RangeAlignment from secondary branch", func(t *testing.T) {
+		// Secondary branches (blowoff sell, proximity-adjusted, reversal buy,
+		// sell-window, dual-proximity) compute rangeAlignment with a different
+		// formula than the primary buy/sell branches. The hints must reuse
+		// decision.RangeAlignment verbatim, not re-derive via the primary
+		// formula (which was the prior bug that produced wrong scores for
+		// signals entering through these branches).
+		fallback := engine.config.DeterministicFallback.Normalized()
+		signal := MarketSignal{
+			Symbol:             "BTC/USDT",
+			Price:              50000,
+			Volume24h:          1_000_000,
+			BidAskSpread:       0.05,
+			OrderBookImbalance: -0.40,
+			RangePosition24h:   80,
+		}
+		customAlignment := clampFloat(
+			(signal.RangePosition24h-scalpingBlowoffSellRangeMin)/
+				math.Max(scalpingBlowoffSellRangeMax-scalpingBlowoffSellRangeMin, 1),
+			0, 1,
+		)
+		decision := &AITradingDecision{
+			Action:         "sell",
+			Confidence:     0.70,
+			RangeAlignment: customAlignment,
+		}
+		hints := engine.computeSignalHints(signal, decision)
+		require.NotNil(t, hints)
+
+		effectiveMaxSpread := math.Max(fallback.MaxBidAskSpread, engine.config.MaxBidAskSpreadPct)
+		liquidityScore := clampFloat(1-(signal.BidAskSpread/effectiveMaxSpread), 0, 1)
+		volumeScore := clampFloat(math.Log10(signal.Volume24h+1)/fallback.VolumeLogScale, 0, 1)
+		expectedScore := math.Abs(signal.OrderBookImbalance)*fallback.ImbalanceWeight +
+			liquidityScore*fallback.LiquidityWeight +
+			customAlignment*fallback.RangeWeight +
+			volumeScore*fallback.VolumeWeight
+		assert.InDelta(t, expectedScore, hints.CandidateScore, 1e-9,
+			"CandidateScore must use decision.RangeAlignment, not a re-derived primary formula")
+	})
+
+	t.Run("zero RangeAlignment yields same score as primary buy branch with RangePosition=BuyRangeMax", func(t *testing.T) {
+		// Regression guard: when the decision carries RangeAlignment=0, the
+		// hints score drops the range component entirely. This pins the
+		// contract that decision.RangeAlignment is the single source of truth.
+		fallback := engine.config.DeterministicFallback.Normalized()
+		signal := MarketSignal{
+			Symbol:             "BTC/USDT",
+			Price:              50000,
+			Volume24h:          1_000_000,
+			BidAskSpread:       0.05,
+			OrderBookImbalance: 0.40,
+			RangePosition24h:   20,
+		}
+		decision := &AITradingDecision{Action: "buy", Confidence: 0.7, RangeAlignment: 0}
+		hints := engine.computeSignalHints(signal, decision)
+		require.NotNil(t, hints)
+
+		effectiveMaxSpread := math.Max(fallback.MaxBidAskSpread, engine.config.MaxBidAskSpreadPct)
+		liquidityScore := clampFloat(1-(signal.BidAskSpread/effectiveMaxSpread), 0, 1)
+		volumeScore := clampFloat(math.Log10(signal.Volume24h+1)/fallback.VolumeLogScale, 0, 1)
+		expectedScore := math.Abs(signal.OrderBookImbalance)*fallback.ImbalanceWeight +
+			liquidityScore*fallback.LiquidityWeight +
+			0.0*fallback.RangeWeight +
+			volumeScore*fallback.VolumeWeight
+		assert.InDelta(t, expectedScore, hints.CandidateScore, 1e-9)
 	})
 }
 

--- a/services/backend-api/internal/services/scalping_backtest_test.go
+++ b/services/backend-api/internal/services/scalping_backtest_test.go
@@ -124,6 +124,47 @@ func TestScalpingBacktestEngine_ValidateConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "valid config with mode=ai",
+			config: ScalpingBacktestConfig{
+				StartTime:      time.Now().Add(-24 * time.Hour),
+				EndTime:        time.Now(),
+				InitialCapital: decimal.NewFromInt(10000),
+				Mode:           "ai",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with mode=deterministic",
+			config: ScalpingBacktestConfig{
+				StartTime:      time.Now().Add(-24 * time.Hour),
+				EndTime:        time.Now(),
+				InitialCapital: decimal.NewFromInt(10000),
+				Mode:           "deterministic",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid mode value",
+			config: ScalpingBacktestConfig{
+				StartTime:      time.Now().Add(-24 * time.Hour),
+				EndTime:        time.Now(),
+				InitialCapital: decimal.NewFromInt(10000),
+				Mode:           "neural",
+			},
+			wantErr: true,
+			errMsg:  "invalid mode \"neural\"",
+		},
+		{
+			name: "empty mode is valid (defaults to deterministic downstream)",
+			config: ScalpingBacktestConfig{
+				StartTime:      time.Now().Add(-24 * time.Hour),
+				EndTime:        time.Now(),
+				InitialCapital: decimal.NewFromInt(10000),
+				Mode:           "",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -141,6 +182,85 @@ func TestScalpingBacktestEngine_ValidateConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestScalpingBacktestEngine_ComputeSignalHints covers the AI-mode sidecar
+// metadata computation (PR-3). The function is called from evaluateSignal
+// when the engine's Mode is "ai"; it must return nil for non-actionable
+// decisions and produce non-negative SuggestedAction/ConfidenceHint/
+// CandidateScore fields for actionable ones.
+func TestScalpingBacktestEngine_ComputeSignalHints(t *testing.T) {
+	engine := &ScalpingBacktestEngine{config: ScalpingBacktestConfig{
+		DeterministicFallback: DefaultDeterministicFallbackConfig(),
+		MaxBidAskSpreadPct:    0.5,
+	}}
+
+	t.Run("nil decision returns nil hints", func(t *testing.T) {
+		hints := engine.computeSignalHints(MarketSignal{}, nil)
+		assert.Nil(t, hints)
+	})
+
+	t.Run("hold decision returns nil hints", func(t *testing.T) {
+		holdDecision := &AITradingDecision{Action: "hold", Confidence: 0.5}
+		hints := engine.computeSignalHints(MarketSignal{}, holdDecision)
+		assert.Nil(t, hints)
+	})
+
+	t.Run("buy decision with valid signal returns hints", func(t *testing.T) {
+		signal := MarketSignal{
+			Symbol:             "BTC/USDT",
+			Price:              50000,
+			High24h:            51000,
+			Low24h:             49000,
+			Volume24h:          1_000_000,
+			BidAskSpread:       0.05,
+			OrderBookImbalance: 0.40,
+			RangePosition24h:   20,
+		}
+		buyDecision := &AITradingDecision{Action: "buy", Confidence: 0.75}
+		hints := engine.computeSignalHints(signal, buyDecision)
+		require.NotNil(t, hints, "buy decision should produce hints")
+		assert.Equal(t, "buy", hints.SuggestedAction)
+		assert.InDelta(t, 0.75, hints.ConfidenceHint, 1e-9)
+		assert.GreaterOrEqual(t, hints.CandidateScore, 0.0,
+			"score must be non-negative (imbalance+liquidity+volume components)")
+	})
+
+	t.Run("sell decision with valid signal returns hints", func(t *testing.T) {
+		signal := MarketSignal{
+			Symbol:             "ETH/USDT",
+			Price:              3000,
+			High24h:            3100,
+			Low24h:             2900,
+			Volume24h:          500_000,
+			BidAskSpread:       0.05,
+			OrderBookImbalance: -0.40,
+			RangePosition24h:   80,
+		}
+		sellDecision := &AITradingDecision{Action: "sell", Confidence: 0.72}
+		hints := engine.computeSignalHints(signal, sellDecision)
+		require.NotNil(t, hints, "sell decision should produce hints")
+		assert.Equal(t, "sell", hints.SuggestedAction)
+		assert.InDelta(t, 0.72, hints.ConfidenceHint, 1e-9)
+		assert.GreaterOrEqual(t, hints.CandidateScore, 0.0)
+	})
+
+	t.Run("whitespace action trimmed", func(t *testing.T) {
+		signal := MarketSignal{
+			Symbol:             "BTC/USDT",
+			Price:              50000,
+			High24h:            51000,
+			Low24h:             49000,
+			Volume24h:          1_000_000,
+			BidAskSpread:       0.05,
+			OrderBookImbalance: 0.40,
+			RangePosition24h:   20,
+		}
+		decision := &AITradingDecision{Action: "  buy  ", Confidence: 0.7}
+		hints := engine.computeSignalHints(signal, decision)
+		require.NotNil(t, hints)
+		assert.Equal(t, "buy", hints.SuggestedAction, "action should be lowercased + trimmed")
+	})
 }
 
 func TestScalpingBacktestEngine_ClassifyRegime(t *testing.T) {


### PR DESCRIPTION
## Summary

PR-3 of the ULTRAWORK decomposition. Adds a 'mode' knob to the scalping
backtest so operators can compare deterministic decisions against the hints
the AI scalping path would have consumed, plus a CLI wrapper for the
existing HTTP endpoint and the W0-D paper-diversify pre-work.

## What's in this PR

- **W0-D cherry-pick** (b2a0448e): Paper trading universe now respects
  `NEURATRADE_PAPER_SYMBOLS` env var. swing_trading strategy covers
  all 5 symbols (BTC/ETH/SOL/BNB/XRP) so the prior BNB-only bias in
  backfill validation is fixed. Closes NeuraTrade-itv9.

- **`ScalpingBacktestConfig.Mode`**: 'deterministic' (default) or
  'ai'. In 'ai' mode, the engine records per-signal hints
  (SuggestedAction/ConfidenceHint/CandidateScore) via a new
  `computeSignalHints` helper that mirrors the field set produced by
  `AIScalpingService.signalsWithDecisionHints`. No live LLM is
  invoked — backtests are offline replays; 'ai' mode is a 'shadow'
  that records what hints the AI path would have consumed for post-hoc
  analysis. Closes NeuraTrade-oxpj structurally.

- **`ScalpingBacktestResult.Mode`** records the mode used;
  `ValidateConfig` rejects anything other than
  'deterministic'/'ai' with a clear error.

- **Handler wiring**: `RunScalpingBacktestRequest.Mode *string`,
  defaults to 'deterministic' when unset or empty. The response
  (`RunScalpingBacktestResponse.Mode`) surfaces the mode used.

- **CLI subcommand** `neuratrade backtest run` wraps the existing
  `/api/v1/scalping/backtest` endpoint. Flags: --start/--end
  (RFC3339, required), --mode (default: deterministic), --symbols,
  --exchange, --initial-capital, --timeout. Rejects bad modes/dates
  with clear errors before hitting the network.

## Pre-review

- services+autonomy+handlers+ai packages all green
- gofmt clean, go vet clean, golangci-lint 0 issues
- Manual QA: `backtest` subcommand registered, `--help` shows flags,
  bad mode/date inputs rejected with clear errors
- 9 new/updated sub-tests across 2 test files:
  * 4 in handlers test for Mode parsing (default, explicit, empty, AI)
  * 4 new sub-tests in TestScalpingBacktestEngine_ValidateConfig
    (valid ai, valid deterministic, invalid mode, empty mode)
  * 5 new sub-tests in TestScalpingBacktestEngine_ComputeSignalHints
    (nil, hold, buy, sell, whitespace)

## Dependencies

- **Blocked by PR-1 (#461)**: Mode flows through handler request → service
  config → result, all of which exist in PR-1's baseline.
- **W0-D** (`fix/paper-trading-diversify`) is cherry-picked on top of
  PR-1 — no dependency on the unmerged branch.

## bd issues

- Closes NeuraTrade-oxpj (P1 AI vs non-AI backtest) — structurally.
  Full closure requires a soak run comparing the two modes.
- Closes NeuraTrade-itv9 (P1 paper trading diversification) via W0-D
  cherry-pick.

## Out of scope

- The codex P1 review comment on PR-2 ('allow ticker-only fallback
  through imbalance gate') was deliberately deferred — the new 0.10
  default already relaxes the gate substantially, and a ticker-only
  bypass changes classification semantics. Awaits explicit user
  sign-off before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a backtest "run" CLI with RFC3339 start/end, mode (deterministic|ai), symbols, exchange, capital, and timeout.
  * Backtests now carry an explicit mode and record signal metadata (hints/confidence/score) for AI-mode runs (computed deterministically).
  * Environment variable to override the default paper-trading symbol universe; swing-trading defaults expanded.

* **Tests**
  * Added/expanded tests for mode handling, signal-hint computation, and environment-based symbol parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->