### PR TITLE
[codex] add runtime config doctor and installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NC=\033[0m
 
 .PHONY: help all go-env-setup proto-gen mod-download build services-setup telegram-setup \
 	test test-backend test-cli test-frontend lint fmt fmt-check typecheck coverage-check \
-	test-scripts run logs logs-all scalping-soak ai-scalping-probe bd-close-qa
+	test-scripts run logs logs-all scalping-soak ai-scalping-probe install-cli update-cli bd-close-qa
 
 all: build
 
@@ -73,6 +73,12 @@ build: mod-download services-setup ## Build backend binaries
 		'exec bun run index.ts "$$@"' > bin/telegram-service
 	@chmod +x bin/telegram-service
 	@echo "$(GREEN)Build complete: bin/neuratrade-server, bin/neuratrade, bin/neuratrade-scalping-soak, bin/neuratrade-paper-validation, bin/neuratrade-paper-readiness, bin/neuratrade-collect-candles, bin/neuratrade-seed-test-candles, bin/neuratrade-backfill-paper-trades, bin/neuratrade-seed-paper-trades, bin/neuratrade-fetch-real-candles$(NC)"
+
+install-cli: build ## Install the neuratrade CLI into ~/.local/bin by symlink
+	@./bin/neuratrade install --force
+
+update-cli: build ## Rebuild and refresh the installed neuratrade CLI link
+	@./bin/neuratrade update
 
 fmt: ## Format backend + frontend code
 	@echo "$(GREEN)Formatting Go code...$(NC)"

--- a/cmd/neuratrade-cli/doctor.go
+++ b/cmd/neuratrade-cli/doctor.go
@@ -68,7 +68,7 @@ func validateRuntimeConfig(home string, report *doctorReport) *runtimeConfig {
 	}
 	report.OK = append(report.OK, "runtime config is readable")
 
-	if !isValidPort(fmt.Sprintf("%d", cfg.Server.Port)) {
+	if cfg.Server.Port < 1 || cfg.Server.Port > 65535 {
 		report.Errors = append(report.Errors, "runtime server.port must be between 1 and 65535")
 	}
 	driver := strings.ToLower(strings.TrimSpace(cfg.Database.Driver))
@@ -86,16 +86,16 @@ func validateRuntimeConfig(home string, report *doctorReport) *runtimeConfig {
 			}
 		}
 	}
