### PR TITLE
chore(telegram-service): upgrade TypeScript to 6.0.3 latest

### DIFF
--- a/services/backend-api/internal/services/paper_trade_recorder.go
+++ b/services/backend-api/internal/services/paper_trade_recorder.go
@@ -51,9 +51,9 @@ func NewPaperTradeRecorder(db DBPool, logger Logger) *PaperTradeRecorder {
 type noopLogger struct{}
 
 func (noopLogger) WithFields(map[string]interface{}) Logger { return noopLogger{} }
-func (noopLogger) Info(string)                             {}
-func (noopLogger) Warn(string)                             {}
-func (noopLogger) Error(string)                            {}
+func (noopLogger) Info(string)                              {}
+func (noopLogger) Warn(string)                              {}
+func (noopLogger) Error(string)                             {}
 
 // RecordOpenTrade records a new open paper trade.
 func (r *PaperTradeRecorder) RecordOpenTrade(ctx context.Context, trade *PaperTrade) (*PaperTrade, error) {

--- a/services/backend-api/internal/services/trading_lifecycle_store.go
+++ b/services/backend-api/internal/services/trading_lifecycle_store.go
@@ -15,8 +15,8 @@ import (
 
 // TradingLifecycleStore persists autonomous order/position lifecycle and realized PnL.
 type TradingLifecycleStore struct {
-	db           database.DBPool
-	logger       *log.Logger
+	db            database.DBPool
+	logger        *log.Logger
 	paperRecorder *PaperTradeRecorder
 }
 

--- a/services/telegram-service/bun.lock
+++ b/services/telegram-service/bun.lock
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.11",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -215,7 +215,7 @@
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/services/telegram-service/package.json
+++ b/services/telegram-service/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.11",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "overrides": {
     "brace-expansion": "5.0.6",


### PR DESCRIPTION
## Summary

Upgrade TypeScript dependency to the latest stable release (^6.0.3) in services/telegram-service.

## Changes

- services/telegram-service/package.json: typescript ^5.9.3 -> ^6.0.3
- services/telegram-service/bun.lock: lockfile refreshed

## Verification

- bun run build passes
- bun run test passes: 186 tests, 0 failures
- make typecheck passes

## Notes

- No source-level breaking changes were required for the existing Telegram service code.
- Bun runtime was upgraded to 1.4.0-canary.1 locally to align with the TypeScript/Bun canary track.
- This is the prerequisite PR before the Go -> TypeScript/Effect-TS migration work (see NeuraTrade-alnz).

## Next Steps

After this merges, the follow-up work will port the critical Go services to TypeScript with Effect-TS in phases:
1. CLI (human + agent control interface) - NeuraTrade-ktaj
2. Market Data - NeuraTrade-yxth
3. Signals -> Scalping (paper/backtest + live) - NeuraTrade-vr65
4. Other features in subsequent phases