### PR TITLE
feat(cli): agent runtime subcommand tree (PR-6 skeleton)

### DIFF
--- a/cmd/neuratrade-cli/agent.go
+++ b/cmd/neuratrade-cli/agent.go
@@ -122,9 +122,11 @@ func readPIDFile(path string) (alive bool, pidStr string, err error) {
 	return true, pidStr, nil
 }
 
-// tailFile returns the last n lines of the file. Uses a streaming
-// reader to avoid loading the entire log into memory. If n <= 0,
-// returns an empty slice.
+// tailFile returns the last n lines of the file in order. Streams
+// the file line-by-line so memory usage stays O(n) — agent log files
+// can grow to hundreds of MB over a long-running session and
+// reading the whole file would blow up the CLI process. If n <= 0,
+// returns an empty slice. If n >= total-line-count, returns all lines.
 func tailFile(path string, n int) ([]string, error) {
 	if n <= 0 {
 		return nil, nil
@@ -135,32 +137,28 @@ func tailFile(path string, n int) ([]string, error) {
 	}
 	defer f.Close()
 
-	// Two-pass tail: first count lines, then read tail. For very large
-	// logs a reverse-seek would be faster, but PR-6 only needs the
-	// last ~50 lines so the simple two-pass is fine.
-	all, err := readAllLines(f)
-	if err != nil {
-		return nil, err
-	}
-	if len(all) <= n {
-		return all, nil
-	}
-	return all[len(all)-n:], nil
-}
-
-func readAllLines(f *os.File) ([]string, error) {
 	scanner := bufio.NewScanner(f)
 	// Allow long log lines (default bufio buffer is 64KB; agent log
 	// lines can be larger when a full event payload is dumped).
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	var lines []string
+
+	// Keep the most recent n lines in a slice that grows up to capacity
+	// n; once full, shift the slice left on each new line to keep only
+	// the trailing window. This is O(n) per line for the typical n=20
+	// case, which is negligible compared to the I/O cost of the
+	// scanner.
+	ring := make([]string, 0, n)
 	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
+		if len(ring) < n {
+			ring = append(ring, scanner.Text())
+		} else {
+			ring = append(ring[1:], scanner.Text())
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-	return lines, nil
+	return ring, nil
 }
 
 // agentCommand builds the urfave/cli/v2 Command tree for the

--- a/cmd/neuratrade-cli/agent.go
+++ b/cmd/neuratrade-cli/agent.go
@@ -24,14 +24,20 @@ import (
 // prints the exact command line they need to invoke, including the
 // relevant NEURATRADE_* env vars to set.
 func agentRunAction(cCtx *cli.Context) error {
-	fmt.Println("The agent service is managed by the gateway.")
-	fmt.Println("To start it as part of the full stack:")
+	fmt.Println("The agent service is NOT yet managed by `neuratrade gateway`.")
+	fmt.Println("`gateway start` only launches backend, ccxt, and telegram;")
+	fmt.Println("the agent-control process must be started separately.")
 	fmt.Println()
-	fmt.Println("    neuratrade gateway start")
+	fmt.Println("For a standalone agent run, invoke the agent-control binary directly")
+	fmt.Println("from its own module (the repo root has no go.mod for the gateway):")
 	fmt.Println()
-	fmt.Println("For a standalone agent run, invoke the binary directly:")
+	fmt.Println("    cd services/agent-control")
+	fmt.Println("    go run ./cmd/agent")
 	fmt.Println()
-	fmt.Println("    go run ./services/agent-control/cmd/agent")
+	fmt.Println("Or build and run the agent binary directly:")
+	fmt.Println()
+	fmt.Println("    go -C services/agent-control build -o bin/neuratrade-agent ./cmd/agent")
+	fmt.Println("    ./services/agent-control/bin/neuratrade-agent")
 	fmt.Println()
 	fmt.Println("Required environment variables (read from .env or config.json):")
 	fmt.Println("    BACKEND_API_URL          (default: http://localhost:8080)")
@@ -199,5 +205,6 @@ func agentCommand() *cli.Command {
 }
 
 // Compile-time assertion that agentCommand returns a non-nil *cli.Command.
-// This catches refactors that accidentally break the command tree.
-var _ = agentCommand
+// This catches refactors that accidentally break the command tree by
+// failing compilation if the function is removed or its return type changes.
+var _ *cli.Command = agentCommand()

--- a/cmd/neuratrade-cli/agent.go
+++ b/cmd/neuratrade-cli/agent.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/urfave/cli/v2"
+)
+
+// agentRunAction is the urfave/cli/v2 Action for `neuratrade agent run`.
+// PR-6 skeleton: this command surfaces the documented way to launch
+// the agent-control service, but does not itself spawn the process —
+// that is the gateway's job (see `neuratrade gateway start`). The
+// rationale is that the agent runtime requires the full gateway
+// supervision graph (backend health probes, gateway-state.json
+// writes, log rotation) and the CLI should not bypass that.
+//
+// If the operator really wants a standalone agent run, the command
+// prints the exact command line they need to invoke, including the
+// relevant NEURATRADE_* env vars to set.
+func agentRunAction(cCtx *cli.Context) error {
+	fmt.Println("The agent service is managed by the gateway.")
+	fmt.Println("To start it as part of the full stack:")
+	fmt.Println()
+	fmt.Println("    neuratrade gateway start")
+	fmt.Println()
+	fmt.Println("For a standalone agent run, invoke the binary directly:")
+	fmt.Println()
+	fmt.Println("    go run ./services/agent-control/cmd/agent")
+	fmt.Println()
+	fmt.Println("Required environment variables (read from .env or config.json):")
+	fmt.Println("    BACKEND_API_URL          (default: http://localhost:8080)")
+	fmt.Println("    BACKEND_EVENT_URL        (default: http://localhost:8080/api/v1/agent/events)")
+	fmt.Println("    ADMIN_API_KEY            (no default; required for write endpoints)")
+	fmt.Println("    POLICY_MAX_ORDER_SIZE    (default: 1.0)")
+	fmt.Println("    POLICY_MAX_LEVERAGE       (default: 5.0)")
+	fmt.Println("    POLICY_MAX_DAILY_LOSS     (default: 1000.0)")
+	return nil
+}
+
+// agentStatusAction is the urfave/cli/v2 Action for `neuratrade agent
+// status`. PR-6 skeleton: it reads ~/.neuratrade/pids/agent.pid (if
+// present) and reports whether the agent process is alive, then tails
+// the last N lines of ~/.neuratrade/logs/agent.log. The PID file is
+// expected to be written by the gateway once it learns to manage the
+// agent service; until that lands, this command reports
+// 'not-managed' and exits 0 (not an error).
+func agentStatusAction(cCtx *cli.Context) error {
+	home := defaultNeuraTradeHome()
+	pidPath := filepath.Join(home, "pids", "agent.pid")
+	logPath := filepath.Join(home, "logs", "agent.log")
+	tailLines := cCtx.Int("tail")
+
+	fmt.Println("🤖 NeuraTrade Agent Status")
+	fmt.Println("============================")
+	fmt.Println()
+
+	pidAlive, pidStr, pidErr := readPIDFile(pidPath)
+	switch {
+	case pidErr == nil && pidAlive:
+		fmt.Printf("Process: RUNNING (PID %s)\n", pidStr)
+		fmt.Printf("PID file: %s\n", pidPath)
+	case pidErr == nil && !pidAlive:
+		fmt.Printf("Process: STALE PID (PID %s not alive)\n", pidStr)
+		fmt.Printf("PID file: %s\n", pidPath)
+	default:
+		fmt.Println("Process: NOT MANAGED")
+		fmt.Println("  (no agent.pid file — gateway does not yet supervise the agent service)")
+		fmt.Println("  Run `neuratrade agent run` for setup instructions.")
+	}
+
+	fmt.Println()
+	fmt.Printf("Log file: %s\n", logPath)
+	if _, err := os.Stat(logPath); err == nil {
+		lines, readErr := tailFile(logPath, tailLines)
+		if readErr != nil {
+			fmt.Printf("(failed to read log: %v)\n", readErr)
+		} else if len(lines) == 0 {
+			fmt.Println("(log file is empty)")
+		} else {
+			fmt.Printf("Last %d lines:\n", len(lines))
+			for _, line := range lines {
+				fmt.Printf("  %s\n", line)
+			}
+		}
+	} else {
+		fmt.Println("(log file does not exist yet)")
+	}
+	return nil
+}
+
+// readPIDFile reads a PID file and reports whether the process is
+// still alive via signal 0. Returns (alive, pid-string, error). The
+// error is non-nil only when the file cannot be read (not when the
+// process is dead). The PID is returned as a string so the caller
+// can echo it in the status output even when alive=false.
+func readPIDFile(path string) (alive bool, pidStr string, err error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false, "", err
+	}
+	pidStr = strings.TrimSpace(string(content))
+	pid, convErr := strconv.Atoi(pidStr)
+	if convErr != nil {
+		return false, pidStr, fmt.Errorf("invalid pid in %s: %q", path, pidStr)
+	}
+	proc, findErr := os.FindProcess(pid)
+	if findErr != nil {
+		// On Unix, FindProcess always succeeds (the process object
+		// exists regardless of liveness). On other platforms it may
+		// fail for non-existent PIDs; treat that as not-alive.
+		return false, pidStr, nil
+	}
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		return false, pidStr, nil
+	}
+	return true, pidStr, nil
+}
+
+// tailFile returns the last n lines of the file. Uses a streaming
+// reader to avoid loading the entire log into memory. If n <= 0,
+// returns an empty slice.
+func tailFile(path string, n int) ([]string, error) {
+	if n <= 0 {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// Two-pass tail: first count lines, then read tail. For very large
+	// logs a reverse-seek would be faster, but PR-6 only needs the
+	// last ~50 lines so the simple two-pass is fine.
+	all, err := readAllLines(f)
+	if err != nil {
+		return nil, err
+	}
+	if len(all) <= n {
+		return all, nil
+	}
+	return all[len(all)-n:], nil
+}
+
+func readAllLines(f *os.File) ([]string, error) {
+	scanner := bufio.NewScanner(f)
+	// Allow long log lines (default bufio buffer is 64KB; agent log
+	// lines can be larger when a full event payload is dumped).
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
+}
+
+// agentCommand builds the urfave/cli/v2 Command tree for the
+// `neuratrade agent` subcommand. The subcommand is registered in
+// main.go's Commands slice alongside `gateway`, `prompt`, `backtest`.
+//
+// PR-6 skeleton surface:
+//   agent run    — print setup instructions (no process spawn)
+//   agent status — show PID file + last N log lines
+//
+// Future PRs can add `agent stop`, `agent inspect` (dump policy +
+// playbook config), and `agent run --once <playbook>` (one-shot
+// playbook execution).
+func agentCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "agent",
+		Usage: "Manage the autonomous agent runtime",
+		Subcommands: []*cli.Command{
+			{
+				Name:   "run",
+				Usage:  "Show how to launch the agent service (managed by the gateway)",
+				Action: agentRunAction,
+			},
+			{
+				Name:   "status",
+				Usage:  "Show agent runtime status (PID + recent log lines)",
+				Action: agentStatusAction,
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "tail",
+						Usage: "number of recent log lines to display",
+						Value: 20,
+					},
+				},
+			},
+		},
+	}
+}
+
+// Compile-time assertion that agentCommand returns a non-nil *cli.Command.
+// This catches refactors that accidentally break the command tree.
+var _ = agentCommand

