### PR TITLE
fix(bitget): TP visibility — modify-in-place + planType filter fix + verify coverage

### DIFF
--- a/docs/bitget-tp-investigation.md
+++ b/docs/bitget-tp-investigation.md
@@ -1,0 +1,233 @@
+# Bitget TP Visibility Investigation
+
+> **Issue:** GH #264 / NeuraTrade-yeso (P0)
+> **Status:** Root cause identified — pre-work for PR-4
+> **Investigator:** W0-F (ULTRAWORK plan)
+> **Date:** 2026-06-04
+
+## Section 1: Root Cause
+
+### Primary Root Cause: Combined→Split Fallback in `SyncPositionProtection`
+
+The TP visibility issue originates in the `SyncPositionProtection` flow at **`bitget_order_executor.go:1268-1274`**. When the combined TP+SL call to `/api/v2/mix/order/place-pos-tpsl` fails, the code falls back to `placePositionTPSLSplit`, which calls the endpoint **twice** — once for TP only, once for SL only.
+
+This creates **two separate plan orders** on Bitget's side. The exchange UI may only display one of them (typically SL), or the second call may overwrite the first.
+
+### Secondary Contributor: `cancelExistingPositionTPSL` Plan Type Mismatch
+
+At **`bitget_order_executor.go:1279-1282`**, the cancel function queries `orders-plan-pending?planType=profit_loss`. However, the plans created by `placePositionTPSL` (line 1383) via `/api/v2/mix/order/place-pos-tpsl` are **position-level plans** (`pos_profit` / `pos_loss`), which may NOT match the `profit_loss` filter. The `orders-plan-pending` endpoint's documented `planType` values include only `profit_plan`, `loss_plan`, and `profit_loss` — NOT `pos_profit` or `pos_loss`.
+
+**Consequence:** After the first successful TP/SL set via `place-pos-tpsl`, subsequent `cancelExistingPositionTPSL` calls silently skip existing position-level plans. These orphaned plans accumulate, causing future combined `place-pos-tpsl` calls to fail (plan limit or conflict), triggering the split fallback, which compounds the issue.
+
+### Tertiary: `place-order` Preset Plans vs Position-Level Plans
+
+The initial order placement at **`bitget_order_executor.go:350-360`** uses `presetStopSurplusPrice` / `presetStopLossPrice` on `/api/v2/mix/order/place-order`. After fill, Bitget auto-creates **order-level plan orders** (`profit_plan` / `loss_plan`). The DynamicProtectionManager (~45s cooldown) subsequently calls `SyncPositionProtection`, which:
+
+1. Cancels the preset-created order-level plans (via `planType=profit_loss` — works here)
+2. Attempts to create **position-level plans** via `place-pos-tpsl` (different plan type)
+3. If the combined call fails, the split fallback creates two separate position-level plans
+
+This plan-type mismatch between the initial preset (order-level) and the managed update (position-level) creates an inconsistency that compounds over repeated reconciliation cycles.
+
+---
+
+## Section 2: Evidence
+
+### 2.1 Code Paths
+
+#### Path A: Order Placement with TP/SL Presets
+
+| File | Line(s) | Description |
+|------|---------|-------------|
+| `bitget_order_executor.go` | 350-360 | Sets `presetStopSurplusPrice` / `presetStopSurplusExecutePrice` / `presetStopLossPrice` on `/api/v2/mix/order/place-order` |
+| `bitget_order_executor.go` | 397-401 | Calls `verifyFuturesTPSLActive` to check plan orders exist after fill |
+| `bitget_order_executor.go` | 409-445 | Queries `/api/v2/mix/order/orders-plan-pending?planType=profit_loss` — only checks `len(orders) > 0`, does NOT verify both TP and SL are present |
+
+#### Path B: Post-Position TP/SL Sync (DynamicProtectionManager)
+
+| File | Line(s) | Description |
+|------|---------|-------------|
+| `dynamic_protection_manager.go` | 96-195 | `ReconcileOpenPositions` — periodic reconciliation loop |
+| `dynamic_protection_manager.go` | 197-274 | `computeTargets` — computes adaptive SL/TP adjustments |
+| `bitget_order_executor.go` | 1236-1276 | `SyncPositionProtection` — cancel existing plans → try combined → fall back to split |
+| `bitget_order_executor.go` | 1262 | `cancelExistingPositionTPSL` — cancels plans matching `planType=profit_loss` |
+| `bitget_order_executor.go` | 1268 | `placePositionTPSL` — combined TP+SL via `/api/v2/mix/order/place-pos-tpsl` |
+| `bitget_order_executor.go` | 1269 | `placePositionTPSLSplit` — fallback: two individual calls |
+| `bitget_order_executor.go` | 1352-1399 | `placePositionTPSL` — sends `stopSurplusTriggerPrice` + `stopLossTriggerPrice` |
+| `bitget_order_executor.go` | 1401-1419 | `placePositionTPSLSplit` — calls `placePositionTPSL` twice (TP first, then SL) |
+
+### 2.2 Log Lines
+
+| Log Pattern | Severity | Location | Meaning |
+|-------------|----------|----------|---------|
+| `[BITGET-ORDER] Combined TP/SL sync rejected, split fallback applied for %s` | WARN | Line 1273 | Combined `place-pos-tpsl` failed; split fallback activated |
+| `[BITGET-ORDER] ⚠️ No active TP/SL plans found for holdSide=%s` | WARN | Line 440 | Verification query returned zero plan orders |
+| `[BITGET-ORDER] ✅ Exchange-side TP/SL verified: %d active plan(s) for holdSide=%s` | INFO | Line 444 | Verification found plan(s) — but doesn't confirm both TP+SL exist |
+| `[BITGET-ORDER] ✅ Futures order placed: %s %s (size: %s contracts) - OrderID: %s` | INFO | Line 394 | Initial order placed successfully |
+| `[PROTECTION] Updating position_id=%q %s %s stop=%s->%s take=%s->%s last=%s` | INFO | `dynamic_protection_manager.go:141` | DynamicProtectionManager computed new targets |
+| `[PROTECTION] Failed to sync exchange-side TP/SL for %s: %v` | WARN | `dynamic_protection_manager.go:176` | SyncPositionProtection returned error to reconciler |
+
+### 2.3 Bitget API Doc References
+
+| Endpoint | URL | Purpose |
+|----------|-----|---------|
+| `POST /api/v2/mix/order/place-order` | [Place Order](https://www.bitget.com/api-doc/contract/trade/Place-Order) | Initial order with `presetStopSurplusPrice`/`presetStopLossPrice` |
+| `POST /api/v2/mix/order/place-pos-tpsl` | [Place Position TP/SL](https://www.bitget.com/api-doc/contract/plan/Place-Pos-Tpsl-Order) | Simultaneous position-level TP+SL (our sync endpoint) |
+| `POST /api/v2/mix/order/place-tpsl-order` | [Place TP/SL Order](https://www.bitget.com/api-doc/contract/plan/Place-Tpsl-Order) | Order-level TP/SL with `planType`+`size` (NOT currently used) |
+| `GET /api/v2/mix/order/orders-plan-pending` | [Pending Trigger Orders](https://www.bitget.com/api-doc/contract/plan/get-orders-plan-pending) | Query pending plan orders with `planType` filter |
+| `POST /api/v2/mix/order/cancel-plan-order` | [Cancel Plan Order](https://www.bitget.com/api-doc/contract/plan/Cancel-Plan-Order) | Cancel individual plan orders |
+| `POST /api/v2/mix/order/modify-tpsl-order` | [Modify TP/SL Order](https://www.bitget.com/api-doc/contract/plan/Modify-Tpsl-Order) | Modify existing TP/SL plan — may be better than cancel+recreate |
+
+### 2.4 Field Name Verification
+
+The test at **`bitget_order_executor_test.go:1052-1060`** confirms:
+- ✅ `presetStopSurplusPrice` is the correct Bitget API field for TP (line 1052)
+- ✅ `presetStopLossPrice` is the correct Bitget API field for SL (line 1054)
+- ✅ `presetStopLossExecutePrice` is intentionally omitted for market SL execution (line 1056-1057)
+- ✅ `presetTakeProfitPrice` is NOT sent — it is an invalid Bitget API field (line 1059-1060)
+- The grep across the entire codebase confirms `presetTakeProfitPrice` appears ONLY in the test assertion (zero production usage)
+
+**Conclusion:** The field naming is correct. The root cause is NOT a parameter name mismatch.
+
+---
+
+## Section 3: Recommended Fix
+
+### Primary Path (Recommended): Replace Cancel+Recreate With Modify
+
+**Problem:** The current cancel→recreate approach is destructive and fragile. Every reconciliation cycle tears down and rebuilds TP/SL plans, increasing the chance of failure, orphaned plans, and visibility gaps.
+
+**Solution:** Replace `cancelExistingPositionTPSL` + `placePositionTPSL` with a single `modify-tpsl-order` call:
+
+```
+POST /api/v2/mix/order/modify-tpsl-order
+```
+
+**Key advantage:** This endpoint modifies existing plan orders in-place without destroying and recreating them. It avoids:
+- The race window between cancel and recreate
+- Plan type mismatches (existing plans stay as-is, only prices update)
+- Orphaned plans from failed recreates
+
+**Implementation sketch:**
+
+```go
+// In placePositionTPSL, instead of cancel+create:
+// 1. Query existing plan orders
+// 2. For each plan order matching the position:
+//    - If it's a TP plan (pos_profit/profit_plan): modify trigger price
+//    - If it's a SL plan (pos_loss/loss_plan): modify trigger price
+//    - If neither exists: create new plan via place-pos-tpsl
+```
+
+### Alternative Path A: Fix Split Fallback Semantics
+
+If the combined→split approach is retained (should not be preferred), fix the issues:
+
+1. **Make split fallback atomic**: Cancel both on failure, or use a two-phase approach
+2. **Fix `cancelExistingPositionTPSL` query**: Use `planType=pos_profit,pos_loss` or query all plan types to properly find position-level plans
+3. **Verify both TP and SL** in `verifyFuturesTPSLActive` rather than just checking count > 0
+
+### Alternative Path B: Switch to Modify API (`modify-tpsl-order`)
+
+This is essentially the primary path. The modify endpoint (`POST /api/v2/mix/order/modify-tpsl-order`) is designed for this exact use case — updating TP/SL trigger prices on existing positions. It:
+- Takes `orderId` (existing plan order ID) + new `triggerPrice`
+- Returns success/failure without destroying the plan
+- Does not create duplicate plans
+
+**Implementation path:**
+1. Before modify, check if plan orders exist via `orders-plan-pending` (with proper `planType`)
+2. If plans exist → modify them
+3. If no plans exist → create them via `place-pos-tpsl`
+
+### Alternative Path C: Remove Position-Level Sync Entirely
+
+If the initial `presetStopSurplusPrice`/`presetStopLossPrice` on `place-order` is sufficient (Bitget auto-creates plan orders after fill), consider **not running `SyncPositionProtection` for positions that already have both TP and SL from the preset**. Only call it when the DynamicProtectionManager determines an adjustment is needed.
+
+---
+
+## Section 4: Adaptive SL/TP Policy
+
+### Current Behavior (`dynamic_protection_manager.go:197-274`)
+
+The `computeTargets` function runs every `UpdateCooldown` (default: 45s) and:
+
+- **SL adjustment:** Moves SL to break-even (entry + `BreakevenBufferPct`) or trailing stop (current price - `TrailingStopPct`), whichever is higher for longs
+- **TP adjustment:** Extends TP to current price + `TakeProfitDistancePct` if market is moving favorably
+- **Activation threshold:** Only kicks in after `ProfitActivationPct` (default: 0.35%) profit
+- **Minimum adjustment:** Skips changes below `MinAdjustmentPct` (default: 0.05%)
+
+### Policy Gaps
+
+| Gap | Impact | Recommendation |
+|-----|--------|----------------|
+| TP is always extended, never trimmed | In a reversal, TP may be unreachable | Add TP reduction logic when position retraces |
+| SL is always moved up (never down) for longs | Safe, but can be too tight | Respect a minimum distance from current price |
+| No maximum TP distance | TP could extend to unrealistic levels | Add a cap (e.g., 2x ATR) |
+| No cooldown-differentiated behavior | Frequent small adjustments | Adjust cooldown per position (e.g., longer for volatile pairs) |
+| No market regime awareness | Same behavior in trend vs chop | Consider ATR or trend strength in adjustment magnitude |
+
+### Recommended Policy
+
+```
+SL Rules (priority order):
+1. If profit < ActivationPct → keep original SL (no change)
+2. If profit > ActivationPct → move SL to break-even + BreakevenBuffer
+3. If trailing stop > break-even stop → use trailing stop
+4. Never move SL DOWN for longs (or UP for shorts)
+
+TP Rules:
+1. If strong uptrend (e.g., price > 20-period EMA + 2 ATR) → extend TP
+2. If range-bound → keep TP fixed
+3. If position retraces > 50% of max profit → reduce TP to current price + 1 ATR
+4. Maximum TP extension: 3x original TP distance
+
+Update Cooldown:
+- Normal: 45s (current)
+- After SL adjustment: 60s
+- After TP extension: 90s (avoid over-optimistic chasing)
+- After any failure: 120s (backoff)
+```
+
+---
+
+## Section 5: Safeguards
+
+### What Could Go Wrong
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **Orphaned plan orders accumulate** | Medium | Fix `cancelExistingPositionTPSL` to use proper plan type filter; add periodic cleanup sweep |
+| **Split fallback creates only one trigger** | High | Make split fallback atomic; verify both are created; cancel on partial failure |
+| **DynamicProtectionManager overwrites manual UI adjustment** | Low-Medium | Add `manual_override` flag; skip positions updated via UI within cooldown period |
+| **Plan type mismatch causes silent failures** | High | Use `/api/v2/mix/order/modify-tpsl-order` instead of cancel+recreate to preserve existing plan types |
+| **Race between reconcile and order fill** | Medium | Check position exists and has fill price before syncing protection; skip if entry price is zero |
+| **API rate limit on plan operations** | Low | Respect Bitget's 10 req/s limit; add rate limiter to plan operations |
+| **Combined call always fails in production** | Medium | Log `Code` and `Msg` from failed response to classify failure reason; add metrics for combined vs split success rate |
+| **Partial failure in split leaves inconsistent state** | High | Before split fallback, record desired state; on failure of either leg, attempt rollback of the successful leg |
+
+### Verification Checks for PR-4
+
+1. **Unit tests:** Both combined and split `placePositionTPSL` paths must succeed in test server
+2. **Log analysis:** Check for `[BITGET-ORDER] Combined TP/SL sync rejected` in production logs — frequency indicates severity
+3. **Plan type audit:** After TP/SL sync, query `orders-plan-pending` with ALL plan type filters to verify both TP and SL exist
+4. **Visibility test:** On Bitget testnet, submit combined TP+SL and verify both appear in the UI
+5. **Reconciliation durability:** Run 100 consecutive `ReconcileOpenPositions` cycles and verify TP/SL integrity
+
+---
+
+## Appendix: Key File References
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `services/backend-api/internal/services/bitget_order_executor.go` | 223-404 | `placeFuturesOrderWithTPSL` — order placement with presets |
+| `services/backend-api/internal/services/bitget_order_executor.go` | 409-445 | `verifyFuturesTPSLActive` — post-order verification |
+| `services/backend-api/internal/services/bitget_order_executor.go` | 1236-1276 | `SyncPositionProtection` — cancel→create→fallback flow |
+| `services/backend-api/internal/services/bitget_order_executor.go` | 1278-1350 | `cancelExistingPositionTPSL` — cancel with `planType=profit_loss` |
+| `services/backend-api/internal/services/bitget_order_executor.go` | 1352-1399 | `placePositionTPSL` — combined `/place-pos-tpsl` call |
+| `services/backend-api/internal/services/bitget_order_executor.go` | 1401-1419 | `placePositionTPSLSplit` — split fallback |
+| `services/backend-api/internal/services/dynamic_protection_manager.go` | 96-195 | `ReconcileOpenPositions` — periodic reconciliation |
+| `services/backend-api/internal/services/dynamic_protection_manager.go` | 197-274 | `computeTargets` — adaptive SL/TP target computation |
+| `services/backend-api/internal/services/smart_order_executor.go` | 602-619 | `SyncPositionProtection` — delegation to base executor |
+| `services/backend-api/internal/services/quest_handlers_integrated.go` | 889-901 | Protection reconciliation call from quest handlers |
+| `services/backend-api/internal/services/bitget_order_executor_test.go` | 1040-1061 | Field name validation tests |
+| `services/backend-api/internal/services/dynamic_protection_manager_test.go` | 62-342 | Protection manager tests |

--- a/docs/bitget-tp-investigation.md
+++ b/docs/bitget-tp-investigation.md
@@ -99,7 +99,7 @@ The test at **`bitget_order_executor_test.go:1052-1060`** confirms:
 
 **Solution:** Replace `cancelExistingPositionTPSL` + `placePositionTPSL` with a single `modify-tpsl-order` call:
 
-```
+```http
 POST /api/v2/mix/order/modify-tpsl-order
 ```
 
@@ -168,7 +168,7 @@ The `computeTargets` function runs every `UpdateCooldown` (default: 45s) and:
 
 ### Recommended Policy
 
-```
+```text
 SL Rules (priority order):
 1. If profit < ActivationPct → keep original SL (no change)
 2. If profit > ActivationPct → move SL to break-even + BreakevenBuffer

--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -1512,6 +1512,58 @@ func (e *BitgetOrderExecutor) modifyPositionTPSL(
 		return false, nil
 	}
 
+	wantTP := takeProfit.GreaterThan(decimal.Zero)
+	wantSL := stopLoss.GreaterThan(decimal.Zero)
+
+	// Pre-flight: classify existing plans by leg, and fall back to
+	// cancel+recreate whenever the existing plan set can't be modified
+	// to match the requested state. Without this check the function
+	// used to return (true, nil) as soon as ONE matching plan was
+	// updated, silently leaving the position with a partial protection
+	// set (e.g. only TP modified, no SL created) — a correctness bug.
+	var hasTP, hasSL bool
+	for _, plan := range plans {
+		planType := strings.ToLower(strings.TrimSpace(mapStringAny(plan, "planType", "plan_type")))
+		// Combined TP+SL plans can't be modified in-place with the
+		// single-triggerPrice body the modify-tpsl-order endpoint
+		// accepts; cancel+recreate produces a clean result.
+		if strings.Contains(planType, "profit_loss") {
+			return false, nil
+		}
+		isTP := strings.Contains(planType, "profit") || strings.Contains(planType, "surplus")
+		isSL := strings.Contains(planType, "loss")
+		if isTP {
+			hasTP = true
+		}
+		if isSL {
+			hasSL = true
+		}
+	}
+	if wantTP && !hasTP {
+		// Caller wants TP but no TP plan exists → fall back.
+		return false, nil
+	}
+	if wantSL && !hasSL {
+		// Caller wants SL but no SL plan exists → fall back.
+		return false, nil
+	}
+	if !wantTP && hasTP {
+		// Caller wants to remove the TP, but modify-tpsl-order can only
+		// adjust prices — it can't delete a plan → fall back.
+		return false, nil
+	}
+	if !wantSL && hasSL {
+		// Same for the SL leg.
+		return false, nil
+	}
+
+	// All requested legs exist. Modify them in place. Plans already
+	// at the target price are skipped (no-op) to avoid the
+	// corresponding API rate-limit cost. We return true even if every
+	// plan was a no-op skip — this is the "already-synced" signal
+	// that lets SyncPositionProtection avoid the wasteful cancel+recreate
+	// fallback (Bug 2: previously returned false, defeating the
+	// optimization).
 	for _, plan := range plans {
 		orderID := strings.TrimSpace(mapStringAny(plan, "orderId", "orderID", "id"))
 		if orderID == "" {
@@ -1577,7 +1629,11 @@ func (e *BitgetOrderExecutor) modifyPositionTPSL(
 		}
 		modifyApplied = true
 	}
-	return modifyApplied, nil
+	// Return true even when modifyApplied stayed false: every existing
+	// plan was a no-op skip (already at the target price), which
+	// means the position is already in the desired state. This is
+	// the "already-synced" signal.
+	return true, nil
 }
 
 // IsPaperTrading returns false for Bitget executor (real trading mode)

--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -1413,7 +1413,10 @@ func (e *BitgetOrderExecutor) listPositionTPSLPlans(ctx context.Context, symbol,
 	filtered := make([]map[string]interface{}, 0, len(orders))
 	for _, order := range orders {
 		recordHoldSide := strings.ToLower(strings.TrimSpace(mapStringAny(order, "holdSide", "posSide")))
-		if recordHoldSide == "" || recordHoldSide == targetHoldSide {
+		if recordHoldSide == "" {
+			continue
+		}
+		if recordHoldSide == targetHoldSide {
 			filtered = append(filtered, order)
 		}
 	}
@@ -1632,8 +1635,17 @@ func (e *BitgetOrderExecutor) modifyPositionTPSL(
 			"size":         planSize,
 			"triggerPrice": targetPrice,
 			"triggerType":  "mark_price",
-			"executePrice": targetPrice,
 			"planType":     planType,
+		}
+		if isSL {
+			// Bitget's modify-tpsl-order treats executePrice=0 (or omitted)
+			// as market execution. For SL/pos_loss legs, sending the stop
+			// trigger as the limit price would convert the protection into
+			// a limit order and could fail to close the position if price
+			// gaps through the trigger.
+			body["executePrice"] = "0"
+		} else {
+			body["executePrice"] = targetPrice
 		}
 		jsonBody, err := json.Marshal(body)
 		if err != nil {

--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -1321,6 +1321,14 @@ func (e *BitgetOrderExecutor) cancelExistingPositionTPSL(ctx context.Context, sy
 		if orderID == "" {
 			continue
 		}
+		// Only cancel TP/SL plan types — skip unrelated plan types
+		// (entry limits, trailing stops) to avoid collateral damage.
+		planType := strings.ToLower(strings.TrimSpace(mapStringAny(order, "planType", "plan_type")))
+		isTP := strings.Contains(planType, "profit") || strings.Contains(planType, "surplus")
+		isSL := strings.Contains(planType, "loss")
+		if !isTP && !isSL {
+			continue
+		}
 		orderIDList = append(orderIDList, map[string]string{"orderId": orderID})
 	}
 	if len(orderIDList) == 0 {

--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -407,41 +407,46 @@ func (e *BitgetOrderExecutor) placeFuturesOrderWithTPSL(ctx context.Context, sym
 // for a position and logs the result. This verifies that exchange-side protection
 // is in place after order placement.
 func (e *BitgetOrderExecutor) verifyFuturesTPSLActive(ctx context.Context, symbol, holdSide string) {
-	endpoint := fmt.Sprintf(
-		"/api/v2/mix/order/orders-plan-pending?productType=USDT-FUTURES&planType=profit_loss&symbol=%s",
-		symbol,
-	)
-	resp, err := e.doRequest(ctx, "GET", endpoint, nil)
+	// Per docs/bitget-tp-investigation.md (Section 1, tertiary root cause):
+	// the legacy implementation only checked `len(orders) > 0` and did NOT
+	// verify that BOTH TP and SL were present. A position with only an SL
+	// plan (or only a TP plan) would pass verification but leave the
+	// opposite leg unprotected. Switched to the unified
+	// listPositionTPSLPlans helper (no planType filter) and now require
+	// at least one surplus/TP plan AND at least one loss/SL plan before
+	// reporting "verified".
+	orders, err := e.listPositionTPSLPlans(ctx, symbol, holdSide)
 	if err != nil {
 		fmt.Printf("[BITGET-ORDER] ⚠️ Failed to verify TP/SL status: %v\n", err)
-		return
-	}
-
-	var result struct {
-		Code string          `json:"code"`
-		Msg  string          `json:"msg"`
-		Data json.RawMessage `json:"data"`
-	}
-	if err := json.Unmarshal(resp, &result); err != nil {
-		fmt.Printf("[BITGET-ORDER] ⚠️ Failed to parse TP/SL verification response: %v\n", err)
-	}
-
-	if result.Code != "00000" {
-		fmt.Printf("[BITGET-ORDER] ⚠️ TP/SL verification API error: %s (code: %s)\n", result.Msg, result.Code)
-		return
-	}
-
-	orders, err := parseBitgetOrderList(result.Data)
-	if err != nil {
-		fmt.Printf("[BITGET-ORDER] ⚠️ Failed to parse TP/SL plan orders: %v\n", err)
 		return
 	}
 	if len(orders) == 0 {
 		fmt.Printf("[BITGET-ORDER] ⚠️ No active TP/SL plans found for holdSide=%s — exchange-side protection may not be set\n", holdSide)
 		return
 	}
-
-	fmt.Printf("[BITGET-ORDER] ✅ Exchange-side TP/SL verified: %d active plan(s) for holdSide=%s\n", len(orders), holdSide)
+	hasTP, hasSL := false, false
+	for _, order := range orders {
+		planType := strings.ToLower(strings.TrimSpace(mapStringAny(order, "planType", "plan_type")))
+		// Bitget planType values: profit_plan, loss_plan, profit_loss,
+		// pos_profit, pos_loss. A "profit_loss" plan covers BOTH legs
+		// (combined TP+SL placed via place-pos-tpsl), so it must set
+		// hasTP and hasSL both. The "profit"/"loss" branches set just
+		// the matching leg.
+		isTP := strings.Contains(planType, "profit") || strings.Contains(planType, "surplus")
+		isSL := strings.Contains(planType, "loss")
+		if isTP {
+			hasTP = true
+		}
+		if isSL {
+			hasSL = true
+		}
+	}
+	if !hasTP || !hasSL {
+		fmt.Printf("[BITGET-ORDER] ⚠️ Partial TP/SL coverage for holdSide=%s: hasTP=%t hasSL=%t (%d plan(s)) — exchange-side protection is incomplete\n",
+			holdSide, hasTP, hasSL, len(orders))
+		return
+	}
+	fmt.Printf("[BITGET-ORDER] ✅ Exchange-side TP/SL verified: %d active plan(s) for holdSide=%s (TP and SL both present)\n", len(orders), holdSide)
 }
 
 // getTicker fetches current ticker price from Bitget
@@ -1259,11 +1264,32 @@ func (e *BitgetOrderExecutor) SyncPositionProtection(
 	if err != nil {
 		return fmt.Errorf("fetch contract info for protection sync: %w", err)
 	}
+	if stopLoss.LessThanOrEqual(decimal.Zero) && takeProfit.LessThanOrEqual(decimal.Zero) {
+		// Caller wants no protection — cancel any existing plans but
+		// don't try to place new ones. cancelExistingPositionTPSL
+		// uses the broadened listPositionTPSLPlans helper (no
+		// planType filter) so it catches position-level plans too.
+		if err := e.cancelExistingPositionTPSL(ctx, apiSymbol, holdSide); err != nil {
+			return fmt.Errorf("cancel existing TP/SL plan orders failed: %w", err)
+		}
+		return nil
+	}
+
+	// Try the modify-in-place path first (PR-4, see
+	// docs/bitget-tp-investigation.md primary root cause). If existing
+	// plans were found and at least one was updated, we're done — the
+	// cancel+recreate path that caused orphaned plans is bypassed
+	// entirely. If no plans exist (first-ever sync) or the modify
+	// path errors, fall through to the legacy cancel+place flow.
+	modified, modifyErr := e.modifyPositionTPSL(ctx, apiSymbol, holdSide, stopLoss, takeProfit, contractInfo)
+	if modifyErr != nil {
+		zaplogrus.Warnf("[BITGET-ORDER] Modify-in-place TP/SL sync failed for %s, falling back to cancel+recreate: %v", apiSymbol, modifyErr)
+	} else if modified {
+		return nil
+	}
+
 	if err := e.cancelExistingPositionTPSL(ctx, apiSymbol, holdSide); err != nil {
 		return fmt.Errorf("cancel existing TP/SL plan orders failed: %w", err)
-	}
-	if stopLoss.LessThanOrEqual(decimal.Zero) && takeProfit.LessThanOrEqual(decimal.Zero) {
-		return nil
 	}
 	if err := e.placePositionTPSL(ctx, apiSymbol, holdSide, stopLoss, takeProfit, contractInfo); err != nil {
 		splitErr := e.placePositionTPSLSplit(ctx, apiSymbol, holdSide, stopLoss, takeProfit, contractInfo)
@@ -1276,30 +1302,9 @@ func (e *BitgetOrderExecutor) SyncPositionProtection(
 }
 
 func (e *BitgetOrderExecutor) cancelExistingPositionTPSL(ctx context.Context, symbol, holdSide string) error {
-	endpoint := fmt.Sprintf(
-		"/api/v2/mix/order/orders-plan-pending?productType=USDT-FUTURES&planType=profit_loss&symbol=%s",
-		symbol,
-	)
-	resp, err := e.doRequest(ctx, "GET", endpoint, nil)
+	orders, err := e.listPositionTPSLPlans(ctx, symbol, holdSide)
 	if err != nil {
-		return fmt.Errorf("list pending TP/SL plans: %w", err)
-	}
-
-	var result struct {
-		Code string          `json:"code"`
-		Msg  string          `json:"msg"`
-		Data json.RawMessage `json:"data"`
-	}
-	if err := json.Unmarshal(resp, &result); err != nil {
-		return fmt.Errorf("failed to parse pending TP/SL orders response: %w", err)
-	}
-	if result.Code != "00000" {
-		return fmt.Errorf("bitget API error while listing TP/SL plans: %s (code: %s)", result.Msg, result.Code)
-	}
-
-	orders, err := parseBitgetOrderList(result.Data)
-	if err != nil {
-		return fmt.Errorf("failed to parse pending TP/SL orders payload: %w", err)
+		return err
 	}
 	if len(orders) == 0 {
 		return nil
@@ -1309,10 +1314,6 @@ func (e *BitgetOrderExecutor) cancelExistingPositionTPSL(ctx context.Context, sy
 	for _, order := range orders {
 		orderID := strings.TrimSpace(mapStringAny(order, "orderId", "orderID", "id"))
 		if orderID == "" {
-			continue
-		}
-		recordHoldSide := strings.ToLower(strings.TrimSpace(mapStringAny(order, "holdSide", "posSide")))
-		if recordHoldSide != "" && recordHoldSide != strings.ToLower(strings.TrimSpace(holdSide)) {
 			continue
 		}
 		orderIDList = append(orderIDList, map[string]string{"orderId": orderID})
@@ -1347,6 +1348,63 @@ func (e *BitgetOrderExecutor) cancelExistingPositionTPSL(ctx context.Context, sy
 		return fmt.Errorf("bitget cancel TP/SL error: %s (code: %s)", cancelResult.Msg, cancelResult.Code)
 	}
 	return nil
+}
+
+// listPositionTPSLPlans returns the set of pending TP/SL plan orders on a
+// futures position, including BOTH order-level plans (profit_plan/loss_plan)
+// and position-level plans (pos_profit/pos_loss). Per docs/bitget-tp-investigation.md:
+//
+//   - The legacy code queried planType=profit_loss only, which silently
+//     skipped position-level plans and left orphaned orders across
+//     reconciliation cycles.
+//   - The orders-plan-pending endpoint accepts ONE planType per call, so
+//     we omit the filter and filter by holdSide client-side. This catches
+//     all plan types Bitget might return (profit_plan, loss_plan,
+//     profit_loss, pos_profit, pos_loss) in a single round-trip and avoids
+//     the "missing plan" class of bugs that compounded the original issue.
+//
+// Returns an empty slice (not nil) when no plans exist for the given
+// holdSide; the caller is expected to handle empty results as a no-op.
+func (e *BitgetOrderExecutor) listPositionTPSLPlans(ctx context.Context, symbol, holdSide string) ([]map[string]interface{}, error) {
+	endpoint := fmt.Sprintf(
+		"/api/v2/mix/order/orders-plan-pending?productType=USDT-FUTURES&symbol=%s",
+		symbol,
+	)
+	resp, err := e.doRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list pending TP/SL plans: %w", err)
+	}
+
+	var result struct {
+		Code string          `json:"code"`
+		Msg  string          `json:"msg"`
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse pending TP/SL orders response: %w", err)
+	}
+	if result.Code != "00000" {
+		return nil, fmt.Errorf("bitget API error while listing TP/SL plans: %s (code: %s)", result.Msg, result.Code)
+	}
+
+	orders, err := parseBitgetOrderList(result.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pending TP/SL orders payload: %w", err)
+	}
+
+	// Filter by holdSide client-side. The Bitget API uses holdSide for
+	// position-level plans and posSide for some legacy schemas; we accept
+	// either spelling. Records with no side are skipped (conservative —
+	// better to leave a stale plan than to cancel a fresh one).
+	targetHoldSide := strings.ToLower(strings.TrimSpace(holdSide))
+	filtered := make([]map[string]interface{}, 0, len(orders))
+	for _, order := range orders {
+		recordHoldSide := strings.ToLower(strings.TrimSpace(mapStringAny(order, "holdSide", "posSide")))
+		if recordHoldSide == "" || recordHoldSide == targetHoldSide {
+			filtered = append(filtered, order)
+		}
+	}
+	return filtered, nil
 }
 
 func (e *BitgetOrderExecutor) placePositionTPSL(
@@ -1416,6 +1474,110 @@ func (e *BitgetOrderExecutor) placePositionTPSLSplit(
 		}
 	}
 	return nil
+}
+
+// modifyPositionTPSL updates the trigger/execute prices of existing
+// position-level TP/SL plan orders in place, replacing the legacy
+// cancel+recreate pattern that caused orphaned plans and Bitget UI
+// showing only the SL leg (see docs/bitget-tp-investigation.md, primary
+// root cause). The function:
+//
+//  1. Lists current position-level plans via listPositionTPSLPlans
+//     (which catches pos_profit/pos_loss/profit_plan/loss_plan, the
+//     full set the legacy planType=profit_loss filter silently skipped).
+//  2. For each plan whose trigger price is stale, POSTs a modify
+//     request to /api/v2/mix/order/modify-tpsl-order with the new
+//     trigger + execute prices. Plans already at the target price are
+//     skipped (no-op).
+//  3. If no plans exist yet, returns nil with modifyApplied=false so
+//     the caller can fall back to placePositionTPSL. This is the
+//     expected case for the first-ever protection sync on a position.
+//
+// The function is conservative: any per-plan failure aborts the whole
+// modify (returns the error) so the caller can decide to fall back to
+// the cancel+create path instead of leaving the position in a
+// half-modified state.
+func (e *BitgetOrderExecutor) modifyPositionTPSL(
+	ctx context.Context,
+	symbol, holdSide string,
+	stopLoss decimal.Decimal,
+	takeProfit decimal.Decimal,
+	contractInfo *ContractInfo,
+) (modifyApplied bool, err error) {
+	plans, err := e.listPositionTPSLPlans(ctx, symbol, holdSide)
+	if err != nil {
+		return false, fmt.Errorf("list existing plans for modify: %w", err)
+	}
+	if len(plans) == 0 {
+		return false, nil
+	}
+
+	for _, plan := range plans {
+		orderID := strings.TrimSpace(mapStringAny(plan, "orderId", "orderID", "id"))
+		if orderID == "" {
+			continue
+		}
+		planType := strings.ToLower(strings.TrimSpace(mapStringAny(plan, "planType", "plan_type")))
+		isTP := strings.Contains(planType, "profit") || strings.Contains(planType, "surplus")
+		isSL := strings.Contains(planType, "loss")
+		if !isTP && !isSL {
+			// Unknown plan type — leave it alone rather than risk
+			// disturbing an unrelated order. The next reconcile
+			// cycle will re-evaluate.
+			continue
+		}
+
+		var targetPrice string
+		if isTP {
+			if !takeProfit.GreaterThan(decimal.Zero) {
+				continue
+			}
+			targetPrice = formatFuturesTriggerPrice(takeProfit, contractInfo)
+		} else {
+			if !stopLoss.GreaterThan(decimal.Zero) {
+				continue
+			}
+			targetPrice = formatFuturesTriggerPrice(stopLoss, contractInfo)
+		}
+
+		// Skip if the trigger price is already at target (avoids a
+		// no-op modify call and the corresponding API rate-limit cost).
+		existingTrigger := strings.TrimSpace(mapStringAny(plan, "triggerPrice", "stopSurplusTriggerPrice", "stopLossTriggerPrice", "price"))
+		if existingTrigger != "" && existingTrigger == targetPrice {
+			continue
+		}
+
+		body := map[string]interface{}{
+			"symbol":       symbol,
+			"productType":  "USDT-FUTURES",
+			"marginCoin":   "USDT",
+			"orderId":      orderID,
+			"triggerPrice": targetPrice,
+			"triggerType":  "mark_price",
+			"executePrice": targetPrice,
+			"planType":     planType,
+		}
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return modifyApplied, fmt.Errorf("marshal modify TP/SL payload for order %s: %w", orderID, err)
+		}
+		resp, err := e.doRequest(ctx, "POST", "/api/v2/mix/order/modify-tpsl-order", jsonBody)
+		if err != nil {
+			return modifyApplied, fmt.Errorf("modify TP/SL request for order %s: %w", orderID, err)
+		}
+		var result struct {
+			Code string `json:"code"`
+			Msg  string `json:"msg"`
+		}
+		if err := json.Unmarshal(resp, &result); err != nil {
+			return modifyApplied, fmt.Errorf("parse modify TP/SL response for order %s: %w", orderID, err)
+		}
+		if result.Code != "00000" {
+			return modifyApplied, fmt.Errorf("bitget modify TP/SL error for order %s: %s (code: %s)", orderID, result.Msg, result.Code)
+		}
+		modifyApplied = true
+	}
+	return modifyApplied, nil
 }
 
 // IsPaperTrading returns false for Bitget executor (real trading mode)

--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -1614,7 +1614,15 @@ func (e *BitgetOrderExecutor) modifyPositionTPSL(
 
 		planSize := strings.TrimSpace(mapStringAny(plan, "size", "Size"))
 		if planSize == "" {
-			continue
+			// Defensive: a plan that lacks a size field can't be
+			// modified in place. Don't silently treat this as
+			// success — that would leave the caller believing the
+			// position is synced when one leg was never updated.
+			// Signal fallback to cancel+recreate so the caller can
+			// establish a clean state. This is distinct from the
+			// no-op skip above (trigger already at target), which is
+			// the legitimate "already-synced" case.
+			return false, nil
 		}
 		body := map[string]interface{}{
 			"symbol":       symbol,

--- a/services/backend-api/internal/services/bitget_order_executor.go
+++ b/services/backend-api/internal/services/bitget_order_executor.go
@@ -397,7 +397,7 @@ func (e *BitgetOrderExecutor) placeFuturesOrderWithTPSL(ctx context.Context, sym
 	if !isRiskReduction && (details.TakeProfit != nil || details.StopLoss != nil) {
 		verifyCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
-		e.verifyFuturesTPSLActive(verifyCtx, symbol, holdSide)
+		e.verifyFuturesTPSLActive(verifyCtx, symbol, holdSide, details.TakeProfit != nil, details.StopLoss != nil)
 	}
 
 	return result.OrderID, nil
@@ -405,8 +405,11 @@ func (e *BitgetOrderExecutor) placeFuturesOrderWithTPSL(ctx context.Context, sym
 
 // verifyFuturesTPSLActive checks whether the exchange has active TP/SL plan orders
 // for a position and logs the result. This verifies that exchange-side protection
-// is in place after order placement.
-func (e *BitgetOrderExecutor) verifyFuturesTPSLActive(ctx context.Context, symbol, holdSide string) {
+// is in place after order placement. expectTP and expectSL tell the verifier which
+// legs the caller placed — only the expected legs are required for a "verified"
+// result, so a caller that placed only a TP doesn't get a spurious "partial
+// coverage" warning when the exchange correctly has no SL plan.
+func (e *BitgetOrderExecutor) verifyFuturesTPSLActive(ctx context.Context, symbol, holdSide string, expectTP, expectSL bool) {
 	// Per docs/bitget-tp-investigation.md (Section 1, tertiary root cause):
 	// the legacy implementation only checked `len(orders) > 0` and did NOT
 	// verify that BOTH TP and SL were present. A position with only an SL
@@ -441,12 +444,14 @@ func (e *BitgetOrderExecutor) verifyFuturesTPSLActive(ctx context.Context, symbo
 			hasSL = true
 		}
 	}
-	if !hasTP || !hasSL {
-		fmt.Printf("[BITGET-ORDER] ⚠️ Partial TP/SL coverage for holdSide=%s: hasTP=%t hasSL=%t (%d plan(s)) — exchange-side protection is incomplete\n",
-			holdSide, hasTP, hasSL, len(orders))
+	missingTP := expectTP && !hasTP
+	missingSL := expectSL && !hasSL
+	if missingTP || missingSL {
+		fmt.Printf("[BITGET-ORDER] ⚠️ Partial TP/SL coverage for holdSide=%s: expectTP=%t expectSL=%t hasTP=%t hasSL=%t (%d plan(s)) — exchange-side protection is incomplete\n",
+			holdSide, expectTP, expectSL, hasTP, hasSL, len(orders))
 		return
 	}
-	fmt.Printf("[BITGET-ORDER] ✅ Exchange-side TP/SL verified: %d active plan(s) for holdSide=%s (TP and SL both present)\n", len(orders), holdSide)
+	fmt.Printf("[BITGET-ORDER] ✅ Exchange-side TP/SL verified: %d active plan(s) for holdSide=%s (expectTP=%t expectSL=%t)\n", len(orders), holdSide, expectTP, expectSL)
 }
 
 // getTicker fetches current ticker price from Bitget
@@ -1599,11 +1604,16 @@ func (e *BitgetOrderExecutor) modifyPositionTPSL(
 			continue
 		}
 
+		planSize := strings.TrimSpace(mapStringAny(plan, "size", "Size"))
+		if planSize == "" {
+			continue
+		}
 		body := map[string]interface{}{
 			"symbol":       symbol,
 			"productType":  "USDT-FUTURES",
 			"marginCoin":   "USDT",
 			"orderId":      orderID,
+			"size":         planSize,
 			"triggerPrice": targetPrice,
 			"triggerType":  "mark_price",
 			"executePrice": targetPrice,

--- a/services/backend-api/internal/services/bitget_order_executor_test.go
+++ b/services/backend-api/internal/services/bitget_order_executor_test.go
@@ -1220,8 +1220,10 @@ func TestBitgetOrderExecutor_ModifyPositionTPSL_SendsModifyRequestsForStalePlans
 	assert.ElementsMatch(t, []string{"tp-1", "sl-1"}, orderIDs)
 }
 
-// PR-4: when both plans are already at the target price, the
-// modify path should be a no-op (no modify-tpsl-order requests).
+// PR-4: when both plans are already at the target price, the modify
+// path is a no-op (no modify-tpsl-order requests) BUT still returns
+// true. The true signal means "already-synced" — SyncPositionProtection
+// uses it to avoid the wasteful cancel+recreate fallback (Bug 2).
 func TestBitgetOrderExecutor_ModifyPositionTPSL_SkipsPlansAlreadyAtTarget(t *testing.T) {
 	var modifyCalls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1257,8 +1259,124 @@ func TestBitgetOrderExecutor_ModifyPositionTPSL_SkipsPlansAlreadyAtTarget(t *tes
 		&ContractInfo{PricePlace: 2},
 	)
 	require.NoError(t, err)
-	assert.False(t, modified, "modified should be false when no plans changed")
+	assert.True(t, modified, "modified should be true (already-synced signal) when all plans are at target")
 	assert.Equal(t, 0, modifyCalls, "no modify requests should be sent when triggers already match")
+}
+
+// PR-4 Bug 1: if the caller wants both TP and SL but only a TP plan
+// exists, modifyPositionTPSL must NOT return true (it must fall
+// back to cancel+recreate). Returning true here would leave the
+// position with only the old TP and no SL — a correctness bug that
+// could cause real financial loss.
+func TestBitgetOrderExecutor_ModifyPositionTPSL_FallsBackWhenSLMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/order/orders-plan-pending":
+			// Only a TP plan exists; no SL.
+			_, _ = w.Write([]byte(`{
+				"code": "00000",
+				"msg": "ok",
+				"data": {
+					"entrustedList": [
+						{"orderId": "tp-1", "planType": "pos_profit", "holdSide": "long", "triggerPrice": "50000"}
+					]
+				}
+			}`))
+		case "/api/v2/mix/order/modify-tpsl-order":
+			t.Fatalf("modify-tpsl-order must NOT be called when SL plan is missing")
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	modified, err := executor.modifyPositionTPSL(
+		context.Background(),
+		"BTCUSDT",
+		"long",
+		decimal.NewFromInt(49000), // SL requested
+		decimal.NewFromInt(52000), // TP requested
+		&ContractInfo{PricePlace: 2},
+	)
+	require.NoError(t, err)
+	assert.False(t, modified, "missing-leg must fall back to cancel+recreate (Bug 1)")
+}
+
+// PR-4 Bug 1 (symmetric): if the caller wants only TP but both TP
+// and SL plans exist, modifyPositionTPSL must fall back because the
+// SL plan can't be removed via the modify-tpsl-order endpoint.
+func TestBitgetOrderExecutor_ModifyPositionTPSL_FallsBackWhenSLExtra(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/order/orders-plan-pending":
+			// Both plans exist; caller wants only TP (SL=0).
+			_, _ = w.Write([]byte(`{
+				"code": "00000",
+				"msg": "ok",
+				"data": {
+					"entrustedList": [
+						{"orderId": "tp-1", "planType": "pos_profit", "holdSide": "long", "triggerPrice": "50000"},
+						{"orderId": "sl-1", "planType": "pos_loss", "holdSide": "long", "triggerPrice": "49000"}
+					]
+				}
+			}`))
+		case "/api/v2/mix/order/modify-tpsl-order":
+			t.Fatalf("modify-tpsl-order must NOT be called when caller wants to remove the SL")
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	modified, err := executor.modifyPositionTPSL(
+		context.Background(),
+		"BTCUSDT",
+		"long",
+		decimal.NewFromInt(0),    // SL = 0 (want to remove)
+		decimal.NewFromInt(52000), // TP requested
+		&ContractInfo{PricePlace: 2},
+	)
+	require.NoError(t, err)
+	assert.False(t, modified, "extra-leg must fall back to cancel+recreate (Bug 1)")
+}
+
+// PR-4 (gemini HIGH): combined TP+SL plans (planType contains
+// "profit_loss") cannot be modified in-place with the single-trigger
+// body the endpoint accepts. Must fall back to cancel+recreate.
+func TestBitgetOrderExecutor_ModifyPositionTPSL_FallsBackOnCombinedPlan(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/order/orders-plan-pending":
+			_, _ = w.Write([]byte(`{
+				"code": "00000",
+				"msg": "ok",
+				"data": {
+					"entrustedList": [
+						{"orderId": "tpsl-1", "planType": "profit_loss", "holdSide": "long", "triggerPrice": "50000"}
+					]
+				}
+			}`))
+		case "/api/v2/mix/order/modify-tpsl-order":
+			t.Fatalf("modify-tpsl-order must NOT be called for combined TP+SL plans")
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	modified, err := executor.modifyPositionTPSL(
+		context.Background(),
+		"BTCUSDT",
+		"long",
+		decimal.NewFromInt(49000),
+		decimal.NewFromInt(52000),
+		&ContractInfo{PricePlace: 2},
+	)
+	require.NoError(t, err)
+	assert.False(t, modified, "combined plans must fall back to cancel+recreate")
 }
 
 // PR-4: modifyPositionTPSL on a position with no existing plans must

--- a/services/backend-api/internal/services/bitget_order_executor_test.go
+++ b/services/backend-api/internal/services/bitget_order_executor_test.go
@@ -1119,3 +1119,343 @@ func TestFormatPrice(t *testing.T) {
 		assert.Equal(t, tt.expected, result, "Price: %s", tt.price.String())
 	}
 }
+
+// PR-4: listPositionTPSLPlans now omits the planType query param to
+// catch all plan types (profit_plan/loss_plan/profit_loss/pos_profit/
+// pos_loss) and filters by holdSide client-side. This test guards
+// against regression of the W0-F secondary root cause.
+func TestBitgetOrderExecutor_ListPositionTPSLPlans_NoPlanTypeFilter(t *testing.T) {
+	var requestedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path + "?" + r.URL.RawQuery
+		_, _ = w.Write([]byte(`{
+			"code": "00000",
+			"msg": "ok",
+			"data": {
+				"entrustedList": [
+					{"orderId": "tp-1", "planType": "pos_profit", "holdSide": "long", "triggerPrice": "51000"},
+					{"orderId": "sl-1", "planType": "pos_loss", "holdSide": "long", "triggerPrice": "49000"},
+					{"orderId": "other-1", "planType": "pos_profit", "holdSide": "short", "triggerPrice": "1100"}
+				]
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	plans, err := executor.listPositionTPSLPlans(context.Background(), "BTCUSDT", "long")
+	require.NoError(t, err)
+	require.Len(t, plans, 2, "should filter to long holdSide only")
+	// Verify the request did NOT specify planType (regression guard).
+	assert.NotContains(t, requestedPath, "planType=",
+		"listPositionTPSLPlans must omit the planType filter to catch all plan types")
+	// Verify the returned IDs are the long-side ones.
+	ids := make([]string, 0, len(plans))
+	for _, p := range plans {
+		ids = append(ids, mapStringAny(p, "orderId", "orderID", "id"))
+	}
+	assert.ElementsMatch(t, []string{"tp-1", "sl-1"}, ids)
+}
+
+// PR-4: modifyPositionTPSL updates existing plan orders via the
+// /api/v2/mix/order/modify-tpsl-order endpoint. This test verifies
+// the per-plan modify request body format and the no-op skip when
+// the trigger price already matches.
+func TestBitgetOrderExecutor_ModifyPositionTPSL_SendsModifyRequestsForStalePlans(t *testing.T) {
+	var modifyRequests []map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v2/mix/order/orders-plan-pending":
+			_, _ = w.Write([]byte(`{
+				"code": "00000",
+				"msg": "ok",
+				"data": {
+					"entrustedList": [
+						{"orderId": "tp-1", "planType": "pos_profit", "holdSide": "long", "triggerPrice": "50000"},
+						{"orderId": "sl-1", "planType": "pos_loss", "holdSide": "long", "triggerPrice": "49500"}
+					]
+				}
+			}`))
+		case r.URL.Path == "/api/v2/mix/order/modify-tpsl-order":
+			body, _ := io.ReadAll(r.Body)
+			var payload map[string]interface{}
+			require.NoError(t, json.Unmarshal(body, &payload))
+			modifyRequests = append(modifyRequests, payload)
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":{}}`))
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	// Force the trigger price to differ from the mocked 50000/49500 so
+	// both plans are considered stale and trigger a modify call.
+	modified, err := executor.modifyPositionTPSL(
+		context.Background(),
+		"BTCUSDT",
+		"long",
+		decimal.NewFromInt(49000), // new SL trigger (was 49500)
+		decimal.NewFromInt(52000), // new TP trigger (was 50000)
+		&ContractInfo{PricePlace: 2},
+	)
+	require.NoError(t, err)
+	assert.True(t, modified, "modified should be true when at least one plan was updated")
+	require.Len(t, modifyRequests, 2, "should issue one modify per stale plan")
+
+	// Verify both request bodies carry the expected shape (orderId,
+	// triggerPrice, planType, mark_price triggerType).
+	orderIDs := make([]string, 0, 2)
+	for _, req := range modifyRequests {
+		orderIDs = append(orderIDs, req["orderId"].(string))
+		assert.Equal(t, "mark_price", req["triggerType"])
+		assert.Equal(t, "USDT-FUTURES", req["productType"])
+		assert.NotEmpty(t, req["triggerPrice"])
+		assert.NotEmpty(t, req["planType"])
+	}
+	assert.ElementsMatch(t, []string{"tp-1", "sl-1"}, orderIDs)
+}
+
+// PR-4: when both plans are already at the target price, the
+// modify path should be a no-op (no modify-tpsl-order requests).
+func TestBitgetOrderExecutor_ModifyPositionTPSL_SkipsPlansAlreadyAtTarget(t *testing.T) {
+	var modifyCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/order/orders-plan-pending":
+			// Trigger prices already match the targets we'll pass below.
+			_, _ = w.Write([]byte(`{
+				"code": "00000",
+				"msg": "ok",
+				"data": {
+					"entrustedList": [
+						{"orderId": "tp-1", "planType": "pos_profit", "holdSide": "long", "triggerPrice": "52000.00"},
+						{"orderId": "sl-1", "planType": "pos_loss", "holdSide": "long", "triggerPrice": "49000.00"}
+					]
+				}
+			}`))
+		case "/api/v2/mix/order/modify-tpsl-order":
+			modifyCalls++
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":{}}`))
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	modified, err := executor.modifyPositionTPSL(
+		context.Background(),
+		"BTCUSDT",
+		"long",
+		decimal.NewFromInt(49000),
+		decimal.NewFromInt(52000),
+		&ContractInfo{PricePlace: 2},
+	)
+	require.NoError(t, err)
+	assert.False(t, modified, "modified should be false when no plans changed")
+	assert.Equal(t, 0, modifyCalls, "no modify requests should be sent when triggers already match")
+}
+
+// PR-4: modifyPositionTPSL on a position with no existing plans must
+// return (false, nil) so the caller can fall through to
+// placePositionTPSL. This is the first-ever-sync case.
+func TestBitgetOrderExecutor_ModifyPositionTPSL_NoExistingPlans(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/order/orders-plan-pending":
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":{}}`))
+		case "/api/v2/mix/order/modify-tpsl-order":
+			t.Fatalf("modify-tpsl-order must not be called when no plans exist")
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	modified, err := executor.modifyPositionTPSL(
+		context.Background(),
+		"BTCUSDT",
+		"long",
+		decimal.NewFromInt(49000),
+		decimal.NewFromInt(52000),
+		&ContractInfo{PricePlace: 2},
+	)
+	require.NoError(t, err)
+	assert.False(t, modified)
+}
+
+// PR-4: SyncPositionProtection now tries modify-in-place first, and
+// only falls back to cancel+place when the modify path either errors
+// or returns modified=false (no plans existed). This test exercises
+// the happy modify path: no cancel and no place-pos-tpsl calls
+// should be made.
+func TestBitgetOrderExecutor_SyncPositionProtection_ModifyInPlaceHappyPath(t *testing.T) {
+	var modifyCalls, cancelCalls, placeCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/market/contracts":
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":[{
+				"sizeMultiplier":"1","minTradeNum":"1","volumePlace":"0","pricePlace":"2"
+			}]}`))
+		case "/api/v2/mix/order/orders-plan-pending":
+			// Existing plans with stale triggers → modify path applies.
+			_, _ = w.Write([]byte(`{
+				"code":"00000","msg":"ok","data":{"entrustedList":[
+					{"orderId":"tp-1","planType":"pos_profit","holdSide":"long","triggerPrice":"50000.00"},
+					{"orderId":"sl-1","planType":"pos_loss","holdSide":"long","triggerPrice":"49500.00"}
+				]}}`))
+		case "/api/v2/mix/order/modify-tpsl-order":
+			modifyCalls++
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":{}}`))
+		case "/api/v2/mix/order/cancel-plan-order":
+			cancelCalls++
+		case "/api/v2/mix/order/place-pos-tpsl":
+			placeCalls++
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	err := executor.SyncPositionProtection(
+		context.Background(),
+		"bitget",
+		ManagedOpenPosition{Symbol: "BTC/USDT", Side: "long", MarketType: "futures"},
+		decimal.NewFromInt(49000),
+		decimal.NewFromInt(52000),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, modifyCalls, "should modify both stale plans")
+	assert.Equal(t, 0, cancelCalls, "should NOT cancel when modify succeeds")
+	assert.Equal(t, 0, placeCalls, "should NOT place new plans when modify succeeds")
+}
+
+// PR-4: when no existing plans exist, SyncPositionProtection falls
+// through to place new plans. The cancel-plan-order call is a no-op
+// (no plans to cancel) so cancelCalls=0 is correct. The place path
+// runs to create the initial protection.
+func TestBitgetOrderExecutor_SyncPositionProtection_FallsBackToPlaceWhenNoPlans(t *testing.T) {
+	var cancelCalls, placeCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/market/contracts":
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":[{
+				"sizeMultiplier":"1","minTradeNum":"1","volumePlace":"0","pricePlace":"2"
+			}]}`))
+		case "/api/v2/mix/order/orders-plan-pending":
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":{}}`))
+		case "/api/v2/mix/order/cancel-plan-order":
+			cancelCalls++
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":{}}`))
+		case "/api/v2/mix/order/place-pos-tpsl":
+			placeCalls++
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok","data":{}}`))
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	err := executor.SyncPositionProtection(
+		context.Background(),
+		"bitget",
+		ManagedOpenPosition{Symbol: "BTC/USDT", Side: "long", MarketType: "futures"},
+		decimal.NewFromInt(49000),
+		decimal.NewFromInt(52000),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, cancelCalls, "cancel is a no-op when no plans exist")
+	assert.Equal(t, 1, placeCalls, "should place new plans when no existing ones")
+}
+
+// PR-4 (tertiary root cause): verifyFuturesTPSLActive now requires
+// BOTH a TP plan AND an SL plan to report "verified". A position
+// with only an SL plan must produce the "Partial TP/SL coverage" log
+// instead of the success log.
+func TestBitgetOrderExecutor_VerifyFuturesTPSLActive_RequiresBothTPAndSL(t *testing.T) {
+	tests := []struct {
+		name        string
+		plans       string
+		shouldCover bool
+	}{
+		{
+			name: "TP only — partial coverage",
+			plans: `{"code":"00000","msg":"ok","data":{"entrustedList":[
+				{"orderId":"tp-1","planType":"pos_profit","holdSide":"long","triggerPrice":"50000"}
+			]}}`,
+			shouldCover: false,
+		},
+		{
+			name: "SL only — partial coverage",
+			plans: `{"code":"00000","msg":"ok","data":{"entrustedList":[
+				{"orderId":"sl-1","planType":"pos_loss","holdSide":"long","triggerPrice":"49000"}
+			]}}`,
+			shouldCover: false,
+		},
+		{
+			name: "Both TP and SL — full coverage",
+			plans: `{"code":"00000","msg":"ok","data":{"entrustedList":[
+				{"orderId":"tp-1","planType":"pos_profit","holdSide":"long","triggerPrice":"50000"},
+				{"orderId":"sl-1","planType":"pos_loss","holdSide":"long","triggerPrice":"49000"}
+			]}}`,
+			shouldCover: true,
+		},
+		{
+			name: "profit_loss plan covers both",
+			plans: `{"code":"00000","msg":"ok","data":{"entrustedList":[
+				{"orderId":"tpsl-1","planType":"profit_loss","holdSide":"long","triggerPrice":"50000"}
+			]}}`,
+			shouldCover: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// No planType filter — the helper now omits it.
+				assert.NotContains(t, r.URL.RawQuery, "planType=")
+				_, _ = w.Write([]byte(tt.plans))
+			}))
+			defer server.Close()
+
+			executor := NewBitgetOrderExecutor("k", "s", "p")
+			executor.baseURL = server.URL
+
+			// We don't assert on stdout (captured by other tests);
+			// the function returns void. The contract is: the
+			// helper now requires BOTH TP and SL plans before
+			// logging the "✅ verified" success line. This
+			// test guards the underlying listPositionTPSLPlans
+			// call and the hasTP/hasSL decomposition, not the
+			// log line itself.
+			plans, err := executor.listPositionTPSLPlans(context.Background(), "BTCUSDT", "long")
+			require.NoError(t, err)
+			hasTP, hasSL := false, false
+			for _, p := range plans {
+				planType := strings.ToLower(strings.TrimSpace(mapStringAny(p, "planType", "plan_type")))
+				// Same decomposition as production: a "profit_loss" plan
+				// covers BOTH legs (combined TP+SL placed via
+				// place-pos-tpsl), so it sets hasTP AND hasSL.
+				isTP := strings.Contains(planType, "profit") || strings.Contains(planType, "surplus")
+				isSL := strings.Contains(planType, "loss")
+				if isTP {
+					hasTP = true
+				}
+				if isSL {
+					hasSL = true
+				}
+			}
+			covered := hasTP && hasSL
+			assert.Equal(t, tt.shouldCover, covered,
+				"hasTP=%t hasSL=%t shouldCover=%t", hasTP, hasSL, tt.shouldCover)
+		})
+	}
+}

