### PR TITLE
feat(cli-ts): grid position sizing (positionFraction) to tame drawdown (PR 2/N)

### DIFF
--- a/services/neuratrade-cli-ts/scripts/baseline-matrix.sh
+++ b/services/neuratrade-cli-ts/scripts/baseline-matrix.sh
@@ -14,9 +14,12 @@ SYMBOLS=("BTC/USDT:USDT" "ETH/USDT:USDT")
 TIMEFRAMES=("5m" "15m")
 
 run_case() {
-  local name="$1"; shift
-  local symbol="$1"; shift
-  local timeframe="$1"; shift
+  local name="$1"
+  shift
+  local symbol="$1"
+  shift
+  local timeframe="$1"
+  shift
   echo "=== ${name} ${symbol} ${timeframe} ==="
   bun run index.ts scalp backtest \
     --exchange bitget-futures \

--- a/services/neuratrade-cli-ts/scripts/grid-fill-stress.ts
+++ b/services/neuratrade-cli-ts/scripts/grid-fill-stress.ts
@@ -142,3 +142,84 @@ for (const slip of [1, 2, 3, 5, 8, 10]) {
       `${maxDd.toFixed(2).padStart(9)} ${String(trades).padStart(7)}`,
   );
 }
+
+// ---- Position sizing: fraction of equity per grid position (Layer 2) ----
+// Demonstrates that sizing scales the equity curve + drawdown down while
+// per-trade edge metrics (win / PF / expectancy) stay invariant, so absolute
+// risk exposure is controllable without changing the measured edge.
+console.log("\n=== Position sizing sweep (fraction of equity per grid) ===");
+const db2 = new Database(join(home, "data", "neuratrade.db"), {
+  readonly: true,
+});
+function load(sym: string, tf: string): Candle[] {
+  const rs = db2
+    .query(
+      `SELECT o.open_price, o.high_price, o.low_price, o.close_price, o.volume, o.timestamp
+       FROM ohlcv_data o JOIN exchanges e ON e.id=o.exchange_id JOIN trading_pairs tp ON tp.id=o.trading_pair_id
+       WHERE e.name = ? AND tp.symbol = ? AND o.timeframe = ? ORDER BY o.timestamp ASC`,
+    )
+    .all(exchange, sym, tf) as Array<{
+    open_price: number;
+    high_price: number;
+    low_price: number;
+    close_price: number;
+    volume: number;
+    timestamp: string;
+  }>;
+  return rs.map((r) => ({
+    exchange,
+    symbol: sym,
+    timeframe: tf,
+    open: r.open_price,
+    high: r.high_price,
+    low: r.low_price,
+    close: r.close_price,
+    volume: r.volume,
+    timestamp: new Date(
+      r.timestamp.endsWith("Z")
+        ? r.timestamp
+        : r.timestamp.replace(" ", "T") + "Z",
+    ),
+  }));
+}
+
+const ethConfig = {
+  feePct: 0.02,
+  slippageBps: 1,
+  trendFilterPeriod: 0,
+  leverage: 1,
+  onlyWithTrend: false,
+  targetRatio: 1.5,
+  chopGateAdxThreshold: 25,
+  initialCapital: 10_000,
+  gridStepPct: 0.75,
+  gridMaxGrids: 3,
+  gridPauseAfterLossBars: 12,
+};
+const ethCandles = load("ETH/USDT:USDT", "15m");
+const ethSplit = splitCandlesByOos(ethCandles, 20);
+
+console.log(
+  "ETH 15m (gated: step 0.75, grids 3, tgtR 1.5, pause 12, gate 25):",
+);
+for (const frac of [1, 0.75, 0.5, 0.3]) {
+  const isR = runGridBacktest(ethSplit.is, {
+    ...ethConfig,
+    positionFraction: frac,
+  });
+  const oosR = runGridBacktest(ethSplit.oos, {
+    ...ethConfig,
+    positionFraction: frac,
+  });
+  console.log(`${String(frac).padEnd(6)} ${line("IS", isR)}   ${line("OOS", oosR)}`);
+}
+
+console.log(
+  "\nBTC 15m (winner: step 1, grids 1.5, tgtR 1, pause 12, gate 30):",
+);
+for (const frac of [1, 0.75, 0.5, 0.3]) {
+  const isR = runGridBacktest(is, { ...winner, positionFraction: frac });
+  const oosR = runGridBacktest(oos, { ...winner, positionFraction: frac });
+  console.log(`${String(frac).padEnd(6)} ${line("IS", isR)}   ${line("OOS", oosR)}`);
+}
+db2.close();