--- a/cmd/neuratrade-cli/main.go
+++ b/cmd/neuratrade-cli/main.go
@@ -514,6 +514,12 @@ func main() {
 		},
 	}
 
+	// Add agent command separately (PR-6) — it's a skeleton with 2
+	// subcommands (run / status) that establish the CLI surface for the
+	// agent-control service. The full implementation will be added in
+	// follow-up PRs once the gateway learns to manage the agent process.
+	app.Commands = append(app.Commands, agentCommand())
+
 	// Add autonomous command separately to avoid struct literal error
 	app.Commands = append(app.Commands, &cli.Command{
 		Name:  "autonomous",

--- a/cmd/neuratrade-cli/main_test.go
+++ b/cmd/neuratrade-cli/main_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -36,8 +37,94 @@ func TestNewAPIClient(t *testing.T) {
 	client := NewAPIClient("http://example.com", "test-key")
 
 	assert.Equal(t, "http://example.com", client.BaseURL)
-	assert.Equal(t, "test-key", client.APIKey)
 	assert.NotNil(t, client.HTTPClient)
+}
+
+// PR-6: readPIDFile treats a missing file as an error (the caller uses
+// the error to decide whether to print 'NOT MANAGED' vs 'STALE PID').
+// A non-existent PID reports alive=false without an error (the file
+// was readable, but the process is gone). A current process's own
+// PID reports alive=true. The PID is echoed back as a string for the
+// status output.
+func TestReadPIDFile(t *testing.T) {
+	t.Run("missing file returns error", func(t *testing.T) {
+		alive, pidStr, err := readPIDFile(filepath.Join(t.TempDir(), "nope.pid"))
+		assert.Error(t, err)
+		assert.False(t, alive)
+		assert.Empty(t, pidStr)
+	})
+	t.Run("current process PID is alive", func(t *testing.T) {
+		pidFile := filepath.Join(t.TempDir(), "self.pid")
+		pid := os.Getpid()
+		require.NoError(t, os.WriteFile(pidFile, []byte(strconv.Itoa(pid)), 0o600))
+		alive, pidStr, err := readPIDFile(pidFile)
+		assert.NoError(t, err)
+		assert.True(t, alive, "current process PID %d must be alive", pid)
+		assert.Equal(t, strconv.Itoa(pid), pidStr)
+	})
+	t.Run("garbage PID is invalid", func(t *testing.T) {
+		pidFile := filepath.Join(t.TempDir(), "garbage.pid")
+		require.NoError(t, os.WriteFile(pidFile, []byte("not-a-number"), 0o600))
+		_, _, err := readPIDFile(pidFile)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid pid")
+	})
+	t.Run("stale PID reports not-alive", func(t *testing.T) {
+		// Use a PID that's extremely unlikely to be alive (Unix PIDs
+		// are typically capped well below 1<<30; 1<<31 is reserved
+		// for kernel use and never assigned to a userspace process).
+		pidFile := filepath.Join(t.TempDir(), "stale.pid")
+		require.NoError(t, os.WriteFile(pidFile, []byte("2147483647"), 0o600))
+		alive, pidStr, err := readPIDFile(pidFile)
+		assert.NoError(t, err)
+		assert.False(t, alive)
+		assert.Equal(t, "2147483647", pidStr)
+	})
+}
+
+// PR-6: tailFile returns the last n lines of a file in order. n<=0
+// returns an empty slice. Missing file returns an error.
+func TestTailFile(t *testing.T) {
+	t.Run("returns last n lines in order", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "log.txt")
+		content := "line1\nline2\nline3\nline4\nline5\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		lines, err := tailFile(path, 3)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"line3", "line4", "line5"}, lines)
+	})
+	t.Run("n=0 returns empty slice without error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "log.txt")
+		require.NoError(t, os.WriteFile(path, []byte("a\nb\n"), 0o600))
+		lines, err := tailFile(path, 0)
+		assert.NoError(t, err)
+		assert.Empty(t, lines)
+	})
+	t.Run("n>=total returns all lines", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "log.txt")
+		require.NoError(t, os.WriteFile(path, []byte("a\nb\n"), 0o600))
+		lines, err := tailFile(path, 10)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"a", "b"}, lines)
+	})
+	t.Run("missing file returns error", func(t *testing.T) {
+		_, err := tailFile(filepath.Join(t.TempDir(), "nope.txt"), 5)
+		assert.Error(t, err)
+	})
+}
+
+// PR-6: agentCommand returns a non-nil *cli.Command with both the
+// 'run' and 'status' subcommands registered. This is a smoke test
+// — the heavy lifting is in agentRunAction/agentStatusAction.
+func TestAgentCommand(t *testing.T) {
+	cmd := agentCommand()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "agent", cmd.Name)
+	names := make([]string, 0, len(cmd.Subcommands))
+	for _, sub := range cmd.Subcommands {
+		names = append(names, sub.Name)
+	}
+	assert.ElementsMatch(t, []string{"run", "status"}, names)
 }
 
 func TestGetBaseURL(t *testing.T) {

--- a/cmd/neuratrade-cli/main_test.go
+++ b/cmd/neuratrade-cli/main_test.go
@@ -37,6 +37,7 @@ func TestNewAPIClient(t *testing.T) {
 	client := NewAPIClient("http://example.com", "test-key")
 
 	assert.Equal(t, "http://example.com", client.BaseURL)
+	assert.Equal(t, "test-key", client.APIKey)
 	assert.NotNil(t, client.HTTPClient)
 }
 


### PR DESCRIPTION
## Summary

PR-6 of the ULTRAWORK decomposition. Establishes the CLI surface for
the agent-control service with 2 subcommands: `agent run` (prints
setup instructions) and `agent status` (reads PID file + tails log).

## Why a skeleton (not full implementation)

The original ULTRAWORK plan estimated ~800 LoC for a full agent-harness
CLI with real backend integration. Two constraints push this PR to a
skeleton scope:

1. The agent-control service does not yet expose an HTTP or gRPC
   API. It runs as a separate Go process that consumes events and
   runs playbooks. Real CLI ↔ agent integration requires adding
   such an API, which is a larger architectural change.
2. The agent service is not yet managed by the gateway (the
   `gateway start` command doesn't include it). A standalone
   `agent run` would bypass the gateway's supervision graph
   (backend health probes, gateway-state.json writes, log rotation).

So this PR establishes the CLI surface and provides
operator-friendly diagnostics (`status` tailing the log file) while
documenting the gateway-managed launch path. Full integration
follows once the gateway learns to manage the agent process.

## What's in this PR

- `cmd/neuratrade-cli/agent.go` (new): 2 subcommands + helpers.
- `cmd/neuratrade-cli/main.go`: register `agentCommand()` in the
  Commands slice.
- `cmd/neuratrade-cli/main_test.go`: 9 new sub-tests.

## Tests (9 new sub-tests)

- `TestReadPIDFile` (4 sub-tests): missing file → error;
  current process PID → alive; garbage content → error; stale PID
  → not-alive.
- `TestTailFile` (4 sub-tests): returns last N lines in order; n=0
  returns empty slice; n≥total returns all lines; missing file
  returns error.
- `TestAgentCommand`: smoke test confirming the `run` and
  `status` subcommands are registered on the agent command.

## Manual QA

Verified via the built binary at `/tmp/neuratrade`:
- `--help` shows the `agent` subcommand
- `agent --help` shows the two subcommands with descriptions
- `agent status` (no PID file) reports 'NOT MANAGED' + log file
  path
- `agent run` prints setup instructions with all required env vars

## Pre-review

- go build clean
- 9 new sub-tests pass
- The pre-existing `TestDefaultCLIAIProviderConfigReturnsCurrentZAIDefaults`
  failure is unrelated to this PR (verified failing on main as well)

## Out of scope (deferred to follow-up PRs)

- `agent stop` subcommand (requires a working gateway PID + signal
  pattern).
- `agent inspect` subcommand (dump policy + playbook config).
- `agent run --once <playbook>` one-shot playbook execution.
- Integration with a future agent-control HTTP/gRPC API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)