--- a/services/backend-api/internal/services/bitget_order_executor_test.go
+++ b/services/backend-api/internal/services/bitget_order_executor_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -1173,8 +1175,8 @@ func TestBitgetOrderExecutor_ModifyPositionTPSL_SendsModifyRequestsForStalePlans
 				"msg": "ok",
 				"data": {
 					"entrustedList": [
-						{"orderId": "tp-1", "planType": "pos_profit", "holdSide": "long", "triggerPrice": "50000"},
-						{"orderId": "sl-1", "planType": "pos_loss", "holdSide": "long", "triggerPrice": "49500"}
+						{"orderId": "tp-1", "planType": "pos_profit", "holdSide": "long", "triggerPrice": "50000", "size": "0.001"},
+						{"orderId": "sl-1", "planType": "pos_loss", "holdSide": "long", "triggerPrice": "49500", "size": "0.001"}
 					]
 				}
 			}`))
@@ -1208,7 +1210,8 @@ func TestBitgetOrderExecutor_ModifyPositionTPSL_SendsModifyRequestsForStalePlans
 	require.Len(t, modifyRequests, 2, "should issue one modify per stale plan")
 
 	// Verify both request bodies carry the expected shape (orderId,
-	// triggerPrice, planType, mark_price triggerType).
+	// triggerPrice, planType, mark_price triggerType, size from the
+	// existing plan — Bitget modify-tpsl-order requires size).
 	orderIDs := make([]string, 0, 2)
 	for _, req := range modifyRequests {
 		orderIDs = append(orderIDs, req["orderId"].(string))
@@ -1216,6 +1219,7 @@ func TestBitgetOrderExecutor_ModifyPositionTPSL_SendsModifyRequestsForStalePlans
 		assert.Equal(t, "USDT-FUTURES", req["productType"])
 		assert.NotEmpty(t, req["triggerPrice"])
 		assert.NotEmpty(t, req["planType"])
+		assert.Equal(t, "0.001", req["size"], "modify-tpsl-order body must carry the plan's size")
 	}
 	assert.ElementsMatch(t, []string{"tp-1", "sl-1"}, orderIDs)
 }
@@ -1425,8 +1429,8 @@ func TestBitgetOrderExecutor_SyncPositionProtection_ModifyInPlaceHappyPath(t *te
 			// Existing plans with stale triggers → modify path applies.
 			_, _ = w.Write([]byte(`{
 				"code":"00000","msg":"ok","data":{"entrustedList":[
-					{"orderId":"tp-1","planType":"pos_profit","holdSide":"long","triggerPrice":"50000.00"},
-					{"orderId":"sl-1","planType":"pos_loss","holdSide":"long","triggerPrice":"49500.00"}
+					{"orderId":"tp-1","planType":"pos_profit","holdSide":"long","triggerPrice":"50000.00","size":"0.001"},
+					{"orderId":"sl-1","planType":"pos_loss","holdSide":"long","triggerPrice":"49500.00","size":"0.001"}
 				]}}`))
 		case "/api/v2/mix/order/modify-tpsl-order":
 			modifyCalls++
@@ -1574,6 +1578,80 @@ func TestBitgetOrderExecutor_VerifyFuturesTPSLActive_RequiresBothTPAndSL(t *test
 			covered := hasTP && hasSL
 			assert.Equal(t, tt.shouldCover, covered,
 				"hasTP=%t hasSL=%t shouldCover=%t", hasTP, hasSL, tt.shouldCover)
+		})
+	}
+}
+
+func TestBitgetOrderExecutor_VerifyFuturesTPSLActive_ExpectationAware(t *testing.T) {
+	tests := []struct {
+		name        string
+		plans       string
+		expectTP    bool
+		expectSL    bool
+		expectEmoji string
+	}{
+		{
+			name: "caller expected both, only TP present — partial",
+			plans: `{"code":"00000","msg":"ok","data":{"entrustedList":[
+				{"orderId":"tp-1","planType":"pos_profit","holdSide":"long","triggerPrice":"50000"}
+			]}}`,
+			expectTP:    true,
+			expectSL:    true,
+			expectEmoji: "⚠️",
+		},
+		{
+			name: "caller expected only TP, only TP present — verified",
+			plans: `{"code":"00000","msg":"ok","data":{"entrustedList":[
+				{"orderId":"tp-1","planType":"pos_profit","holdSide":"long","triggerPrice":"50000"}
+			]}}`,
+			expectTP:    true,
+			expectSL:    false,
+			expectEmoji: "✅",
+		},
+		{
+			name: "caller expected only SL, only SL present — verified",
+			plans: `{"code":"00000","msg":"ok","data":{"entrustedList":[
+				{"orderId":"sl-1","planType":"pos_loss","holdSide":"long","triggerPrice":"49000"}
+			]}}`,
+			expectTP:    false,
+			expectSL:    true,
+			expectEmoji: "✅",
+		},
+		{
+			name: "caller expected both, both present — verified",
+			plans: `{"code":"00000","msg":"ok","data":{"entrustedList":[
+				{"orderId":"tp-1","planType":"pos_profit","holdSide":"long","triggerPrice":"50000"},
+				{"orderId":"sl-1","planType":"pos_loss","holdSide":"long","triggerPrice":"49000"}
+			]}}`,
+			expectTP:    true,
+			expectSL:    true,
+			expectEmoji: "✅",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tt.plans))
+			}))
+			defer server.Close()
+
+			executor := NewBitgetOrderExecutor("k", "s", "p")
+			executor.baseURL = server.URL
+
+			// Capture stdout to verify the log message reflects expectations.
+			oldStdout := os.Stdout
+			rPipe, wPipe, _ := os.Pipe()
+			os.Stdout = wPipe
+			executor.verifyFuturesTPSLActive(context.Background(), "BTCUSDT", "long", tt.expectTP, tt.expectSL)
+			_ = wPipe.Close()
+			os.Stdout = oldStdout
+			var buf bytes.Buffer
+			_, _ = io.Copy(&buf, rPipe)
+			output := buf.String()
+
+			assert.Contains(t, output, tt.expectEmoji,
+				"expected %q in stdout for expectTP=%t expectSL=%t", tt.expectEmoji, tt.expectTP, tt.expectSL)
 		})
 	}
 }

--- a/services/backend-api/internal/services/bitget_order_executor_test.go
+++ b/services/backend-api/internal/services/bitget_order_executor_test.go
@@ -1334,7 +1334,7 @@ func TestBitgetOrderExecutor_ModifyPositionTPSL_FallsBackWhenSLExtra(t *testing.
 		context.Background(),
 		"BTCUSDT",
 		"long",
-		decimal.NewFromInt(0),    // SL = 0 (want to remove)
+		decimal.NewFromInt(0),     // SL = 0 (want to remove)
 		decimal.NewFromInt(52000), // TP requested
 		&ContractInfo{PricePlace: 2},
 	)

--- a/services/backend-api/internal/services/bitget_order_executor_test.go
+++ b/services/backend-api/internal/services/bitget_order_executor_test.go
@@ -1383,6 +1383,57 @@ func TestBitgetOrderExecutor_ModifyPositionTPSL_FallsBackOnCombinedPlan(t *testi
 	assert.False(t, modified, "combined plans must fall back to cancel+recreate")
 }
 
+// PR-4 (Oracle iteration 7 Blocker 2): if any existing plan lacks a
+// size field, modifyPositionTPSL must NOT return true. The pre-flight
+// checks leg coverage but not per-plan data integrity, so a plan can
+// pass pre-flight yet still be unmodifiable in place. Returning true
+// here would leave the caller believing the position is synced when
+// one leg was never updated — a silent partial-sync bug that could
+// cause real financial loss. The function must fall back to
+// cancel+recreate so the caller can establish a clean state.
+func TestBitgetOrderExecutor_ModifyPositionTPSL_FallsBackWhenPlanLacksSize(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/order/orders-plan-pending":
+			// Both plans exist (pre-flight passes), but the SL
+			// plan has no size field. The TP plan has a valid
+			// size and a trigger price that differs from the
+			// requested target, so it would normally be modified
+			// in place under the old behavior.
+			_, _ = w.Write([]byte(`{
+				"code": "00000",
+				"msg": "ok",
+				"data": {
+					"entrustedList": [
+						{"orderId": "tp-1", "planType": "pos_profit", "holdSide": "long", "triggerPrice": "50000", "size": "0.001"},
+						{"orderId": "sl-1", "planType": "pos_loss", "holdSide": "long", "triggerPrice": "49000"}
+					]
+				}
+			}`))
+		case "/api/v2/mix/order/modify-tpsl-order":
+			// If modify-tpsl-order IS called (for the TP), return
+			// success. The function should still return false
+			// because the SL plan lacks a size.
+			_, _ = w.Write([]byte(`{"code": "00000", "msg": "ok", "data": {}}`))
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	modified, err := executor.modifyPositionTPSL(
+		context.Background(),
+		"BTCUSDT",
+		"long",
+		decimal.NewFromInt(48000), // SL requested (differs from existing 49000)
+		decimal.NewFromInt(52000), // TP requested (differs from existing 50000)
+		&ContractInfo{PricePlace: 2},
+	)
+	require.NoError(t, err)
+	assert.False(t, modified, "size-missing plan must fall back to cancel+recreate (partial sync bug)")
+}
+
 // PR-4: modifyPositionTPSL on a position with no existing plans must
 // return (false, nil) so the caller can fall through to
 // placePositionTPSL. This is the first-ever-sync case.

--- a/services/backend-api/internal/services/bitget_order_executor_test.go
+++ b/services/backend-api/internal/services/bitget_order_executor_test.go
@@ -1655,3 +1655,40 @@ func TestBitgetOrderExecutor_VerifyFuturesTPSLActive_ExpectationAware(t *testing
 		})
 	}
 }
+
+func TestBitgetOrderExecutor_CancelExistingPositionTPSL_SkipsNonTPSLPlans(t *testing.T) {
+	var cancelledOrderIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/mix/order/orders-plan-pending":
+			_, _ = w.Write([]byte(`{
+				"code":"00000","msg":"ok","data":{"entrustedList":[
+					{"orderId":"tp-1","planType":"pos_profit","holdSide":"long","triggerPrice":"50000"},
+					{"orderId":"sl-1","planType":"pos_loss","holdSide":"long","triggerPrice":"49000"},
+					{"orderId":"entry-1","planType":"track_plan","holdSide":"long","triggerPrice":"48000"},
+					{"orderId":"trail-1","planType":"moving_plan","holdSide":"long","triggerPrice":"51000"}
+				]}}`))
+		case "/api/v2/mix/order/cancel-plan-order":
+			body, _ := io.ReadAll(r.Body)
+			var payload struct {
+				OrderIDList []map[string]string `json:"orderIdList"`
+			}
+			_ = json.Unmarshal(body, &payload)
+			for _, id := range payload.OrderIDList {
+				cancelledOrderIDs = append(cancelledOrderIDs, id["orderId"])
+			}
+			_, _ = w.Write([]byte(`{"code":"00000","msg":"ok"}`))
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	executor := NewBitgetOrderExecutor("k", "s", "p")
+	executor.baseURL = server.URL
+
+	err := executor.cancelExistingPositionTPSL(context.Background(), "BTCUSDT", "long")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"tp-1", "sl-1"}, cancelledOrderIDs,
+		"should only cancel TP/SL plans, not entry/trailing plans")
+}


### PR DESCRIPTION
## Summary

PR-4 of the ULTRAWORK decomposition. Addresses all 3 root causes
identified in docs/bitget-tp-investigation.md (W0-F pre-work,
already cherry-picked on this branch).

## What this fixes

### Primary root cause: cancel+recreate → modify-in-place

The legacy `SyncPositionProtection` flow at
`bitget_order_executor.go:1268-1274` fell back to
`placePositionTPSLSplit` (two separate `place-pos-tpsl` calls)
when the combined TP+SL call failed. This created **two separate
plan orders** on Bitget; the second call may overwrite the first
and the UI may show only the SL leg.

**Fix:** new `modifyPositionTPSL` method POSTs to the
`/api/v2/mix/order/modify-tpsl-order` endpoint, updating existing
plans in place. `SyncPositionProtection` tries modify-in-place
FIRST and falls back to the legacy cancel+place path only when
modify returns `false` (no existing plans) or errors. The
cancel+recreate path is bypassed entirely when modify succeeds.

### Secondary root cause: `planType=profit_loss` filter missed position-level plans

`cancelExistingPositionTPSL` queried
`orders-plan-pending?planType=profit_loss`, which silently skipped
`pos_profit`/`pos_loss` position-level plans. The newly-introduced
`listPositionTPSLPlans` helper **omits the planType query param**
and filters by holdSide client-side, catching all plan types
(`profit_plan`/`loss_plan`/`profit_loss`/`pos_profit`/`pos_loss`)
in a single round-trip.

### Tertiary root cause: `verifyFuturesTPSLActive` only checked count > 0

A position with only an SL plan (or only a TP plan) would log
`✅ verified` but leave the opposite leg unprotected. The function
now uses the broadened `listPositionTPSLPlans` helper and requires
**BOTH** a surplus/TP plan AND a loss/SL plan before logging
`verified`. A `profit_loss` planType correctly counts as covering
both legs (combined TP+SL placed via `place-pos-tpsl`).

## Pre-review

- services+autonomy+handlers+ai packages all green
- gofmt clean, go vet clean, golangci-lint 0 issues
- 8 new/updated sub-tests (5 test functions):
  * `TestBitgetOrderExecutor_ListPositionTPSLPlans_NoPlanTypeFilter`
    — regression guard: query must omit planType
  * `TestBitgetOrderExecutor_ModifyPositionTPSL_SendsModifyRequestsForStalePlans`
    — happy path with stale triggers
  * `TestBitgetOrderExecutor_ModifyPositionTPSL_SkipsPlansAlreadyAtTarget`
    — no-op skip when triggers already match
  * `TestBitgetOrderExecutor_ModifyPositionTPSL_NoExistingPlans`
    — first-ever-sync case returns `(false, nil)`
  * `TestBitgetOrderExecutor_SyncPositionProtection_ModifyInPlaceHappyPath`
    — full flow: modify succeeds, no cancel/place
  * `TestBitgetOrderExecutor_SyncPositionProtection_FallsBackToPlaceWhenNoPlans`
    — full flow: no plans → place runs
  * `TestBitgetOrderExecutor_VerifyFuturesTPSLActive_RequiresBothTPAndSL`
    — 4 sub-tests: TP-only, SL-only, both, profit_loss-covers-both

## bd issues

- Closes NeuraTrade-yeso (P0 Bitget TP visibility). Note: the
  `modify-tpsl-order` request body format is my best inference
  from the existing `place-pos-tpsl` and `cancel-plan-order`
  patterns; final verification requires a Bitget testnet run
  (no sandbox available locally). The conservative error handling
  ensures the function falls back to the legacy cancel+place path
  on any API error, so a body-format mismatch would only disable
  the optimize-path; existing positions stay protected via
  the fallback.

## Out of scope

- No changes to the dynamic protection manager's reconcile
  cadence or to the Bitget CCXT integration. The fix is entirely
  within the bitget_order_executor package and is a drop-in
  replacement for the existing sync flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Bitget take-profit/stop-loss order synchronization with improved verification and in-place modification support.
  * Improved detection and recovery from orphaned stop-loss plans during order synchronization.
  * Optimized order handling to attempt in-place modifications before recreating orders.

* **Tests**
  * Added comprehensive test coverage for stop-loss/take-profit plan management and synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->