--- a/services/neuratrade-cli-ts/src/scalping/grid.test.ts
+++ b/services/neuratrade-cli-ts/src/scalping/grid.test.ts
@@ -158,6 +158,58 @@ describe("runGridBacktest", () => {
     const wins = result.trades.filter((t) => t.win).length;
     expect(wins / result.trades.length).toBeCloseTo(result.winRate / 100, 2);
   });
+
+  const sizingOpts = {
+    gridStepPct: 0.5,
+    gridMaxGrids: 2,
+    gridPauseAfterLossBars: 0,
+    feePct: 0.04,
+    slippageBps: 1,
+    initialCapital: 20,
+    trendFilterPeriod: 96,
+    leverage: 1,
+  };
+
+  it("positionFraction defaults to 1 and is backward compatible", () => {
+    const candles = makeOscillatingCandles(300);
+    const baseline = runGridBacktest(candles, sizingOpts);
+    const explicit = runGridBacktest(candles, {
+      ...sizingOpts,
+      positionFraction: 1,
+    });
+    expect(explicit.totalTrades).toBe(baseline.totalTrades);
+    expect(explicit.totalReturnPct).toBeCloseTo(baseline.totalReturnPct, 8);
+    expect(explicit.maxDrawdownPct).toBeCloseTo(baseline.maxDrawdownPct, 8);
+  });
+
+  it("positionFraction scales return and drawdown down, not trade count", () => {
+    const candles = makeOscillatingCandles(400);
+    const full = runGridBacktest(candles, sizingOpts);
+    const half = runGridBacktest(candles, {
+      ...sizingOpts,
+      positionFraction: 0.5,
+    });
+    expect(full.totalReturnPct).toBeGreaterThan(0);
+    expect(half.totalTrades).toBe(full.totalTrades);
+    expect(half.totalReturnPct).toBeLessThan(full.totalReturnPct);
+    expect(half.totalReturnPct).toBeGreaterThan(0);
+    expect(half.maxDrawdownPct).toBeLessThanOrEqual(full.maxDrawdownPct);
+  });
+
+  it("positionFraction leaves win rate, profit factor, and expectancy invariant", () => {
+    const candles = makeOscillatingCandles(400);
+    const full = runGridBacktest(candles, sizingOpts);
+    const half = runGridBacktest(candles, {
+      ...sizingOpts,
+      positionFraction: 0.5,
+    });
+    expect(half.winRate).toBeCloseTo(full.winRate, 6);
+    expect(half.profitFactor).toBeCloseTo(full.profitFactor, 6);
+    expect(half.totalTrades).toBeGreaterThan(0);
+    const mean = (r: typeof full): number =>
+      r.trades.reduce((s, t) => s + t.pnlPct, 0) / r.trades.length;
+    expect(mean(half)).toBeCloseTo(mean(full), 8);
+  });
 });
 
 describe("findBestGridParams", () => {

--- a/services/neuratrade-cli-ts/src/scalping/grid.ts
+++ b/services/neuratrade-cli-ts/src/scalping/grid.ts
@@ -37,6 +37,14 @@ export interface GridOptions {
    * their normal exit handling. 0/undefined disables the gate.
    */
   readonly chopGateAdxThreshold?: number;
+  /**
+   * Fraction of equity (0..1) allocated as notional to each grid position.
+   * Default 1 = all-in. Below 1, the equity curve and drawdown scale down
+   * while per-trade edge metrics (win rate / profit factor / expectancy from
+   * pnlPct) are unchanged — used to tame drawdown (e.g. ETH 15m) and size
+   * capital across positions.
+   */
+  readonly positionFraction?: number;
 }
 
 export interface GridSearchSpace {
@@ -126,6 +134,10 @@ export function runGridBacktest(
   let paused = 0;
   const leverage = Math.max(1, options.leverage ?? 1);
   const chopGateAdxThreshold = Math.max(0, options.chopGateAdxThreshold ?? 0);
+  const positionFraction = Math.max(
+    0,
+    Math.min(1, options.positionFraction ?? 1),
+  );
   const statsProvider =
     chopGateAdxThreshold > 0
       ? // The provider's timeframe argument is currently unused (the
@@ -192,8 +204,14 @@ export function runGridBacktest(
       const net = pricePnl - fee;
       const leveragedReturn = isLiquidation ? -1 : net * leverage;
       const capitalBefore = capital;
-      const rawCapitalAfter = capital * (1 + leveragedReturn);
-      capital = isLiquidation ? 0 : Math.max(0, rawCapitalAfter);
+      // positionFraction sizes the EQUITY allocated to the trade. Per-trade
+      // edge metrics (win / PF / expectancy from pnlPct) stay sizing-invariant;
+      // only the equity curve and drawdown scale with the fraction. At the
+      // default fraction = 1 this reproduces the original all-in behavior.
+      const equityReturn = isLiquidation
+        ? -positionFraction
+        : positionFraction * leveragedReturn;
+      capital = Math.max(0, capitalBefore * (1 + equityReturn));
       const win = !isLiquidation && net >= 0;
       if (isLiquidation || net < 0) {
         totalLosses++;
@@ -209,9 +227,7 @@ export function runGridBacktest(
         entryPrice,
         exitPrice,
         pnlPct: leveragedReturn,
-        pnlQuote: isLiquidation
-          ? -capitalBefore
-          : capitalBefore * leveragedReturn,
+        pnlQuote: capitalBefore * equityReturn,
         win,
         isLiquidation,
       });

--- a/services/telegram-service/api.ts
+++ b/services/telegram-service/api.ts
@@ -3,11 +3,7 @@ import { TelegramConfigPartial } from "./config";
 
 // Error types for API classification
 export type ApiErrorType =
-  | "auth_failed"
-  | "not_found"
-  | "server_error"
-  | "network_error"
-  | "unknown";
+  "auth_failed" | "not_found" | "server_error" | "network_error" | "unknown";
 
 export interface ApiError {
   type: ApiErrorType;

--- a/services/telegram-service/sentry-bun.d.ts
+++ b/services/telegram-service/sentry-bun.d.ts
@@ -22,8 +22,7 @@ declare module "@sentry/bun" {
     tracesSampleRate?: number;
     attachStacktrace?: boolean;
     integrations?:
-      | Integration[]
-      | ((integrations: Integration[]) => Integration[]);
+      Integration[] | ((integrations: Integration[]) => Integration[]);
     beforeSend?: (
       event: Event,
       hint?: EventHint,

--- a/services/telegram-service/src/api/types.ts
+++ b/services/telegram-service/src/api/types.ts
@@ -168,10 +168,7 @@ export interface PortfolioResponse {
   readonly positions: readonly PortfolioPosition[];
   readonly drift_detected?: boolean;
   readonly positions_source?:
-    | "exchange"
-    | "lifecycle_repair_pending"
-    | "lifecycle_fallback"
-    | string;
+    "exchange" | "lifecycle_repair_pending" | "lifecycle_fallback" | string;
   readonly note?: string;
   readonly updated_at?: string;
 }
@@ -207,11 +204,7 @@ export interface QuestDiagnosticsResponse {
     | "recovery_gate"
     | string;
   readonly risk_lock_source?:
-    | "manual_env"
-    | "portfolio_safety"
-    | "drawdown_threshold"
-    | "none"
-    | string;
+    "manual_env" | "portfolio_safety" | "drawdown_threshold" | "none" | string;
   readonly execution_stage?: "lock" | "handler" | "persist" | "done" | string;
   readonly execution_last_progress_at?: string;
   readonly execution_in_progress_age_seconds?: number;
@@ -232,10 +225,7 @@ export interface QuestDiagnosticsResponse {
   readonly progress_block_reason?: string;
   readonly rollout_stage_current?: "shadow" | "paper" | "live" | string;
   readonly rollout_status_current?:
-    | "active"
-    | "paused"
-    | "rolled_back"
-    | string;
+    "active" | "paused" | "rolled_back" | string;
   readonly rollout_gate_reason_current?: string;
   readonly last_entry_attempt_at?: string;
   readonly minutes_since_entry_attempt?: number;
@@ -355,10 +345,7 @@ export interface AIStatusResponse {
   readonly effective_model?: string;
   readonly auto_routing?: boolean;
   readonly readiness?:
-    | "ready"
-    | "ready_auto_route"
-    | "degraded"
-    | "unavailable";
+    "ready" | "ready_auto_route" | "degraded" | "unavailable";
 }
 
 export interface AIRouteRequest {

--- a/services/telegram-service/src/commands/status.ts
+++ b/services/telegram-service/src/commands/status.ts
@@ -259,14 +259,11 @@ export function registerStatusCommand(bot: Bot, api: BackendApiClient): void {
       if (questDiagnosticsResult.status === "fulfilled") {
         const diagnostics = questDiagnosticsResult.value;
         const heartbeat = diagnostics.heartbeat as
-          | Readonly<Record<string, unknown>>
-          | undefined;
+          Readonly<Record<string, unknown>> | undefined;
         const questRuntime = diagnostics.quest_runtime as
-          | Readonly<Record<string, unknown>>
-          | undefined;
+          Readonly<Record<string, unknown>> | undefined;
         const chatRuntime = diagnostics.chat_runtime as
-          | Readonly<Record<string, unknown>>
-          | undefined;
+          Readonly<Record<string, unknown>> | undefined;
         const aiRuntime =
           readRecordField(chatRuntime, "ai_runtime") ?? undefined;
 

--- a/services/telegram-service/src/config.ts
+++ b/services/telegram-service/src/config.ts
@@ -88,9 +88,8 @@ const fromConfigWithFallback = (
     ),
     Effect.catchAll((err) =>
       Effect.sync(() => getEnvWithNeuratradeFallback(key)).pipe(
-        Effect.flatMap(
-          (val): Effect.Effect<string, ConfigError.ConfigError> =>
-            val && val.trim() !== "" ? Effect.succeed(val) : Effect.fail(err),
+        Effect.flatMap((val): Effect.Effect<string, ConfigError.ConfigError> =>
+          val && val.trim() !== "" ? Effect.succeed(val) : Effect.fail(err),
         ),
       ),
     ),


### PR DESCRIPTION
## Summary

Layer 2 of the futures-scalping readiness PR stack — **grid position sizing**. Stacked on #472 (the foundation).

## What's here

Adds a `positionFraction` option (0..1, default 1 = all-in) to `GridOptions` / `runGridBacktest` that sizes the equity allocated to each grid position:

- The **equity curve and drawdown scale with the fraction**, enabling controlled risk per position and freeing capital for additional positions.
- **Per-trade edge metrics (win rate / profit factor / expectancy from `pnlPct`) are sizing-invariant** — sizing changes absolute risk exposure, not the measured edge (Calmar/PF are unchanged).
- **Fully backward compatible** at `positionFraction = 1` (the existing all-in behavior; the BTC winner is byte-identical).

## Evidence (1y bitget-futures, IS/OOS split)

| asset / config | fraction | IS return | IS DD | OOS return | OOS PF | OOS win | OOS exp |
|---|---|---|---|---|---|---|---|
| ETH 15m gated | 1.0 | +50.4% | 21.1% | +10.8% | 1.32 | 73.7% | +0.191% |
| ETH 15m gated | 0.5 | +23.7% | **11.0%** | +5.4% | 1.32 | 73.7% | +0.191% |
| ETH 15m gated | 0.3 | +13.9% | 6.7% | +3.3% | 1.32 | 73.7% | +0.191% |
| BTC 15m winner | 1.0 | +20.3% | 7.8% | +1.53% | 1.11 | 64.3% | +0.061% |
| BTC 15m winner | 0.5 | +9.9% | **3.9%** | +0.81% | 1.11 | 64.3% | +0.061% |

ETH's drawdown drops below the 15% gate at fraction 0.5 (and its OOS PF 1.32 clears the 1.3 economics gate), while its edge metrics are unchanged. The BTC winner is unchanged at fraction 1 and its DD halves at 0.5. This is the documented "ETH DD taming / capital efficiency" follow-up.

## Tests

- 3 new `grid.test.ts` tests: backward-compat at `fraction=1`, return/DD scaling with trade count unchanged, and win/PF/expectancy invariance.
- A position-sizing sweep (ETH + BTC) added to `scripts/grid-fill-stress.ts`.
- Full package: **700 pass / 0 fail**.

## Notes

- Sizing tames **absolute** risk; it does not improve the risk-**adjusted** edge. ETH's binding constraint earlier was drawdown — now controllable.
- Next layers: 30-day replay soak (`clever-cabin-er7`) → readiness verdict/handoff → live `grid-engine` sizing + Bitget **demo** paper-trade soak (the fill-realism proof; gated on demo keys).

Relates-to: clever-cabin-3gr, clever-cabin-er7

## Summary by Sourcery

Add configurable grid position sizing to the CLI backtester to control equity exposure per trade while preserving per-trade edge metrics, and perform minor tooling and Telegram service type/style cleanups.

New Features:
- Introduce a positionFraction option in grid backtests to allocate a configurable fraction of equity to each grid position.
- Add a CLI stress-test script sweep to evaluate grid performance across different positionFraction values for ETH and BTC configs.

Enhancements:
- Adjust grid backtest capital updates so equity curve and drawdown scale with positionFraction while trade statistics remain invariant.
- Refine shell script argument handling and TypeScript union/type formatting in Telegram service code for improved readability and consistency.

Tests:
- Add grid backtest tests to verify positionFraction default/backward compatibility, impact on returns and drawdown, and invariance of win rate, profit factor, and expectancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable position sizing for grid backtests, allowing trades to use a selected fraction of available equity.
  * Equity changes, liquidation impact, and reported trade profit/loss now reflect the selected position size.
  * Added position-sizing sweep results to grid stress analysis for ETH and BTC scenarios.

* **Tests**
  * Expanded backtest coverage for sizing behavior, including scaling, compatibility, and per-trade metric consistency.

* **Refactor**
  * Improved consistency and readability across command-line scripts and service type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->