-	if cfg.Redis.Port != 0 && !isValidPort(fmt.Sprintf("%d", cfg.Redis.Port)) {
+	if cfg.Redis.Port != 0 && (cfg.Redis.Port < 1 || cfg.Redis.Port > 65535) {
 		report.Errors = append(report.Errors, "runtime redis.port must be between 1 and 65535")
 	}
-	if cfg.Gateway.CCXTPort != 0 && !isValidPort(fmt.Sprintf("%d", cfg.Gateway.CCXTPort)) {
+	if cfg.Gateway.CCXTPort != 0 && (cfg.Gateway.CCXTPort < 1 || cfg.Gateway.CCXTPort > 65535) {
 		report.Errors = append(report.Errors, "runtime gateway.ccxt_port must be between 1 and 65535")
 	}
-	if cfg.Gateway.TelegramPort != 0 && !isValidPort(fmt.Sprintf("%d", cfg.Gateway.TelegramPort)) {
+	if cfg.Gateway.TelegramPort != 0 && (cfg.Gateway.TelegramPort < 1 || cfg.Gateway.TelegramPort > 65535) {
 		report.Errors = append(report.Errors, "runtime gateway.telegram_port must be between 1 and 65535")
 	}
-	if cfg.Gateway.TelegramGRPCPort != 0 && !isValidPort(fmt.Sprintf("%d", cfg.Gateway.TelegramGRPCPort)) {
+	if cfg.Gateway.TelegramGRPCPort != 0 && (cfg.Gateway.TelegramGRPCPort < 1 || cfg.Gateway.TelegramGRPCPort > 65535) {
 		report.Errors = append(report.Errors, "runtime gateway.telegram_grpc_port must be between 1 and 65535")
 	}
 	if cfg.Gateway.HealthTimeoutSeconds <= 0 {

--- a/cmd/neuratrade-cli/doctor.go
+++ b/cmd/neuratrade-cli/doctor.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+type doctorReport struct {
+	OK       []string
+	Warnings []string
+	Errors   []string
+}
+
+func cliDoctor(cCtx *cli.Context) error {
+	home := defaultNeuraTradeHome()
+	report := collectDoctorReport(home)
+	printDoctorReport(home, report)
+	if len(report.Errors) > 0 {
+		return cli.Exit("doctor found blocking configuration errors", 1)
+	}
+	return nil
+}
+
+func collectDoctorReport(home string) doctorReport {
+	var report doctorReport
+
+	if strings.TrimSpace(home) == "" {
+		report.Errors = append(report.Errors, "NEURATRADE_HOME resolved to an empty path")
+		return report
+	}
+	if info, err := os.Stat(home); err != nil {
+		if os.IsNotExist(err) {
+			report.Warnings = append(report.Warnings, fmt.Sprintf("home directory does not exist yet: %s", home))
+		} else {
+			report.Errors = append(report.Errors, fmt.Sprintf("cannot inspect home directory: %v", err))
+		}
+	} else if !info.IsDir() {
+		report.Errors = append(report.Errors, fmt.Sprintf("NEURATRADE_HOME is not a directory: %s", home))
+	} else {
+		report.OK = append(report.OK, "home directory exists")
+	}
+
+	runtimeCfg := validateRuntimeConfig(home, &report)
+	secretsCfg := validateSecretsConfig(home, runtimeCfg, &report)
+	validateRuntimeArtifacts(home, &report)
+
+	if runtimeCfg != nil && secretsCfg != nil {
+		report.OK = append(report.OK, "runtime and secret config files are both readable")
+	}
+	return report
+}
+
+func validateRuntimeConfig(home string, report *doctorReport) *runtimeConfig {
+	path := runtimeConfigPath(home)
+	cfg, err := loadRuntimeConfig(home)
+	if err != nil {
+		if os.IsNotExist(err) {
+			report.Warnings = append(report.Warnings, fmt.Sprintf("%s is missing; run `neuratrade config init` to create deterministic runtime defaults", path))
+			return nil
+		}
+		report.Errors = append(report.Errors, err.Error())
+		return nil
+	}
+	report.OK = append(report.OK, "runtime config is readable")
+
+	if !isValidPort(fmt.Sprintf("%d", cfg.Server.Port)) {
+		report.Errors = append(report.Errors, "runtime server.port must be between 1 and 65535")
+	}
+	driver := strings.ToLower(strings.TrimSpace(cfg.Database.Driver))
+	if driver != "sqlite" && driver != "postgres" {
+		report.Errors = append(report.Errors, fmt.Sprintf("runtime database.driver must be sqlite or postgres, got %q", cfg.Database.Driver))
+	}
+	if driver == "sqlite" {
+		if strings.TrimSpace(cfg.Database.SQLitePath) == "" {
+			report.Errors = append(report.Errors, "runtime database.sqlite_path is required when database.driver=sqlite")
+		} else if parent := filepath.Dir(cfg.Database.SQLitePath); parent != "." {
+			if info, err := os.Stat(parent); err == nil && !info.IsDir() {
+				report.Errors = append(report.Errors, fmt.Sprintf("runtime sqlite parent is not a directory: %s", parent))
+			} else if os.IsNotExist(err) {
+				report.Warnings = append(report.Warnings, fmt.Sprintf("runtime sqlite parent will be created on gateway start: %s", parent))
+			}
+		}
+	}
+	if cfg.Redis.Port != 0 && !isValidPort(fmt.Sprintf("%d", cfg.Redis.Port)) {
+		report.Errors = append(report.Errors, "runtime redis.port must be between 1 and 65535")
+	}
+	if cfg.Gateway.CCXTPort != 0 && !isValidPort(fmt.Sprintf("%d", cfg.Gateway.CCXTPort)) {
+		report.Errors = append(report.Errors, "runtime gateway.ccxt_port must be between 1 and 65535")
+	}
+	if cfg.Gateway.TelegramPort != 0 && !isValidPort(fmt.Sprintf("%d", cfg.Gateway.TelegramPort)) {
+		report.Errors = append(report.Errors, "runtime gateway.telegram_port must be between 1 and 65535")
+	}
+	if cfg.Gateway.TelegramGRPCPort != 0 && !isValidPort(fmt.Sprintf("%d", cfg.Gateway.TelegramGRPCPort)) {
+		report.Errors = append(report.Errors, "runtime gateway.telegram_grpc_port must be between 1 and 65535")
+	}
+	if cfg.Gateway.HealthTimeoutSeconds <= 0 {
+		report.Errors = append(report.Errors, "runtime gateway.health_timeout_seconds must be positive")
+	}
+	if cfg.Gateway.SignalTimeoutSeconds <= 0 {
+		report.Errors = append(report.Errors, "runtime gateway.signal_timeout_seconds must be positive")
+	}
+	if cfg.Gateway.GracefulTimeoutSeconds <= 0 {
+		report.Errors = append(report.Errors, "runtime gateway.graceful_timeout_seconds must be positive")
+	}
+	if cfg.Features.EnableAI {
+		if strings.TrimSpace(cfg.AI.Provider) == "" {
+			report.Errors = append(report.Errors, "runtime ai.provider is required when features.enable_ai=true")
+		}
+		if strings.TrimSpace(cfg.AI.Model) == "" {
+			report.Errors = append(report.Errors, "runtime ai.model is required when features.enable_ai=true")
+		}
+	}
+	if cfg.AI.MaxTokens < 0 {
+		report.Errors = append(report.Errors, "runtime ai.max_tokens cannot be negative")
+	}
+	if cfg.AI.MinConfidence < 0 || cfg.AI.MinConfidence > 1 {
+		report.Errors = append(report.Errors, "runtime ai.min_confidence must be between 0 and 1")
+	}
+	return cfg
+}
+
+func validateSecretsConfig(home string, runtimeCfg *runtimeConfig, report *doctorReport) *localConfig {
+	path := filepath.Join(home, "config.json")
+	cfg, err := loadLocalConfig(home)
+	if err != nil {
+		if os.IsNotExist(err) {
+			report.Warnings = append(report.Warnings, fmt.Sprintf("%s is missing; keep secrets in env or run `neuratrade config init`", path))
+			return nil
+		}
+		report.Errors = append(report.Errors, err.Error())
+		return nil
+	}
+	report.OK = append(report.OK, "secret config is readable")
+
+	adminKey := configAdminAPIKey(cfg)
+	if strings.TrimSpace(os.Getenv("ADMIN_API_KEY")) == "" && len(strings.TrimSpace(adminKey)) < 32 {
+		report.Warnings = append(report.Warnings, "ADMIN_API_KEY is missing or shorter than 32 chars; gateway will generate an ephemeral key")
+	}
+	jwtSecret := configJWTSecret(cfg)
+	if strings.TrimSpace(os.Getenv("JWT_SECRET")) == "" && len(strings.TrimSpace(jwtSecret)) < 32 {
+		report.Warnings = append(report.Warnings, "JWT_SECRET is missing or shorter than 32 chars; gateway will generate an ephemeral secret")
+	}
+	aiEnabled := runtimeCfg == nil || runtimeCfg.Features.EnableAI
+	if aiEnabled && strings.TrimSpace(os.Getenv("AI_API_KEY")) == "" && strings.TrimSpace(cfg.AI.APIKey) == "" {
+		report.Warnings = append(report.Warnings, "AI_API_KEY is not configured; AI features may degrade to deterministic fallback")
+	}
+	if strings.TrimSpace(os.Getenv("TELEGRAM_BOT_TOKEN")) == "" && strings.TrimSpace(cfg.Telegram.BotToken) == "" {
+		report.Warnings = append(report.Warnings, "TELEGRAM_BOT_TOKEN is not configured; Telegram service may be disabled in paper-only mode")
+	}
+	return cfg
+}
+
+func validateRuntimeArtifacts(home string, report *doctorReport) {
+	statePath := filepath.Join(home, "pids", "gateway-state.json")
+	content, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			report.Warnings = append(report.Warnings, "gateway state is missing; run `neuratrade gateway start` after configuration")
+			return
+		}
+		report.Warnings = append(report.Warnings, fmt.Sprintf("cannot read gateway state: %v", err))
+		return
+	}
+	var state gatewayRuntimeState
+	if err := json.Unmarshal(content, &state); err != nil {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("gateway state is not valid JSON: %v", err))
+		return
+	}
+	if strings.TrimSpace(state.Mode) == "" {
+		report.Warnings = append(report.Warnings, "gateway state has no mode")
+		return
+	}
+	report.OK = append(report.OK, fmt.Sprintf("gateway state mode is %s", state.Mode))
+}
+
+func printDoctorReport(home string, report doctorReport) {
+	fmt.Println("NeuraTrade Doctor")
+	fmt.Println("=================")
+	fmt.Printf("Home: %s\n", home)
+	fmt.Printf("Runtime config: %s\n", runtimeConfigPath(home))
+	fmt.Printf("Secret config: %s\n", filepath.Join(home, "config.json"))
+	fmt.Println()
+
+	for _, item := range report.OK {
+		fmt.Printf("OK    %s\n", item)
+	}
+	for _, item := range report.Warnings {
+		fmt.Printf("WARN  %s\n", item)
+	}
+	for _, item := range report.Errors {
+		fmt.Printf("ERROR %s\n", item)
+	}
+	if len(report.Errors) == 0 {
+		fmt.Println()
+		fmt.Println("Doctor completed without blocking errors.")
+	}
+}

--- a/cmd/neuratrade-cli/doctor_test.go
+++ b/cmd/neuratrade-cli/doctor_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoctorReportAcceptsFreshRuntimeAndSecretConfig(t *testing.T) {
+	home := t.TempDir()
+	runtimeCfg := defaultRuntimeConfig(home)
+	require.NoError(t, writeRuntimeConfig(home, runtimeCfg))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.json"), []byte(`{
+		"security":{"admin_api_key":"abcdefghijklmnopqrstuvwxyz123456","jwt_secret":"abcdefghijklmnopqrstuvwxyz123456"},
+		"ai":{"api_key":"secret"},
+		"telegram":{"bot_token":"token"}
+	}`), 0o600))
+
+	report := collectDoctorReport(home)
+
+	require.Empty(t, report.Errors)
+	require.NotEmpty(t, report.OK)
+}
+
+func TestDoctorReportFlagsInvalidRuntimeConfig(t *testing.T) {
+	home := t.TempDir()
+	runtimeCfg := defaultRuntimeConfig(home)
+	runtimeCfg.Server.Port = 70000
+	runtimeCfg.AI.MinConfidence = 2
+	require.NoError(t, writeRuntimeConfig(home, runtimeCfg))
+
+	report := collectDoctorReport(home)
+
+	require.NotEmpty(t, report.Errors)
+	require.Contains(t, report.Errors, "runtime server.port must be between 1 and 65535")
+	require.Contains(t, report.Errors, "runtime ai.min_confidence must be between 0 and 1")
+}

--- a/cmd/neuratrade-cli/gateway.go
+++ b/cmd/neuratrade-cli/gateway.go
@@ -890,7 +890,7 @@ func getEnvBoolIfSet(key string) (bool, bool) {
 	case "false", "0", "no", "off":
 		return false, true
 	default:
-		return false, true
+		return false, false
 	}
 }
 

--- a/cmd/neuratrade-cli/gateway.go
+++ b/cmd/neuratrade-cli/gateway.go
@@ -265,11 +265,11 @@ func gatewayStart(cCtx *cli.Context) error {
 		"AI_BASE_URL":            aiBaseURL,
 		"AI_PROVIDER":            aiProvider,
 		"AI_MODEL":               aiModel,
-		"FEATURES_ENABLE_AI":     runtimeBoolString(runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.EnableAI),
-		"ENABLE_AI_SIGNALS":      runtimeBoolString(runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.EnableAISignals),
-		"ENABLE_AI_ARBITRAGE":    runtimeBoolString(runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.EnableAIArbitrage),
-		"FEATURES_PAPER_TRADING": runtimeBoolString(runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.PaperTrading),
-		"FEATURES_REAL_TRADING":  runtimeBoolString(runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.RealTrading),
+		"FEATURES_ENABLE_AI":     getEnvOrRuntimeBoolEnvString("FEATURES_ENABLE_AI", runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.EnableAI),
+		"ENABLE_AI_SIGNALS":      getEnvOrRuntimeBoolEnvString("ENABLE_AI_SIGNALS", runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.EnableAISignals),
+		"ENABLE_AI_ARBITRAGE":    getEnvOrRuntimeBoolEnvString("ENABLE_AI_ARBITRAGE", runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.EnableAIArbitrage),
+		"FEATURES_PAPER_TRADING": getEnvOrRuntimeBoolEnvString("FEATURES_PAPER_TRADING", runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.PaperTrading),
+		"FEATURES_REAL_TRADING":  getEnvOrRuntimeBoolEnvString("FEATURES_REAL_TRADING", runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.RealTrading),
 	}
 
 	// Start Backend API
@@ -801,6 +801,16 @@ func getEnvOrRuntimeBoolStringIfPresent(key string, runtimeCfg *runtimeConfig, r
 	return strconv.FormatBool(defaultValue)
 }
 
+func getEnvOrRuntimeBoolEnvString(key string, runtimeCfg *runtimeConfig, runtimeValue bool) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	if runtimeCfg != nil {
+		return strconv.FormatBool(runtimeValue)
+	}
+	return ""
+}
+
 func getEnvOrRuntimeDurationSeconds(key string, runtimeValue, defaultSeconds int) time.Duration {
 	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
 		seconds, err := strconv.Atoi(value)
@@ -853,9 +863,8 @@ func getEnvDurationSeconds(key string, defaultSeconds int) time.Duration {
 }
 
 func shouldSkipTelegramGateway(telegramToken string) bool {
-	if value := strings.TrimSpace(os.Getenv("NEURATRADE_GATEWAY_SKIP_TELEGRAM")); value != "" {
-		parsed, err := strconv.ParseBool(value)
-		return err == nil && parsed
+	if parsed, ok := getEnvBoolIfSet("NEURATRADE_GATEWAY_SKIP_TELEGRAM"); ok {
+		return parsed
 	}
 	if runtimeCfg := getRuntimeConfigValue(defaultNeuraTradeHome()); runtimeCfg != nil {
 		if runtimeCfg.Gateway.SkipTelegram {
@@ -868,6 +877,21 @@ func shouldSkipTelegramGateway(telegramToken string) bool {
 	return strings.TrimSpace(telegramToken) == "" &&
 		getEnvBoolAnyDefault([]string{"FEATURES_PAPER_TRADING", "FEATURE_PAPER_TRADING"}, false) &&
 		!getEnvBoolAnyDefault([]string{"FEATURES_REAL_TRADING", "FEATURE_REAL_TRADING"}, true)
+}
+
+func getEnvBoolIfSet(key string) (bool, bool) {
+	value := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
+	if value == "" {
+		return false, false
+	}
+	switch value {
+	case "true", "1", "yes", "on":
+		return true, true
+	case "false", "0", "no", "off":
+		return false, true
+	default:
+		return false, true
+	}
 }
 
 func ensureSQLiteParentDir(sqlitePath string) error {
@@ -990,13 +1014,6 @@ func runtimeTelegramUsePolling(cfg *runtimeConfig) bool {
 		return false
 	}
 	return cfg.Telegram.UsePolling
-}
-
-func runtimeBoolString(cfg *runtimeConfig, value bool) string {
-	if cfg == nil {
-		return ""
-	}
-	return strconv.FormatBool(value)
 }
 
 func isValidPort(port string) bool {

--- a/cmd/neuratrade-cli/gateway.go
+++ b/cmd/neuratrade-cli/gateway.go
@@ -127,7 +127,7 @@ func gatewayStart(cCtx *cli.Context) error {
 	telegramPort := getEnvOrRuntimePort("TELEGRAM_PORT", runtimeGatewayTelegramPort(runtimeCfg), "3002")
 	telegramGRPCPort := getEnvOrRuntimePort("TELEGRAM_GRPC_PORT", runtimeGatewayTelegramGRPCPort(runtimeCfg), "50052")
 	bindHost := getEnvOrRuntimeString("BIND_HOST", runtimeGatewayBindHost(runtimeCfg), "127.0.0.1")
-	supervised := cCtx.Bool("supervised") || getEnvOrRuntimeBool("NEURATRADE_GATEWAY_SUPERVISED", runtimeGatewaySupervised(runtimeCfg), false)
+	supervised := cCtx.Bool("supervised") || getEnvOrRuntimeBool("NEURATRADE_GATEWAY_SUPERVISED", runtimeCfg, runtimeGatewaySupervised(runtimeCfg), false)
 	healthTimeout := getEnvOrRuntimeDurationSeconds("NEURATRADE_GATEWAY_HEALTH_TIMEOUT_SECONDS", runtimeGatewayHealthTimeoutSeconds(runtimeCfg), gatewayDefaultHealthTimeoutSeconds)
 	signalTimeout := getEnvOrRuntimeDurationSeconds("NEURATRADE_GATEWAY_SIGNAL_TIMEOUT_SECONDS", runtimeGatewaySignalTimeoutSeconds(runtimeCfg), 5)
 	gracefulTimeout := getEnvOrRuntimeDurationSeconds("NEURATRADE_GATEWAY_GRACEFUL_TIMEOUT_SECONDS", runtimeGatewayGracefulTimeoutSeconds(runtimeCfg), 10)
@@ -769,7 +769,7 @@ func getEnvOrRuntimePort(key string, runtimeValue int, defaultValue string) stri
 	return runtimePort(runtimeValue, defaultValue)
 }
 
-func getEnvOrRuntimeBool(key string, runtimeValue, defaultValue bool) bool {
+func getEnvOrRuntimeBool(key string, runtimeCfg *runtimeConfig, runtimeValue, defaultValue bool) bool {
 	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
 		parsed, err := strconv.ParseBool(value)
 		if err == nil {
@@ -777,14 +777,14 @@ func getEnvOrRuntimeBool(key string, runtimeValue, defaultValue bool) bool {
 		}
 		return defaultValue
 	}
-	if runtimeValue {
-		return true
+	if runtimeCfg != nil {
+		return runtimeValue
 	}
 	return defaultValue
 }
 
-func getEnvOrRuntimeBoolString(key string, runtimeValue, defaultValue bool) string {
-	return strconv.FormatBool(getEnvOrRuntimeBool(key, runtimeValue, defaultValue))
+func getEnvOrRuntimeBoolString(key string, runtimeCfg *runtimeConfig, runtimeValue, defaultValue bool) string {
+	return strconv.FormatBool(getEnvOrRuntimeBool(key, runtimeCfg, runtimeValue, defaultValue))
 }
 
 func getEnvOrRuntimeBoolStringIfPresent(key string, runtimeCfg *runtimeConfig, runtimeValue, defaultValue bool) string {

--- a/cmd/neuratrade-cli/gateway.go
+++ b/cmd/neuratrade-cli/gateway.go
@@ -113,6 +113,7 @@ func gatewayStart(cCtx *cli.Context) error {
 
 	home := defaultNeuraTradeHome()
 	cfg := getConfigValue(home)
+	runtimeCfg := getRuntimeConfigValue(home)
 	statePath := filepath.Join(home, "pids", "gateway-state.json")
 	servicePIDFiles := []string{
 		filepath.Join(home, "pids", "backend.pid"),
@@ -120,19 +121,23 @@ func gatewayStart(cCtx *cli.Context) error {
 		filepath.Join(home, "pids", "telegram.pid"),
 	}
 
-	backendPort := resolveBackendPort(cfg)
+	backendPort := resolveBackendPortWithRuntime(cfg, runtimeCfg)
 
-	ccxtPort := getEnvOrDefault("CCXT_PORT", "3001")
-	telegramPort := getEnvOrDefault("TELEGRAM_PORT", "3002")
-	bindHost := getEnvOrDefault("BIND_HOST", "127.0.0.1")
-	supervised := cCtx.Bool("supervised") || getEnvBoolDefault("NEURATRADE_GATEWAY_SUPERVISED", false)
-	healthTimeout := getEnvDurationSeconds("NEURATRADE_GATEWAY_HEALTH_TIMEOUT_SECONDS", gatewayDefaultHealthTimeoutSeconds)
-	signalTimeout := getEnvDurationSeconds("NEURATRADE_GATEWAY_SIGNAL_TIMEOUT_SECONDS", 5)
-	gracefulTimeout := getEnvDurationSeconds("NEURATRADE_GATEWAY_GRACEFUL_TIMEOUT_SECONDS", 10)
+	ccxtPort := getEnvOrRuntimePort("CCXT_PORT", runtimeGatewayCCXTPort(runtimeCfg), "3001")
+	telegramPort := getEnvOrRuntimePort("TELEGRAM_PORT", runtimeGatewayTelegramPort(runtimeCfg), "3002")
+	telegramGRPCPort := getEnvOrRuntimePort("TELEGRAM_GRPC_PORT", runtimeGatewayTelegramGRPCPort(runtimeCfg), "50052")
+	bindHost := getEnvOrRuntimeString("BIND_HOST", runtimeGatewayBindHost(runtimeCfg), "127.0.0.1")
+	supervised := cCtx.Bool("supervised") || getEnvOrRuntimeBool("NEURATRADE_GATEWAY_SUPERVISED", runtimeGatewaySupervised(runtimeCfg), false)
+	healthTimeout := getEnvOrRuntimeDurationSeconds("NEURATRADE_GATEWAY_HEALTH_TIMEOUT_SECONDS", runtimeGatewayHealthTimeoutSeconds(runtimeCfg), gatewayDefaultHealthTimeoutSeconds)
+	signalTimeout := getEnvOrRuntimeDurationSeconds("NEURATRADE_GATEWAY_SIGNAL_TIMEOUT_SECONDS", runtimeGatewaySignalTimeoutSeconds(runtimeCfg), 5)
+	gracefulTimeout := getEnvOrRuntimeDurationSeconds("NEURATRADE_GATEWAY_GRACEFUL_TIMEOUT_SECONDS", runtimeGatewayGracefulTimeoutSeconds(runtimeCfg), 10)
 	adminAPIKey := normalizeAdminAPIKey(getEnvOrDefault("ADMIN_API_KEY", configAdminAPIKey(cfg)))
 	jwtSecret := normalizeJWTSecret(getEnvOrDefault("JWT_SECRET", configJWTSecret(cfg)))
 
 	sqlitePath := getEnvOrDefault("SQLITE_PATH", "")
+	if sqlitePath == "" && runtimeCfg != nil && runtimeCfg.Database.SQLitePath != "" {
+		sqlitePath = runtimeCfg.Database.SQLitePath
+	}
 	if sqlitePath == "" && cfg != nil && cfg.Database.SQLitePath != "" {
 		sqlitePath = cfg.Database.SQLitePath
 	}
@@ -153,6 +158,19 @@ func gatewayStart(cCtx *cli.Context) error {
 		if aiAPIKey == "" {
 			aiAPIKey = cfg.AI.APIKey
 		}
+	}
+	if runtimeCfg != nil {
+		if aiBaseURL == "" {
+			aiBaseURL = runtimeCfg.AI.BaseURL
+		}
+		if aiProvider == "" {
+			aiProvider = runtimeCfg.AI.Provider
+		}
+		if aiModel == "" {
+			aiModel = runtimeCfg.AI.Model
+		}
+	}
+	if cfg != nil {
 		if aiBaseURL == "" {
 			aiBaseURL = cfg.AI.BaseURL
 		}
@@ -167,6 +185,7 @@ func gatewayStart(cCtx *cli.Context) error {
 
 	fmt.Printf("📁 NeuraTrade Home: %s\n", home)
 	fmt.Printf("⚙️  Config File: %s\n", filepath.Join(home, "config.json"))
+	fmt.Printf("🧭 Runtime File: %s\n", runtimeConfigPath(home))
 	fmt.Printf("🌐 Backend Port: %s (public)\n", backendPort)
 	fmt.Printf("🔌 CCXT Port: %s (internal, bound to %s)\n", ccxtPort, bindHost)
 	fmt.Printf("📞 Telegram Port: %s (internal, bound to %s)\n", telegramPort, bindHost)
@@ -227,25 +246,30 @@ func gatewayStart(cCtx *cli.Context) error {
 	// so the backend detects embedded CCXT. In external mode, the user's env
 	// vars (CCXT_SERVICE_URL, CCXT_GRPC_ADDRESS) are inherited via os.Environ.
 	backendEnv := map[string]string{
-		"PORT":                  backendPort,
-		"SERVER_PORT":           backendPort,
-		"BACKEND_HOST_PORT":     backendPort,
-		"HOST":                  "0.0.0.0", // Backend binds to all interfaces
-		"DATABASE_DRIVER":       getEnvOrDefault("DATABASE_DRIVER", "sqlite"),
-		"SQLITE_PATH":           sqlitePath,
-		"SQLITE_DB_PATH":        sqlitePath,
-		"REDIS_HOST":            getEnvOrDefault("REDIS_HOST", "localhost"),
-		"REDIS_PORT":            getEnvOrDefault("REDIS_PORT", "6379"),
-		"TELEGRAM_SERVICE_URL":  fmt.Sprintf("http://%s:%s", bindHost, telegramPort),
-		"TELEGRAM_GRPC_ADDRESS": fmt.Sprintf("%s:%s", bindHost, getEnvOrDefault("TELEGRAM_GRPC_PORT", "50052")),
-		"JWT_SECRET":            jwtSecret,
-		"ADMIN_API_KEY":         adminAPIKey,
-		"SENTRY_ENVIRONMENT":    getEnvOrDefault("SENTRY_ENVIRONMENT", "production"),
-		"SENTRY_DSN":            getEnvOrDefault("SENTRY_DSN", ""),
-		"AI_API_KEY":            aiAPIKey,
-		"AI_BASE_URL":           aiBaseURL,
-		"AI_PROVIDER":           aiProvider,
-		"AI_MODEL":              aiModel,
+		"PORT":                   backendPort,
+		"SERVER_PORT":            backendPort,
+		"BACKEND_HOST_PORT":      backendPort,
+		"HOST":                   "0.0.0.0", // Backend binds to all interfaces
+		"DATABASE_DRIVER":        getEnvOrRuntimeString("DATABASE_DRIVER", runtimeDatabaseDriver(runtimeCfg), "sqlite"),
+		"SQLITE_PATH":            sqlitePath,
+		"SQLITE_DB_PATH":         sqlitePath,
+		"REDIS_HOST":             getEnvOrRuntimeString("REDIS_HOST", runtimeRedisHost(runtimeCfg), "localhost"),
+		"REDIS_PORT":             getEnvOrRuntimePort("REDIS_PORT", runtimeRedisPort(runtimeCfg), "6379"),
+		"TELEGRAM_SERVICE_URL":   fmt.Sprintf("http://%s:%s", bindHost, telegramPort),
+		"TELEGRAM_GRPC_ADDRESS":  fmt.Sprintf("%s:%s", bindHost, telegramGRPCPort),
+		"JWT_SECRET":             jwtSecret,
+		"ADMIN_API_KEY":          adminAPIKey,
+		"SENTRY_ENVIRONMENT":     getEnvOrDefault("SENTRY_ENVIRONMENT", "production"),
+		"SENTRY_DSN":             getEnvOrDefault("SENTRY_DSN", ""),
+		"AI_API_KEY":             aiAPIKey,
+		"AI_BASE_URL":            aiBaseURL,
+		"AI_PROVIDER":            aiProvider,
+		"AI_MODEL":               aiModel,
+		"FEATURES_ENABLE_AI":     runtimeBoolString(runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.EnableAI),
+		"ENABLE_AI_SIGNALS":      runtimeBoolString(runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.EnableAISignals),
+		"ENABLE_AI_ARBITRAGE":    runtimeBoolString(runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.EnableAIArbitrage),
+		"FEATURES_PAPER_TRADING": runtimeBoolString(runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.PaperTrading),
+		"FEATURES_REAL_TRADING":  runtimeBoolString(runtimeCfg, runtimeCfg != nil && runtimeCfg.Features.RealTrading),
 	}
 
 	// Start Backend API
@@ -294,7 +318,7 @@ func gatewayStart(cCtx *cli.Context) error {
 				"PORT":                  telegramPort,
 				"BIND_HOST":             bindHost,
 				"TELEGRAM_BOT_TOKEN":    telegramToken,
-				"TELEGRAM_USE_POLLING":  getEnvOrDefault("TELEGRAM_USE_POLLING", "true"),
+				"TELEGRAM_USE_POLLING":  getEnvOrRuntimeBoolStringIfPresent("TELEGRAM_USE_POLLING", runtimeCfg, runtimeTelegramUsePolling(runtimeCfg), true),
 				"TELEGRAM_API_BASE_URL": fmt.Sprintf("http://%s:%s", bindHost, backendPort),
 				"BACKEND_HOST_PORT":     backendPort,
 				"NODE_ENV":              "production",
@@ -731,6 +755,66 @@ func getEnvOrDefault(key, defaultValue string) string {
 	return defaultValue
 }
 
+func getEnvOrRuntimeString(key, runtimeValue, defaultValue string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return runtimeString(runtimeValue, defaultValue)
+}
+
+func getEnvOrRuntimePort(key string, runtimeValue int, defaultValue string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return runtimePort(runtimeValue, defaultValue)
+}
+
+func getEnvOrRuntimeBool(key string, runtimeValue, defaultValue bool) bool {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		parsed, err := strconv.ParseBool(value)
+		if err == nil {
+			return parsed
+		}
+		return defaultValue
+	}
+	if runtimeValue {
+		return true
+	}
+	return defaultValue
+}
+
+func getEnvOrRuntimeBoolString(key string, runtimeValue, defaultValue bool) string {
+	return strconv.FormatBool(getEnvOrRuntimeBool(key, runtimeValue, defaultValue))
+}
+
+func getEnvOrRuntimeBoolStringIfPresent(key string, runtimeCfg *runtimeConfig, runtimeValue, defaultValue bool) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		parsed, err := strconv.ParseBool(value)
+		if err == nil {
+			return strconv.FormatBool(parsed)
+		}
+		return strconv.FormatBool(defaultValue)
+	}
+	if runtimeCfg != nil {
+		return strconv.FormatBool(runtimeValue)
+	}
+	return strconv.FormatBool(defaultValue)
+}
+
+func getEnvOrRuntimeDurationSeconds(key string, runtimeValue, defaultSeconds int) time.Duration {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		seconds, err := strconv.Atoi(value)
+		if err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		return time.Duration(defaultSeconds) * time.Second
+	}
+	if runtimeValue > 0 {
+		return time.Duration(runtimeValue) * time.Second
+	}
+	return time.Duration(defaultSeconds) * time.Second
+}
+
 func getEnvBoolDefault(key string, defaultValue bool) bool {
 	value := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
 	if value == "" {
@@ -769,8 +853,17 @@ func getEnvDurationSeconds(key string, defaultSeconds int) time.Duration {
 }
 
 func shouldSkipTelegramGateway(telegramToken string) bool {
-	if getEnvBoolDefault("NEURATRADE_GATEWAY_SKIP_TELEGRAM", false) {
-		return true
+	if value := strings.TrimSpace(os.Getenv("NEURATRADE_GATEWAY_SKIP_TELEGRAM")); value != "" {
+		parsed, err := strconv.ParseBool(value)
+		return err == nil && parsed
+	}
+	if runtimeCfg := getRuntimeConfigValue(defaultNeuraTradeHome()); runtimeCfg != nil {
+		if runtimeCfg.Gateway.SkipTelegram {
+			return true
+		}
+		if strings.TrimSpace(telegramToken) == "" && runtimeCfg.Features.PaperTrading && !runtimeCfg.Features.RealTrading {
+			return true
+		}
 	}
 	return strings.TrimSpace(telegramToken) == "" &&
 		getEnvBoolAnyDefault([]string{"FEATURES_PAPER_TRADING", "FEATURE_PAPER_TRADING"}, false) &&
@@ -795,6 +888,10 @@ func ensureSQLiteParentDir(sqlitePath string) error {
 }
 
 func resolveBackendPort(cfg *localConfig) string {
+	return resolveBackendPortWithRuntime(cfg, getRuntimeConfigValue(defaultNeuraTradeHome()))
+}
+
+func resolveBackendPortWithRuntime(cfg *localConfig, runtimeCfg *runtimeConfig) string {
 	candidates := []string{
 		os.Getenv("SERVER_PORT"),
 		os.Getenv("PORT"),
@@ -805,10 +902,101 @@ func resolveBackendPort(cfg *localConfig) string {
 			return candidate
 		}
 	}
+	if runtimeCfg != nil && runtimeCfg.Server.Port > 0 {
+		return strconv.Itoa(runtimeCfg.Server.Port)
+	}
 	if cfg != nil && cfg.Server.Port > 0 {
 		return strconv.Itoa(cfg.Server.Port)
 	}
 	return "8080"
+}
+
+func runtimeGatewayBindHost(cfg *runtimeConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Gateway.BindHost
+}
+
+func runtimeGatewayCCXTPort(cfg *runtimeConfig) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Gateway.CCXTPort
+}
+
+func runtimeGatewayTelegramPort(cfg *runtimeConfig) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Gateway.TelegramPort
+}
+
+func runtimeGatewayTelegramGRPCPort(cfg *runtimeConfig) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Gateway.TelegramGRPCPort
+}
+
+func runtimeGatewaySupervised(cfg *runtimeConfig) bool {
+	return cfg != nil && cfg.Gateway.Supervised
+}
+
+func runtimeGatewayHealthTimeoutSeconds(cfg *runtimeConfig) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Gateway.HealthTimeoutSeconds
+}
+
+func runtimeGatewaySignalTimeoutSeconds(cfg *runtimeConfig) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Gateway.SignalTimeoutSeconds
+}
+
+func runtimeGatewayGracefulTimeoutSeconds(cfg *runtimeConfig) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Gateway.GracefulTimeoutSeconds
+}
+
+func runtimeDatabaseDriver(cfg *runtimeConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Database.Driver
+}
+
+func runtimeRedisHost(cfg *runtimeConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Redis.Host
+}
+
+func runtimeRedisPort(cfg *runtimeConfig) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Redis.Port
+}
+
+func runtimeTelegramUsePolling(cfg *runtimeConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	return cfg.Telegram.UsePolling
+}
+
+func runtimeBoolString(cfg *runtimeConfig, value bool) string {
+	if cfg == nil {
+		return ""
+	}
+	return strconv.FormatBool(value)
 }
 
 func isValidPort(port string) bool {

--- a/cmd/neuratrade-cli/gateway_test.go
+++ b/cmd/neuratrade-cli/gateway_test.go
@@ -181,6 +181,13 @@ func TestRuntimeBoolStringIfPresentRespectsExplicitFalse(t *testing.T) {
 	require.Equal(t, "true", getEnvOrRuntimeBoolStringIfPresent("TELEGRAM_USE_POLLING", nil, false, true))
 }
 
+func TestGetEnvOrRuntimeBoolRespectsExplicitFalseWhenDefaultTrue(t *testing.T) {
+	t.Setenv("NEURATRADE_GATEWAY_SUPERVISED", "")
+
+	require.False(t, getEnvOrRuntimeBool("NEURATRADE_GATEWAY_SUPERVISED", &runtimeConfig{}, false, true))
+	require.True(t, getEnvOrRuntimeBool("NEURATRADE_GATEWAY_SUPERVISED", nil, false, true))
+}
+
 func TestShouldSkipTelegramGatewayAcceptsLegacySingularFeatureEnv(t *testing.T) {
 	t.Setenv("NEURATRADE_GATEWAY_SKIP_TELEGRAM", "")
 	t.Setenv("FEATURES_PAPER_TRADING", "")

--- a/cmd/neuratrade-cli/gateway_test.go
+++ b/cmd/neuratrade-cli/gateway_test.go
@@ -229,6 +229,19 @@ func TestShouldSkipTelegramGatewayOverrideAcceptsLegacyBoolValues(t *testing.T) 
 	require.True(t, shouldSkipTelegramGateway("telegram-token"))
 }
 
+func TestShouldSkipTelegramGatewayInvalidOverrideFallsThroughToRuntimeConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("NEURATRADE_HOME", home)
+	t.Setenv("NEURATRADE_GATEWAY_SKIP_TELEGRAM", "ye")
+	t.Setenv("FEATURES_PAPER_TRADING", "")
+	t.Setenv("FEATURES_REAL_TRADING", "")
+	runtimeCfg := defaultRuntimeConfig(home)
+	runtimeCfg.Gateway.SkipTelegram = true
+	require.NoError(t, writeRuntimeConfig(home, runtimeCfg))
+
+	require.True(t, shouldSkipTelegramGateway("telegram-token"))
+}
+
 func TestEnsureSQLiteParentDirCreatesConfiguredDataDirectory(t *testing.T) {
 	sqlitePath := filepath.Join(t.TempDir(), "runtime", "data", "neuratrade.db")
 

--- a/cmd/neuratrade-cli/gateway_test.go
+++ b/cmd/neuratrade-cli/gateway_test.go
@@ -34,6 +34,22 @@ func TestResolveBackendPort_FallbackToConfig(t *testing.T) {
 	}
 }
 
+func TestResolveBackendPort_RuntimeBeatsLegacyConfig(t *testing.T) {
+	t.Setenv("SERVER_PORT", "")
+	t.Setenv("PORT", "")
+	t.Setenv("BACKEND_HOST_PORT", "")
+
+	cfg := &localConfig{}
+	cfg.Server.Port = 9090
+	runtimeCfg := &runtimeConfig{}
+	runtimeCfg.Server.Port = 7070
+
+	got := resolveBackendPortWithRuntime(cfg, runtimeCfg)
+	if got != "7070" {
+		t.Fatalf("expected runtime server.port to win, got %s", got)
+	}
+}
+
 func TestResolveBackendPort_Default(t *testing.T) {
 	t.Setenv("SERVER_PORT", "")
 	t.Setenv("PORT", "")
@@ -142,6 +158,27 @@ func TestShouldSkipTelegramGatewayForPaperOnlyRuntime(t *testing.T) {
 
 	require.True(t, shouldSkipTelegramGateway(""))
 	require.False(t, shouldSkipTelegramGateway("telegram-token"))
+}
+
+func TestShouldSkipTelegramGatewayForRuntimePaperOnlyMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("NEURATRADE_HOME", home)
+	t.Setenv("NEURATRADE_GATEWAY_SKIP_TELEGRAM", "")
+	t.Setenv("FEATURES_PAPER_TRADING", "")
+	t.Setenv("FEATURES_REAL_TRADING", "")
+	runtimeCfg := defaultRuntimeConfig(home)
+	runtimeCfg.Features.PaperTrading = true
+	runtimeCfg.Features.RealTrading = false
+	require.NoError(t, writeRuntimeConfig(home, runtimeCfg))
+
+	require.True(t, shouldSkipTelegramGateway(""))
+	require.False(t, shouldSkipTelegramGateway("telegram-token"))
+}
+
+func TestRuntimeBoolStringIfPresentRespectsExplicitFalse(t *testing.T) {
+	t.Setenv("TELEGRAM_USE_POLLING", "")
+	require.Equal(t, "false", getEnvOrRuntimeBoolStringIfPresent("TELEGRAM_USE_POLLING", &runtimeConfig{}, false, true))
+	require.Equal(t, "true", getEnvOrRuntimeBoolStringIfPresent("TELEGRAM_USE_POLLING", nil, false, true))
 }
 
 func TestShouldSkipTelegramGatewayAcceptsLegacySingularFeatureEnv(t *testing.T) {

--- a/cmd/neuratrade-cli/gateway_test.go
+++ b/cmd/neuratrade-cli/gateway_test.go
@@ -188,6 +188,12 @@ func TestGetEnvOrRuntimeBoolRespectsExplicitFalseWhenDefaultTrue(t *testing.T) {
 	require.True(t, getEnvOrRuntimeBool("NEURATRADE_GATEWAY_SUPERVISED", nil, false, true))
 }
 
+func TestGetEnvOrRuntimeBoolEnvStringPreservesEnvOverride(t *testing.T) {
+	t.Setenv("FEATURES_ENABLE_AI", "false")
+
+	require.Equal(t, "false", getEnvOrRuntimeBoolEnvString("FEATURES_ENABLE_AI", &runtimeConfig{}, true))
+}
+
 func TestShouldSkipTelegramGatewayAcceptsLegacySingularFeatureEnv(t *testing.T) {
 	t.Setenv("NEURATRADE_GATEWAY_SKIP_TELEGRAM", "")
 	t.Setenv("FEATURES_PAPER_TRADING", "")
@@ -209,6 +215,14 @@ func TestShouldSkipTelegramGatewayRequiresExplicitPaperOnlyMode(t *testing.T) {
 
 func TestShouldSkipTelegramGatewayOverride(t *testing.T) {
 	t.Setenv("NEURATRADE_GATEWAY_SKIP_TELEGRAM", "true")
+	t.Setenv("FEATURES_PAPER_TRADING", "")
+	t.Setenv("FEATURES_REAL_TRADING", "")
+
+	require.True(t, shouldSkipTelegramGateway("telegram-token"))
+}
+
+func TestShouldSkipTelegramGatewayOverrideAcceptsLegacyBoolValues(t *testing.T) {
+	t.Setenv("NEURATRADE_GATEWAY_SKIP_TELEGRAM", "yes")
 	t.Setenv("FEATURES_PAPER_TRADING", "")
 	t.Setenv("FEATURES_REAL_TRADING", "")
 

--- a/cmd/neuratrade-cli/go.mod
+++ b/cmd/neuratrade-cli/go.mod
@@ -2,7 +2,10 @@ module github.com/irfndi/neuratrade/cmd/neuratrade-cli
 
 go 1.25
 
-require github.com/urfave/cli/v2 v2.27.2
+require (
+	github.com/shopspring/decimal v1.4.0
+	github.com/urfave/cli/v2 v2.27.2
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/cmd/neuratrade-cli/go.sum
+++ b/cmd/neuratrade-cli/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/urfave/cli/v2 v2.27.2 h1:6e0H+AkS+zDckwPCUrZkKX38mRaau4nL2uipkJpbkcI=

--- a/cmd/neuratrade-cli/install.go
+++ b/cmd/neuratrade-cli/install.go
@@ -149,13 +149,17 @@ func copyExecutable(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("create destination executable: %w", err)
 	}
-	defer out.Close()
 
 	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
 		return fmt.Errorf("copy executable: %w", err)
 	}
 	if err := out.Chmod(0o755); err != nil {
+		_ = out.Close()
 		return fmt.Errorf("set executable mode: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close destination executable: %w", err)
 	}
 	return nil
 }

--- a/cmd/neuratrade-cli/install.go
+++ b/cmd/neuratrade-cli/install.go
@@ -95,7 +95,7 @@ func defaultInstallBinDir() string {
 	}
 	home, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(home) == "" {
-		return "."
+		return "/usr/local/bin"
 	}
 	return filepath.Join(home, ".local", "bin")
 }

--- a/cmd/neuratrade-cli/install.go
+++ b/cmd/neuratrade-cli/install.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+const defaultInstallBinaryName = "neuratrade"
+
+func cliInstall(cCtx *cli.Context) error {
+	return installCurrentCLI(cCtx, cCtx.Bool("force"))
+}
+
+func cliUpdate(cCtx *cli.Context) error {
+	return installCurrentCLI(cCtx, true)
+}
+
+func cliInstallStatus(cCtx *cli.Context) error {
+	dst := installDestination(cCtx)
+	fmt.Println("NeuraTrade CLI Install Status")
+	fmt.Println("==============================")
+	fmt.Printf("Install path: %s\n", dst)
+
+	info, err := os.Lstat(dst)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("Status: not installed")
+			fmt.Println("Run: neuratrade install")
+			return nil
+		}
+		return fmt.Errorf("inspect installed CLI: %w", err)
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(dst)
+		if err != nil {
+			return fmt.Errorf("read install symlink: %w", err)
+		}
+		fmt.Println("Status: installed as symlink")
+		fmt.Printf("Target: %s\n", target)
+		return nil
+	}
+
+	fmt.Println("Status: installed as regular file")
+	fmt.Printf("Mode: %s\n", info.Mode().Perm())
+	return nil
+}
+
+func installCurrentCLI(cCtx *cli.Context, force bool) error {
+	src, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve current executable: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(src); err == nil {
+		src = resolved
+	}
+
+	dst := installDestination(cCtx)
+	copyMode := cCtx.Bool("copy")
+	if err := installCLIExecutable(src, dst, copyMode, force); err != nil {
+		return err
+	}
+
+	if copyMode {
+		fmt.Printf("Installed neuratrade CLI: %s\n", dst)
+	} else {
+		fmt.Printf("Linked neuratrade CLI: %s -> %s\n", dst, src)
+	}
+	if !pathContains(filepath.Dir(dst)) {
+		fmt.Printf("Warning: %s is not currently in PATH\n", filepath.Dir(dst))
+	}
+	return nil
+}
+
+func installDestination(cCtx *cli.Context) string {
+	binDir := strings.TrimSpace(cCtx.String("bin-dir"))
+	if binDir == "" {
+		binDir = defaultInstallBinDir()
+	}
+	name := strings.TrimSpace(cCtx.String("name"))
+	if name == "" {
+		name = defaultInstallBinaryName
+	}
+	return filepath.Join(binDir, name)
+}
+
+func defaultInstallBinDir() string {
+	if v := strings.TrimSpace(os.Getenv("NEURATRADE_INSTALL_BIN_DIR")); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return "."
+	}
+	return filepath.Join(home, ".local", "bin")
+}
+
+func installCLIExecutable(src, dst string, copyMode, force bool) error {
+	if strings.TrimSpace(src) == "" || strings.TrimSpace(dst) == "" {
+		return fmt.Errorf("source and destination are required")
+	}
+	srcAbs, err := filepath.Abs(src)
+	if err != nil {
+		return fmt.Errorf("resolve source path: %w", err)
+	}
+	dstAbs, err := filepath.Abs(dst)
+	if err != nil {
+		return fmt.Errorf("resolve destination path: %w", err)
+	}
+	if srcAbs == dstAbs {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dstAbs), 0o755); err != nil {
+		return fmt.Errorf("create install directory: %w", err)
+	}
+	if _, err := os.Lstat(dstAbs); err == nil {
+		if !force {
+			return fmt.Errorf("%s already exists; rerun with --force or use `neuratrade update`", dstAbs)
+		}
+		if err := os.Remove(dstAbs); err != nil {
+			return fmt.Errorf("replace existing install path: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect install path: %w", err)
+	}
+
+	if copyMode {
+		return copyExecutable(srcAbs, dstAbs)
+	}
+	if err := os.Symlink(srcAbs, dstAbs); err != nil {
+		return fmt.Errorf("create install symlink: %w", err)
+	}
+	return nil
+}
+
+func copyExecutable(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source executable: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return fmt.Errorf("create destination executable: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy executable: %w", err)
+	}
+	if err := out.Chmod(0o755); err != nil {
+		return fmt.Errorf("set executable mode: %w", err)
+	}
+	return nil
+}
+
+func pathContains(dir string) bool {
+	dir = filepath.Clean(dir)
+	for _, entry := range filepath.SplitList(os.Getenv("PATH")) {
+		if filepath.Clean(entry) == dir {
+			return true
+		}
+	}
+	return false
+}
+
+func installFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "bin-dir",
+			Usage: "directory where the neuratrade command is installed",
+			Value: defaultInstallBinDir(),
+		},
+		&cli.StringFlag{
+			Name:  "name",
+			Usage: "installed command name",
+			Value: defaultInstallBinaryName,
+		},
+		&cli.BoolFlag{
+			Name:  "copy",
+			Usage: "copy the current executable instead of creating a symlink",
+		},
+		&cli.BoolFlag{
+			Name:  "force",
+			Usage: "replace an existing install path",
+		},
+	}
+}

--- a/cmd/neuratrade-cli/install_test.go
+++ b/cmd/neuratrade-cli/install_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstallCLIExecutableCreatesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "neuratrade-source")
+	dst := filepath.Join(dir, "bin", "neuratrade")
+	require.NoError(t, os.WriteFile(src, []byte("binary"), 0o755))
+
+	require.NoError(t, installCLIExecutable(src, dst, false, false))
+
+	target, err := os.Readlink(dst)
+	require.NoError(t, err)
+	require.Equal(t, src, target)
+}
+
+func TestInstallCLIExecutableRequiresForceToReplace(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "neuratrade-source")
+	dst := filepath.Join(dir, "bin", "neuratrade")
+	require.NoError(t, os.WriteFile(src, []byte("binary"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0o755))
+
+	require.Error(t, installCLIExecutable(src, dst, false, false))
+	require.NoError(t, installCLIExecutable(src, dst, false, true))
+	target, err := os.Readlink(dst)
+	require.NoError(t, err)
+	require.Equal(t, src, target)
+}
+
+func TestInstallCLIExecutableCanCopyBinary(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "neuratrade-source")
+	dst := filepath.Join(dir, "bin", "neuratrade")
+	require.NoError(t, os.WriteFile(src, []byte("binary"), 0o755))
+
+	require.NoError(t, installCLIExecutable(src, dst, true, false))
+
+	data, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	require.Equal(t, []byte("binary"), data)
+	info, err := os.Stat(dst)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}

--- a/cmd/neuratrade-cli/install_test.go
+++ b/cmd/neuratrade-cli/install_test.go
@@ -51,3 +51,10 @@ func TestInstallCLIExecutableCanCopyBinary(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
 }
+
+func TestDefaultInstallBinDirDoesNotFallbackToCurrentDirectory(t *testing.T) {
+	t.Setenv("NEURATRADE_INSTALL_BIN_DIR", "")
+	t.Setenv("HOME", "")
+
+	require.NotEqual(t, ".", defaultInstallBinDir())
+}

--- a/cmd/neuratrade-cli/local_config.go
+++ b/cmd/neuratrade-cli/local_config.go
@@ -18,6 +18,7 @@ type localConfig struct {
 		Port int    `json:"port"`
 	} `json:"server"`
 	Database struct {
+		Driver     string `json:"driver"`
 		SQLitePath string `json:"sqlite_path"`
 	} `json:"database"`
 	CCXT struct {
@@ -26,10 +27,11 @@ type localConfig struct {
 		GrpcAddress string `json:"grpc_address"`
 	} `json:"ccxt"`
 	Telegram struct {
-		BotToken   string `json:"bot_token"`
-		ApiBaseURL string `json:"api_base_url"`
-		ServiceURL string `json:"service_url"`
-		ChatID     string `json:"chat_id"`
+		BotToken    string `json:"bot_token"`
+		ApiBaseURL  string `json:"api_base_url"`
+		ServiceURL  string `json:"service_url"`
+		GrpcAddress string `json:"grpc_address"`
+		ChatID      string `json:"chat_id"`
 	} `json:"telegram"`
 	Services struct {
 		Telegram struct {

--- a/cmd/neuratrade-cli/main.go
+++ b/cmd/neuratrade-cli/main.go
@@ -288,6 +288,24 @@ func newCLIApp() *cli.App {
 				Action: health,
 			},
 			{
+				Name:   "doctor",
+				Usage:  "Validate local configuration and runtime readiness",
+				Action: cliDoctor,
+			},
+			{
+				Name:        "install",
+				Usage:       "Install the neuratrade command into a local bin directory",
+				Action:      cliInstall,
+				Flags:       installFlags(),
+				Subcommands: []*cli.Command{{Name: "status", Usage: "Show local CLI install status", Action: cliInstallStatus, Flags: installFlags()}},
+			},
+			{
+				Name:   "update",
+				Usage:  "Refresh the installed neuratrade command with the current binary",
+				Action: cliUpdate,
+				Flags:  installFlags(),
+			},
+			{
 				Name:  "gateway",
 				Usage: "Manage NeuraTrade gateway (start/stop/status)",
 				Subcommands: []*cli.Command{
@@ -492,6 +510,11 @@ func newCLIApp() *cli.App {
 						Action: configStatus,
 					},
 					{
+						Name:   "doctor",
+						Usage:  "Validate local configuration and runtime readiness",
+						Action: cliDoctor,
+					},
+					{
 						Name:   "show",
 						Usage:  "Show full configuration (mask secrets)",
 						Action: configShow,
@@ -639,6 +662,11 @@ func getBaseURL() string {
 	baseURL := strings.TrimSpace(os.Getenv("NEURATRADE_API_BASE_URL"))
 	if baseURL != "" {
 		return strings.TrimRight(baseURL, "/")
+	}
+
+	runtimeCfg := getRuntimeConfigValue(defaultNeuraTradeHome())
+	if runtimeCfg != nil && runtimeCfg.Telegram.ApiBaseURL != "" && !strings.Contains(runtimeCfg.Telegram.ApiBaseURL, "api.telegram.org") {
+		return strings.TrimRight(runtimeCfg.Telegram.ApiBaseURL, "/")
 	}
 
 	cfg := getConfigValue(defaultNeuraTradeHome())
@@ -1940,6 +1968,7 @@ func prettyPrint(data interface{}) {
 func configInit(cCtx *cli.Context) error {
 	configHome := defaultNeuraTradeHome()
 	configPath := path.Join(configHome, "config.json")
+	runtimePath := runtimeConfigPath(configHome)
 	force := cCtx.Bool("force")
 
 	// Check if config already exists
@@ -1947,6 +1976,12 @@ func configInit(cCtx *cli.Context) error {
 		if _, err := os.Stat(configPath); err == nil {
 			content, _ := os.ReadFile(configPath)
 			if string(content) != "{}" && len(content) > 5 {
+				if _, runtimeErr := os.Stat(runtimePath); os.IsNotExist(runtimeErr) {
+					if writeErr := writeRuntimeConfig(configHome, defaultRuntimeConfig(configHome)); writeErr != nil {
+						return fmt.Errorf("failed to write runtime config file: %w", writeErr)
+					}
+					fmt.Printf("Runtime configuration initialized: %s\n", runtimePath)
+				}
 				fmt.Printf("Configuration file already exists: %s\n", configPath)
 				fmt.Println("Use 'neuratrade config show' to view current configuration.")
 				fmt.Println("Use 'neuratrade config init --force' to overwrite.")
@@ -2044,14 +2079,19 @@ func configInit(cCtx *cli.Context) error {
 	if err := os.WriteFile(configPath, configData, 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
+	if err := writeRuntimeConfig(configHome, defaultRuntimeConfig(configHome)); err != nil {
+		return fmt.Errorf("failed to write runtime config file: %w", err)
+	}
 
 	fmt.Println("✓ Configuration initialized successfully!")
 	fmt.Printf("  Config file: %s\n", configPath)
+	fmt.Printf("  Runtime file: %s\n", runtimePath)
 	fmt.Println("")
 	fmt.Println("Next steps:")
 	fmt.Println("  1. Review configuration: neuratrade config show")
-	fmt.Println("  2. Start services: neuratrade gateway start")
-	fmt.Println("  3. Test Telegram bot: Send /start to your bot")
+	fmt.Println("  2. Validate locally: neuratrade doctor")
+	fmt.Println("  3. Start services: neuratrade gateway start")
+	fmt.Println("  4. Test Telegram bot: Send /start to your bot")
 	fmt.Println("")
 
 	if binanceKey == "" {
@@ -2073,6 +2113,7 @@ func configInit(cCtx *cli.Context) error {
 // configStatus shows the configuration status
 func configStatus(cCtx *cli.Context) error {
 	configPath := path.Join(defaultNeuraTradeHome(), "config.json")
+	runtimePath := runtimeConfigPath(defaultNeuraTradeHome())
 
 	fmt.Println("NeuraTrade Configuration Status")
 	fmt.Println("================================")
@@ -2085,6 +2126,14 @@ func configStatus(cCtx *cli.Context) error {
 	}
 
 	fmt.Println("✓ Configuration file exists")
+	if _, err := os.Stat(runtimePath); os.IsNotExist(err) {
+		fmt.Println("⚠ Runtime configuration file not found")
+		fmt.Printf("  Run: neuratrade config init\n")
+	} else if err != nil {
+		fmt.Printf("✗ Cannot inspect runtime config: %v\n", err)
+	} else {
+		fmt.Println("✓ Runtime configuration file exists")
+	}
 
 	// Read and parse config
 	content, err := os.ReadFile(configPath)
@@ -2161,6 +2210,7 @@ func configStatus(cCtx *cli.Context) error {
 
 	fmt.Println("")
 	fmt.Println("Use 'neuratrade config show' to view full configuration.")
+	fmt.Println("Use 'neuratrade doctor' to validate runtime readiness.")
 
 	return nil
 }
@@ -2194,6 +2244,11 @@ func configShow(cCtx *cli.Context) error {
 	maskSecretsInConfig(config)
 
 	prettyPrint(config)
+	if runtimeCfg, err := loadRuntimeConfig(defaultNeuraTradeHome()); err == nil {
+		fmt.Println()
+		fmt.Printf("%s:\n", runtimeConfigFileName)
+		prettyPrint(runtimeCfg)
+	}
 	return nil
 }
 

--- a/cmd/neuratrade-cli/main.go
+++ b/cmd/neuratrade-cli/main.go
@@ -1977,7 +1977,11 @@ func configInit(cCtx *cli.Context) error {
 			content, _ := os.ReadFile(configPath)
 			if string(content) != "{}" && len(content) > 5 {
 				if _, runtimeErr := os.Stat(runtimePath); os.IsNotExist(runtimeErr) {
-					if writeErr := writeRuntimeConfig(configHome, defaultRuntimeConfig(configHome)); writeErr != nil {
+					existingCfg, loadErr := loadLocalConfig(configHome)
+					if loadErr != nil {
+						return fmt.Errorf("failed to load existing config for runtime backfill: %w", loadErr)
+					}
+					if writeErr := writeRuntimeConfig(configHome, runtimeConfigFromLocalConfig(configHome, existingCfg)); writeErr != nil {
 						return fmt.Errorf("failed to write runtime config file: %w", writeErr)
 					}
 					fmt.Printf("Runtime configuration initialized: %s\n", runtimePath)

--- a/cmd/neuratrade-cli/main_test.go
+++ b/cmd/neuratrade-cli/main_test.go
@@ -210,6 +210,32 @@ func TestConfigInitRespectsNeuratradeHome(t *testing.T) {
 	databaseConfig, ok := config["database"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, filepath.Join(configHome, "data", "neuratrade.db"), databaseConfig["sqlite_path"])
+
+	runtimeData, err := os.ReadFile(filepath.Join(configHome, runtimeConfigFileName))
+	require.NoError(t, err)
+	var runtimeCfg runtimeConfig
+	require.NoError(t, json.Unmarshal(runtimeData, &runtimeCfg))
+	assert.Equal(t, 8080, runtimeCfg.Server.Port)
+	assert.Equal(t, filepath.Join(configHome, "data", "neuratrade.db"), runtimeCfg.Database.SQLitePath)
+	assert.Equal(t, "deepseek", runtimeCfg.AI.Provider)
+}
+
+func TestConfigInitAddsRuntimeFileWhenLegacyConfigExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("NEURATRADE_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.json"), []byte(`{"security":{"admin_api_key":"abcdefghijklmnopqrstuvwxyz123456"}}`), 0600))
+
+	flags := flag.NewFlagSet("config-init", flag.ContinueOnError)
+	flags.String("binance-key", "", "")
+	flags.String("binance-secret", "", "")
+	flags.String("telegram-token", "", "")
+	flags.String("ai-key", "", "")
+	flags.Bool("force", false, "")
+	require.NoError(t, flags.Parse([]string{}))
+
+	ctx := cli.NewContext(cli.NewApp(), flags, nil)
+	require.NoError(t, configInit(ctx))
+	require.FileExists(t, filepath.Join(home, runtimeConfigFileName))
 }
 
 func TestConfigStatusAndShowRespectNeuratradeHome(t *testing.T) {
@@ -247,6 +273,9 @@ func TestNewCLIAppRegistersStableCommandSurface(t *testing.T) {
 	}
 
 	assert.Contains(t, names, "gateway")
+	assert.Contains(t, names, "doctor")
+	assert.Contains(t, names, "install")
+	assert.Contains(t, names, "update")
 	assert.Contains(t, names, "ops")
 	assert.Contains(t, names, "backtest")
 	assert.Contains(t, names, "autonomous")

--- a/cmd/neuratrade-cli/main_test.go
+++ b/cmd/neuratrade-cli/main_test.go
@@ -218,6 +218,7 @@ func TestConfigInitRespectsNeuratradeHome(t *testing.T) {
 	assert.Equal(t, 8080, runtimeCfg.Server.Port)
 	assert.Equal(t, filepath.Join(configHome, "data", "neuratrade.db"), runtimeCfg.Database.SQLitePath)
 	assert.Equal(t, "deepseek", runtimeCfg.AI.Provider)
+	assert.Equal(t, "10", runtimeCfg.AI.DailyBudget.String())
 }
 
 func TestConfigInitAddsRuntimeFileWhenLegacyConfigExists(t *testing.T) {

--- a/cmd/neuratrade-cli/main_test.go
+++ b/cmd/neuratrade-cli/main_test.go
@@ -224,7 +224,14 @@ func TestConfigInitRespectsNeuratradeHome(t *testing.T) {
 func TestConfigInitAddsRuntimeFileWhenLegacyConfigExists(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("NEURATRADE_HOME", home)
-	require.NoError(t, os.WriteFile(filepath.Join(home, "config.json"), []byte(`{"security":{"admin_api_key":"abcdefghijklmnopqrstuvwxyz123456"}}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.json"), []byte(`{
+		"server":{"host":"127.0.0.1","port":9090},
+		"database":{"driver":"sqlite","sqlite_path":"/tmp/legacy-neuratrade.db"},
+		"ccxt":{"service_url":"http://legacy-ccxt:3001","grpc_address":"127.0.0.1:51051"},
+		"telegram":{"service_url":"http://legacy-telegram:3002","grpc_address":"127.0.0.1:51052","api_base_url":"http://legacy-api:9090"},
+		"ai":{"provider":"legacy-ai","model":"legacy-model","base_url":"https://legacy-ai.example/v1"},
+		"security":{"admin_api_key":"abcdefghijklmnopqrstuvwxyz123456"}
+	}`), 0600))
 
 	flags := flag.NewFlagSet("config-init", flag.ContinueOnError)
 	flags.String("binance-key", "", "")
@@ -236,7 +243,17 @@ func TestConfigInitAddsRuntimeFileWhenLegacyConfigExists(t *testing.T) {
 
 	ctx := cli.NewContext(cli.NewApp(), flags, nil)
 	require.NoError(t, configInit(ctx))
-	require.FileExists(t, filepath.Join(home, runtimeConfigFileName))
+	runtimeData, err := os.ReadFile(filepath.Join(home, runtimeConfigFileName))
+	require.NoError(t, err)
+	var runtimeCfg runtimeConfig
+	require.NoError(t, json.Unmarshal(runtimeData, &runtimeCfg))
+	assert.Equal(t, 9090, runtimeCfg.Server.Port)
+	assert.Equal(t, "/tmp/legacy-neuratrade.db", runtimeCfg.Database.SQLitePath)
+	assert.Equal(t, "legacy-ai", runtimeCfg.AI.Provider)
+	assert.Equal(t, "legacy-model", runtimeCfg.AI.Model)
+	assert.Equal(t, "https://legacy-ai.example/v1", runtimeCfg.AI.BaseURL)
+	assert.Equal(t, "http://legacy-ccxt:3001", runtimeCfg.CCXT.ServiceURL)
+	assert.Equal(t, "127.0.0.1:51052", runtimeCfg.Telegram.GrpcAddress)
 }
 
 func TestConfigStatusAndShowRespectNeuratradeHome(t *testing.T) {

--- a/cmd/neuratrade-cli/runtime_config.go
+++ b/cmd/neuratrade-cli/runtime_config.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const runtimeConfigFileName = "runtime.json"
+
+type runtimeConfig struct {
+	Server struct {
+		Host string `json:"host"`
+		Port int    `json:"port"`
+	} `json:"server"`
+	Database struct {
+		Driver     string `json:"driver"`
+		SQLitePath string `json:"sqlite_path"`
+	} `json:"database"`
+	Redis struct {
+		Host string `json:"host"`
+		Port int    `json:"port"`
+	} `json:"redis"`
+	CCXT struct {
+		ServiceURL  string `json:"service_url"`
+		GrpcAddress string `json:"grpc_address"`
+	} `json:"ccxt"`
+	Telegram struct {
+		ServiceURL  string `json:"service_url"`
+		GrpcAddress string `json:"grpc_address"`
+		UsePolling  bool   `json:"use_polling"`
+		ApiBaseURL  string `json:"api_base_url"`
+	} `json:"telegram"`
+	AI struct {
+		Provider      string  `json:"provider"`
+		Model         string  `json:"model"`
+		BaseURL       string  `json:"base_url"`
+		Temperature   float64 `json:"temperature"`
+		MaxTokens     int     `json:"max_tokens"`
+		MinConfidence float64 `json:"min_confidence"`
+		DailyBudget   float64 `json:"daily_budget"`
+		RoutingMode   string  `json:"routing_mode"`
+	} `json:"ai"`
+	Features struct {
+		EnableAI          bool `json:"enable_ai"`
+		EnableAIScalping  bool `json:"enable_ai_scalping"`
+		EnableAISignals   bool `json:"enable_ai_signals"`
+		EnableAIArbitrage bool `json:"enable_ai_arbitrage"`
+		PaperTrading      bool `json:"paper_trading"`
+		RealTrading       bool `json:"real_trading"`
+	} `json:"features"`
+	Gateway struct {
+		BindHost               string `json:"bind_host"`
+		CCXTPort               int    `json:"ccxt_port"`
+		TelegramPort           int    `json:"telegram_port"`
+		TelegramGRPCPort       int    `json:"telegram_grpc_port"`
+		Supervised             bool   `json:"supervised"`
+		HealthTimeoutSeconds   int    `json:"health_timeout_seconds"`
+		SignalTimeoutSeconds   int    `json:"signal_timeout_seconds"`
+		GracefulTimeoutSeconds int    `json:"graceful_timeout_seconds"`
+		SkipTelegram           bool   `json:"skip_telegram"`
+	} `json:"gateway"`
+}
+
+func runtimeConfigPath(home string) string {
+	return filepath.Join(home, runtimeConfigFileName)
+}
+
+func defaultRuntimeConfig(home string) runtimeConfig {
+	defaultAI := defaultCLIAIProviderConfig()
+	var cfg runtimeConfig
+	cfg.Server.Host = "0.0.0.0"
+	cfg.Server.Port = 8080
+	cfg.Database.Driver = "sqlite"
+	cfg.Database.SQLitePath = filepath.Join(home, "data", "neuratrade.db")
+	cfg.Redis.Host = "127.0.0.1"
+	cfg.Redis.Port = 6379
+	cfg.CCXT.ServiceURL = "http://localhost:3001"
+	cfg.CCXT.GrpcAddress = "127.0.0.1:50051"
+	cfg.Telegram.ServiceURL = "http://localhost:3002"
+	cfg.Telegram.GrpcAddress = "127.0.0.1:50052"
+	cfg.Telegram.UsePolling = true
+	cfg.Telegram.ApiBaseURL = "http://localhost:8080"
+	cfg.AI.Provider = defaultAI.Provider
+	cfg.AI.Model = defaultAI.Model
+	cfg.AI.BaseURL = defaultAI.BaseURL
+	cfg.AI.Temperature = 0.7
+	cfg.AI.MaxTokens = 4096
+	cfg.AI.MinConfidence = 0.7
+	cfg.AI.DailyBudget = 10.0
+	cfg.AI.RoutingMode = "primary"
+	cfg.Features.EnableAI = true
+	cfg.Features.EnableAIScalping = true
+	cfg.Features.EnableAISignals = false
+	cfg.Features.EnableAIArbitrage = false
+	cfg.Features.PaperTrading = true
+	cfg.Features.RealTrading = false
+	cfg.Gateway.BindHost = "127.0.0.1"
+	cfg.Gateway.CCXTPort = 3001
+	cfg.Gateway.TelegramPort = 3002
+	cfg.Gateway.TelegramGRPCPort = 50052
+	cfg.Gateway.Supervised = false
+	cfg.Gateway.HealthTimeoutSeconds = gatewayDefaultHealthTimeoutSeconds
+	cfg.Gateway.SignalTimeoutSeconds = 5
+	cfg.Gateway.GracefulTimeoutSeconds = 10
+	cfg.Gateway.SkipTelegram = false
+	return cfg
+}
+
+func loadRuntimeConfig(home string) (*runtimeConfig, error) {
+	content, err := os.ReadFile(runtimeConfigPath(home))
+	if err != nil {
+		return nil, fmt.Errorf("read runtime config: %w", err)
+	}
+	var cfg runtimeConfig
+	if err := json.Unmarshal(content, &cfg); err != nil {
+		return nil, fmt.Errorf("parse runtime config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func getRuntimeConfigValue(home string) *runtimeConfig {
+	cfg, err := loadRuntimeConfig(home)
+	if err != nil {
+		return nil
+	}
+	return cfg
+}
+
+func writeRuntimeConfig(home string, cfg runtimeConfig) error {
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal runtime config: %w", err)
+	}
+	if err := os.WriteFile(runtimeConfigPath(home), data, 0o644); err != nil {
+		return fmt.Errorf("write runtime config: %w", err)
+	}
+	return nil
+}
+
+func runtimeString(value, fallback string) string {
+	if strings.TrimSpace(value) != "" {
+		return strings.TrimSpace(value)
+	}
+	return fallback
+}
+
+func runtimePort(value int, fallback string) string {
+	if value > 0 && value < 65536 {
+		return fmt.Sprintf("%d", value)
+	}
+	return fallback
+}

--- a/cmd/neuratrade-cli/runtime_config.go
+++ b/cmd/neuratrade-cli/runtime_config.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/shopspring/decimal"
 )
 
 const runtimeConfigFileName = "runtime.json"
@@ -34,14 +36,14 @@ type runtimeConfig struct {
 		ApiBaseURL  string `json:"api_base_url"`
 	} `json:"telegram"`
 	AI struct {
-		Provider      string  `json:"provider"`
-		Model         string  `json:"model"`
-		BaseURL       string  `json:"base_url"`
-		Temperature   float64 `json:"temperature"`
-		MaxTokens     int     `json:"max_tokens"`
-		MinConfidence float64 `json:"min_confidence"`
-		DailyBudget   float64 `json:"daily_budget"`
-		RoutingMode   string  `json:"routing_mode"`
+		Provider      string          `json:"provider"`
+		Model         string          `json:"model"`
+		BaseURL       string          `json:"base_url"`
+		Temperature   float64         `json:"temperature"`
+		MaxTokens     int             `json:"max_tokens"`
+		MinConfidence float64         `json:"min_confidence"`
+		DailyBudget   decimal.Decimal `json:"daily_budget"`
+		RoutingMode   string          `json:"routing_mode"`
 	} `json:"ai"`
 	Features struct {
 		EnableAI          bool `json:"enable_ai"`
@@ -89,7 +91,7 @@ func defaultRuntimeConfig(home string) runtimeConfig {
 	cfg.AI.Temperature = 0.7
 	cfg.AI.MaxTokens = 4096
 	cfg.AI.MinConfidence = 0.7
-	cfg.AI.DailyBudget = 10.0
+	cfg.AI.DailyBudget = decimal.NewFromInt(10)
 	cfg.AI.RoutingMode = "primary"
 	cfg.Features.EnableAI = true
 	cfg.Features.EnableAIScalping = true

--- a/cmd/neuratrade-cli/runtime_config.go
+++ b/cmd/neuratrade-cli/runtime_config.go
@@ -111,6 +111,50 @@ func defaultRuntimeConfig(home string) runtimeConfig {
 	return cfg
 }
 
+func runtimeConfigFromLocalConfig(home string, local *localConfig) runtimeConfig {
+	cfg := defaultRuntimeConfig(home)
+	if local == nil {
+		return cfg
+	}
+	if strings.TrimSpace(local.Server.Host) != "" {
+		cfg.Server.Host = strings.TrimSpace(local.Server.Host)
+	}
+	if local.Server.Port > 0 {
+		cfg.Server.Port = local.Server.Port
+	}
+	if strings.TrimSpace(local.Database.Driver) != "" {
+		cfg.Database.Driver = strings.TrimSpace(local.Database.Driver)
+	}
+	if strings.TrimSpace(local.Database.SQLitePath) != "" {
+		cfg.Database.SQLitePath = strings.TrimSpace(local.Database.SQLitePath)
+	}
+	if strings.TrimSpace(local.CCXT.ServiceURL) != "" {
+		cfg.CCXT.ServiceURL = strings.TrimSpace(local.CCXT.ServiceURL)
+	}
+	if strings.TrimSpace(local.CCXT.GrpcAddress) != "" {
+		cfg.CCXT.GrpcAddress = strings.TrimSpace(local.CCXT.GrpcAddress)
+	}
+	if strings.TrimSpace(local.Telegram.ServiceURL) != "" {
+		cfg.Telegram.ServiceURL = strings.TrimSpace(local.Telegram.ServiceURL)
+	}
+	if strings.TrimSpace(local.Telegram.GrpcAddress) != "" {
+		cfg.Telegram.GrpcAddress = strings.TrimSpace(local.Telegram.GrpcAddress)
+	}
+	if strings.TrimSpace(local.Telegram.ApiBaseURL) != "" {
+		cfg.Telegram.ApiBaseURL = strings.TrimSpace(local.Telegram.ApiBaseURL)
+	}
+	if strings.TrimSpace(local.AI.Provider) != "" {
+		cfg.AI.Provider = strings.TrimSpace(local.AI.Provider)
+	}
+	if strings.TrimSpace(local.AI.Model) != "" {
+		cfg.AI.Model = strings.TrimSpace(local.AI.Model)
+	}
+	if strings.TrimSpace(local.AI.BaseURL) != "" {
+		cfg.AI.BaseURL = strings.TrimSpace(local.AI.BaseURL)
+	}
+	return cfg
+}
+
 func loadRuntimeConfig(home string) (*runtimeConfig, error) {
 	content, err := os.ReadFile(runtimeConfigPath(home))
 	if err != nil {

--- a/services/backend-api/internal/config/config.go
+++ b/services/backend-api/internal/config/config.go
@@ -427,6 +427,8 @@ type LiveReadinessConfig struct {
 }
 
 func Load() (*Config, error) {
+	viper.Reset()
+
 	// First: add user-local NeuraTrade config path.
 	if dir := neuratradeHomeDir(); dir != "" {
 		viper.AddConfigPath(dir)
@@ -485,6 +487,8 @@ func Load() (*Config, error) {
 	_ = viper.BindEnv("telegram.grpc_address", "TELEGRAM_GRPC_ADDRESS")
 	_ = viper.BindEnv("backfill.enabled", "BACKFILL_ENABLED")
 	_ = viper.BindEnv("arbitrage.enabled", "ARBITRAGE_ENABLED")
+	_ = viper.BindEnv("features.enable_ai", "FEATURES_ENABLE_AI")
+	_ = viper.BindEnv("features.enable_ai_scalping", "FEATURES_ENABLE_AI_SCALPING")
 	_ = viper.BindEnv("features.enable_ai_arbitrage", "ENABLE_AI_ARBITRAGE")
 	_ = viper.BindEnv("features.enable_ai_signals", "ENABLE_AI_SIGNALS")
 
@@ -500,6 +504,9 @@ func Load() (*Config, error) {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return nil, err
 		}
+	}
+	if err := mergeRuntimeConfig(); err != nil {
+		return nil, err
 	}
 
 	var config Config
@@ -728,6 +735,31 @@ func neuratradeHomeDir() string {
 		return ""
 	}
 	return filepath.Join(homeDir, ".neuratrade")
+}
+
+func mergeRuntimeConfig() error {
+	dir := neuratradeHomeDir()
+	if dir == "" {
+		return nil
+	}
+	runtimePath := filepath.Join(dir, "runtime.json")
+	if _, err := os.Stat(runtimePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspect runtime config: %w", err)
+	}
+
+	runtimeViper := viper.New()
+	runtimeViper.SetConfigFile(runtimePath)
+	runtimeViper.SetConfigType("json")
+	if err := runtimeViper.ReadInConfig(); err != nil {
+		return fmt.Errorf("read runtime config: %w", err)
+	}
+	if err := viper.MergeConfigMap(runtimeViper.AllSettings()); err != nil {
+		return fmt.Errorf("merge runtime config: %w", err)
+	}
+	return nil
 }
 
 // GetServiceURL returns the CCXT service URL.

--- a/services/backend-api/internal/config/config_test.go
+++ b/services/backend-api/internal/config/config_test.go
@@ -462,3 +462,52 @@ func TestLoad_NeuratradeConfigEnvTakesPrecedence(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "env-host", config.Database.Host)
 }
+
+func TestLoad_RuntimeConfigOverridesLegacyConfig(t *testing.T) {
+	os.Clearenv()
+	home := t.TempDir()
+	t.Setenv("NEURATRADE_HOME", home)
+
+	configContent := `{
+		"server": {"port": 9999},
+		"database": {
+			"driver": "sqlite",
+			"sqlite_path": "` + home + `/legacy.db"
+		},
+		"ai": {
+			"provider": "legacy",
+			"model": "legacy-model"
+		}
+	}`
+	require.NoError(t, os.WriteFile(home+"/config.json", []byte(configContent), 0644))
+
+	runtimeContent := `{
+		"server": {"port": 7070},
+		"database": {
+			"driver": "sqlite",
+			"sqlite_path": "` + home + `/runtime.db"
+		},
+		"ai": {
+			"provider": "deepseek",
+			"model": "deepseek-chat"
+		},
+		"features": {
+			"enable_ai": true,
+			"enable_ai_scalping": true
+		}
+	}`
+	require.NoError(t, os.WriteFile(home+"/runtime.json", []byte(runtimeContent), 0644))
+
+	config, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	assert.Equal(t, 7070, config.Server.Port)
+	assert.Equal(t, home+"/runtime.db", config.Database.SQLitePath)
+	assert.Equal(t, "deepseek", config.AI.Provider)
+	assert.Equal(t, "deepseek-chat", config.AI.Model)
+
+	t.Setenv("SERVER_PORT", "8088")
+	config, err = Load()
+	require.NoError(t, err)
+	assert.Equal(t, 8088, config.Server.Port)
+}

--- a/services/backend-api/internal/config/config_test.go
+++ b/services/backend-api/internal/config/config_test.go
@@ -464,9 +464,21 @@ func TestLoad_NeuratradeConfigEnvTakesPrecedence(t *testing.T) {
 }
 
 func TestLoad_RuntimeConfigOverridesLegacyConfig(t *testing.T) {
-	os.Clearenv()
 	home := t.TempDir()
 	t.Setenv("NEURATRADE_HOME", home)
+	for _, key := range []string{
+		"SERVER_PORT",
+		"PORT",
+		"DATABASE_DRIVER",
+		"DATABASE_URL",
+		"SQLITE_PATH",
+		"AI_PROVIDER",
+		"AI_MODEL",
+		"FEATURES_ENABLE_AI",
+		"FEATURES_ENABLE_AI_SCALPING",
+	} {
+		t.Setenv(key, "")
+	}
 
 	configContent := `{
 		"server": {"port": 9999},


### PR DESCRIPTION
## What changed
- Added `runtime.json` as the non-secret deterministic runtime config generated by `neuratrade config init`.
- Added `neuratrade doctor` / `neuratrade config doctor` to validate local config, runtime settings, and gateway state warnings.
- Wired gateway and backend config loading to honor `runtime.json` with env overrides still taking precedence.
- Added `neuratrade install`, `neuratrade install status`, `neuratrade update`, plus `make install-cli` / `make update-cli` for user-level CLI linking.

## Why
Operators need a clean split between secrets and tunable runtime settings, plus a local CLI validation path before starting services. The CLI also needed a first-class install/update path so `neuratrade --help` works from PATH after installation.

## Validation
- `go test ./...` in `cmd/neuratrade-cli` passed: 85 tests.
- `go test ./internal/config` in `services/backend-api` passed: 20 tests.
- `make build` passed.
- `./bin/neuratrade --help` shows `doctor`, `install`, and `update`.
- Temp-home smoke: `neuratrade config init --force`, `neuratrade doctor`, and symlinked `/private/tmp/neuratrade-bin/neuratrade --help` all passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `doctor` command to validate system health, configuration files, and runtime readiness.
  * Introduced `install` and `update` CLI commands for self-management with symlink and copy installation modes.
  * Implemented runtime configuration file support for centralized gateway and application settings management.

* **Chores**
  * Added Make targets for automated CLI installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->